### PR TITLE
Prepare Zig package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -66,13 +66,12 @@ pub fn build(b: *Build) void {
         lib.addCSourceFile(path, &flags);
     }
     lib.linkLibC();
-    lib.install();
+    b.installArtifact(lib);
     lib.installHeader(b.pathJoin(&.{ lib_dir, "lua.h" }), "lua/lua.h");
     lib.installHeader(b.pathJoin(&.{ lib_dir, "lualib.h" }), "lua/lualib.h");
     lib.installHeader(b.pathJoin(&.{ lib_dir, "lauxlib.h" }), "lua/lauxlib.h");
 
-    b.addModule(.{
-        .name = "ziglua",
+    _ = b.addModule("ziglua", .{
         .source_file = switch (lua_version) {
             .lua_51 => .{ .path = "src/ziglua-5.1/lib.zig" },
             .lua_52 => .{ .path = "src/ziglua-5.2/lib.zig" },

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 const Build = std.Build;
-const CompileStep = std.build.CompileStep;
 
 pub const LuaVersion = enum {
     lua_51,
@@ -11,98 +10,48 @@ pub const LuaVersion = enum {
     // lua_jit,
 };
 
-fn libPath(version: LuaVersion) []const u8 {
-    return switch (version) {
-        .lua_51 => "src/ziglua-5.1/lib.zig",
-        .lua_52 => "src/ziglua-5.2/lib.zig",
-        .lua_53 => "src/ziglua-5.3/lib.zig",
-        .lua_54 => "src/ziglua-5.4/lib.zig",
-    };
-}
-
 pub fn build(b: *Build) void {
-    const version = b.option(LuaVersion, "version", "lua version to test") orelse .lua_54;
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const lua_version = b.option(LuaVersion, "version", "Lua API and library version") orelse .lua_54;
+    const shared = b.option(bool, "shared", "Build shared library instead of static") orelse false;
 
-    const tests = b.addTest(.{
-        .root_source_file = switch (version) {
-            .lua_51 => .{ .path = "src/ziglua-5.1/tests.zig" },
-            .lua_52 => .{ .path = "src/ziglua-5.2/tests.zig" },
-            .lua_53 => .{ .path = "src/ziglua-5.3/tests.zig" },
-            .lua_54 => .{ .path = "src/ziglua-5.4/tests.zig" },
+    const lib_opts = .{
+        .name = "lua",
+        .target = target,
+        .optimize = optimize,
+        .version = switch (lua_version) {
+            .lua_51 => std.builtin.Version{ .major = 5, .minor = 1, .patch = 5 },
+            .lua_52 => std.builtin.Version{ .major = 5, .minor = 2, .patch = 4 },
+            .lua_53 => std.builtin.Version{ .major = 5, .minor = 3, .patch = 6 },
+            .lua_54 => std.builtin.Version{ .major = 5, .minor = 4, .patch = 4 },
         },
-    });
-    link(b, tests, .{ .use_apicheck = true, .version = version });
-
-    const test_step = b.step("test", "Run ziglua tests");
-    test_step.dependOn(&tests.step);
-}
-
-fn dir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
-}
-
-pub const Options = struct {
-    /// Defines the macro LUA_USE_APICHECK in debug builds
-    use_apicheck: bool = false,
-    /// Defines the Lua version to build and link
-    version: LuaVersion = .lua_54,
-
-    shared: bool = false,
-};
-
-pub fn compileAndCreateModule(b: *Build, step: *CompileStep, options: Options) *std.build.Module {
-    link(b, step, options);
-
-    const lib_path = libPath(options.version);
-    return b.createModule(.{
-        .source_file = .{ .path = std.fs.path.join(b.allocator, &.{ dir(), lib_path }) catch unreachable },
-    });
-}
-
-// TODO: expose the link and package steps separately for advanced use cases?
-fn link(b: *Build, step: *CompileStep, options: Options) void {
-    const lua = buildLua(b, step, options);
-    step.linkLibrary(lua);
-}
-
-// TODO: how to test all versions? May need a make/help script to test all
-// versions separately because there might be name collisions
-fn buildLua(b: *Build, step: *CompileStep, options: Options) *CompileStep {
-    const lib_dir = switch (options.version) {
-        .lua_51 => "lib/lua-5.1.5/src/",
-        .lua_52 => "lib/lua-5.2.4/src/",
-        .lua_53 => "lib/lua-5.3.6/src/",
-        .lua_54 => "lib/lua-5.4.4/src/",
     };
-
-    const lua = brk: {
-        if (options.shared) break :brk b.addSharedLibrary(.{
-            .name = "lua",
-            .target = step.target,
-            .optimize = step.optimize,
-        });
-
-        break :brk b.addStaticLibrary(.{
-            .name = "lua",
-            .target = step.target,
-            .optimize = step.optimize,
-        });
+    const lib = if (shared)
+        b.addSharedLibrary(lib_opts)
+    else
+        b.addStaticLibrary(lib_opts);
+    const lib_dir = switch (lua_version) {
+        .lua_51 => "lib/lua-5.1.5/src",
+        .lua_52 => "lib/lua-5.2.4/src",
+        .lua_53 => "lib/lua-5.3.6/src",
+        .lua_54 => "lib/lua-5.4.4/src",
     };
-
-    lua.linkLibC();
-
-    const apicheck = step.optimize == .Debug and options.use_apicheck;
-
-    step.addIncludePath(std.fs.path.join(b.allocator, &.{ dir(), lib_dir }) catch unreachable);
-
-    const target = (std.zig.system.NativeTargetInfo.detect(step.target) catch unreachable).target;
-
+    const lua_source_files = switch (lua_version) {
+        .lua_51 => &lua_51_source_files,
+        .lua_52 => &lua_52_source_files,
+        .lua_53 => &lua_53_source_files,
+        .lua_54 => &lua_54_source_files,
+    };
+    lib.addIncludePath(lib_dir);
+    const os_tag = target.os_tag orelse
+        (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.os.tag;
     const flags = [_][]const u8{
         // Standard version used in Lua Makefile
         "-std=gnu99",
 
         // Define target-specific macro
-        switch (target.os.tag) {
+        switch (os_tag) {
             .linux => "-DLUA_USE_LINUX",
             .macos => "-DLUA_USE_MACOSX",
             .windows => "-DLUA_USE_WINDOWS",
@@ -110,22 +59,44 @@ fn buildLua(b: *Build, step: *CompileStep, options: Options) *CompileStep {
         },
 
         // Enable api check if desired
-        if (apicheck) "-DLUA_USE_APICHECK" else "",
+        if (optimize == .Debug) "-DLUA_USE_APICHECK" else "",
     };
-
-    const lua_source_files = switch (options.version) {
-        .lua_51 => &lua_51_source_files,
-        .lua_52 => &lua_52_source_files,
-        .lua_53 => &lua_53_source_files,
-        .lua_54 => &lua_54_source_files,
-    };
-
     for (lua_source_files) |file| {
-        const path = std.fs.path.join(b.allocator, &.{ dir(), lib_dir, file }) catch unreachable;
-        lua.addCSourceFile(path, &flags);
+        const path = std.fs.path.join(b.allocator, &.{ lib_dir, file }) catch unreachable;
+        lib.addCSourceFile(path, &flags);
     }
+    lib.linkLibC();
+    lib.install();
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lua.h" }), "lua/lua.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lualib.h" }), "lua/lualib.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lauxlib.h" }), "lua/lauxlib.h");
 
-    return lua;
+    b.addModule(.{
+        .name = "ziglua",
+        .source_file = switch (lua_version) {
+            .lua_51 => .{ .path = "src/ziglua-5.1/lib.zig" },
+            .lua_52 => .{ .path = "src/ziglua-5.2/lib.zig" },
+            .lua_53 => .{ .path = "src/ziglua-5.3/lib.zig" },
+            .lua_54 => .{ .path = "src/ziglua-5.4/lib.zig" },
+        },
+    });
+    // TODO: mod.addIncludePath(lib_dir);
+    // https://github.com/ziglang/zig/issues/14719
+
+    const tests = b.addTest(.{
+        .root_source_file = switch (lua_version) {
+            .lua_51 => .{ .path = "src/ziglua-5.1/tests.zig" },
+            .lua_52 => .{ .path = "src/ziglua-5.2/tests.zig" },
+            .lua_53 => .{ .path = "src/ziglua-5.3/tests.zig" },
+            .lua_54 => .{ .path = "src/ziglua-5.4/tests.zig" },
+        },
+        .optimize = optimize,
+    });
+    tests.addIncludePath(lib_dir);
+    tests.linkLibrary(lib);
+
+    const test_step = b.step("test", "Run ziglua tests");
+    test_step.dependOn(&tests.step);
 }
 
 const lua_51_source_files = [_][]const u8{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "ziglua",
+    .description = "Zig bindings for the Lua C API",
+    .version = "0.1.0",
+}


### PR DESCRIPTION
Hello! Here is a first swipe at making ziglua available as a package dependency. I'm sure you will catch things I haven't covered yet but thought I would open this and get the discussion rolling.

## Overview

This is a breaking change. Currently, the intended way to use ziglua is to `@import("path/to/ziglua/build.zig")` and call its helpers to create the artifacts. While this should be possible in a dependency context once https://github.com/ziglang/zig/issues/14279 is implemented, this isn't the intended way to define CompileSteps in a remote Zig package (as you know). This PR sets things up for the intended way:

- Add build.zig.zon
- Refactor build.zig to define a module and create artifacts (static or shared lib) directly on the `*std.Build`
- Install headers along with the library
- Pass target and optimize options to the library CompileStep, as well as the custom `version` and `shared` options, all of which can be specified locally or by a depending project's build.zig

I threw in some miscellaneous changes, but open to discussion if you don't agree with them:

- Add version info to Lua shared/static lib
- Define `LUA_USE_APICHECK` if and only if opitimize=Debug
- Add zig-out to .gitignore (not a relevant change but this is usually desirable)

## Deficiencies

There is a limitation in `std.Build.Module` that makes the new module painful to use in depending projects: https://github.com/ziglang/zig/issues/14719 . There is a workaround in that issue, which I have verified as working in a downstream project. If you approve of the general approach in this PR, we may still want to hold of on merging this until `Module.addIncludePath()` exists.

With this change as it is currently, it is possible to run `zig build test -Dtarget=...`, which will create a cross-compiled test executable which cannot be run. That's probably not ideal, but I'm not sure what the correct solution is there. Options that come to mind are disallowing/ignoring `-Dtarget` in the test step (simple) or providing a custom test runner that tests the library on a foreign target (less simple).

I haven't made any relative documentation changes yet.