### PR TITLE
fix: for Zig-0.11.0+dev3859, `Cast` directives accept one argument

### DIFF
--- a/src/ziglua-5.1/lib.zig
+++ b/src/ziglua-5.1/lib.zig
@@ -1650,7 +1650,6 @@ fn wrapZigReaderFn(comptime f: ZigReaderFn) CReaderFn {
 
 /// Wrap a ZigWriterFn in a CWriterFn for passing to the API
 fn wrapZigWriterFn(comptime f: ZigWriterFn) CWriterFn {
-    _ = f;
     return struct {
         fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
             // this is called by Lua, state should never be null

--- a/src/ziglua-5.1/lib.zig
+++ b/src/ziglua-5.1/lib.zig
@@ -274,7 +274,7 @@ pub const Lua = struct {
         // desire to allocate. use the largest alignment for the target
         const allocator = opaqueCast(Allocator, data.?);
 
-        if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+        if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
             const prev_slice = prev_ptr[0..osize];
 
             // when nsize is zero the allocator must behave like free and return null
@@ -464,7 +464,7 @@ pub const Lua = struct {
     pub fn getAllocFn(lua: *Lua, data: ?**anyopaque) AllocFn {
         // Assert cannot be null because it is impossible (and not useful) to pass null
         // to the functions that set the allocator (setallocf and newstate)
-        return c.lua_getallocf(lua.state, @ptrCast([*c]?*anyopaque, data)).?;
+        return c.lua_getallocf(lua.state, @as([*c]?*anyopaque, @ptrCast(data))).?;
     }
 
     /// Pushes onto the stack the environment table of the value at the given index.
@@ -642,7 +642,7 @@ pub const Lua = struct {
     pub fn newUserdataSlice(lua: *Lua, comptime T: type, size: usize) []T {
         // safe to .? because this function throws a Lua error on out of memory
         const ptr = c.lua_newuserdata(lua.state, @sizeOf(T) * size).?;
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Pops a key from the stack, and pushes a key-value pair from the table at the given index.
@@ -819,7 +819,7 @@ pub const Lua = struct {
             StatusCode.err_runtime => return error.Runtime,
             StatusCode.err_memory => return error.Memory,
             StatusCode.err_error => return error.MsgHandler,
-            else => return @enumFromInt(ResumeStatus, thread_status),
+            else => return @as(ResumeStatus, @enumFromInt(thread_status)),
         }
     }
 
@@ -875,7 +875,7 @@ pub const Lua = struct {
     /// Returns the status of this thread
     /// See https://www.lua.org/manual/5.1/manual.html#lua_status
     pub fn status(lua: *Lua) Status {
-        return @enumFromInt(Status, c.lua_status(lua.state));
+        return @as(Status, @enumFromInt(c.lua_status(lua.state)));
     }
 
     /// Converts the Lua value at the given `index` into a boolean
@@ -958,7 +958,7 @@ pub const Lua = struct {
     pub fn toUserdataSlice(lua: *Lua, comptime T: type, index: i32) ![]T {
         if (c.lua_touserdata(lua.state, index)) |ptr| {
             const size = lua.objectLen(index) / @sizeOf(T);
-            return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
         }
         return error.Fail;
     }
@@ -967,7 +967,7 @@ pub const Lua = struct {
     /// Note that this is equivalent to lua_type but because type is a Zig primitive it is renamed to `typeOf`
     /// See https://www.lua.org/manual/5.1/manual.html#lua_type
     pub fn typeOf(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_type(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_type(lua.state, index)));
     }
 
     /// Returns the name of the given `LuaType` as a null-terminated slice
@@ -1193,7 +1193,7 @@ pub const Lua = struct {
 
         inline for (std.meta.fields(T)) |field| {
             if (std.mem.eql(u8, field.name, name)) {
-                return @enumFromInt(T, field.value);
+                return @as(T, @enumFromInt(field.value));
             }
         }
 
@@ -1234,7 +1234,7 @@ pub const Lua = struct {
         // the returned pointer will not be null
         const ptr = c.luaL_checkudata(lua.state, arg, name.ptr).?;
         const size = lua.objectLen(arg) / @sizeOf(T);
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Loads and runs the given file
@@ -1264,7 +1264,7 @@ pub const Lua = struct {
     /// and returns the type of the pushed value
     /// See https://www.lua.org/manual/5.1/manual.html#luaL_getmetafield
     pub fn getMetaField(lua: *Lua, obj: i32, field: [:0]const u8) !LuaType {
-        const val_type = @enumFromInt(LuaType, c.luaL_getmetafield(lua.state, obj, field.ptr));
+        const val_type = @as(LuaType, @enumFromInt(c.luaL_getmetafield(lua.state, obj, field.ptr)));
         if (val_type == .nil) return error.Fail;
         return val_type;
     }
@@ -1395,7 +1395,7 @@ pub const Lua = struct {
             lua.getField(-1, name);
             if (!lua.isTable(-1)) {
                 lua.pop(1);
-                if (c.luaL_findtable(lua.state, globals_index, name, @intCast(c_int, funcs.len))) |_| {
+                if (c.luaL_findtable(lua.state, globals_index, name, @as(c_int, @intCast(funcs.len)))) |_| {
                     lua.raiseErrorStr("name conflict for module " ++ c.LUA_QS, .{name.ptr});
                 }
                 lua.pushValue(-1);
@@ -1571,7 +1571,7 @@ pub const Buffer = struct {
 /// Casts the opaque pointer to a pointer of the given type with the proper alignment
 /// Useful for casting pointers from the Lua API like userdata or other data
 pub inline fn opaqueCast(comptime T: type, ptr: *anyopaque) *T {
-    return @ptrCast(*T, @alignCast(@alignOf(T), ptr));
+    return @as(*T, @ptrCast(@alignCast(ptr)));
 }
 
 pub const ZigFn = fn (lua: *Lua) i32;
@@ -1627,7 +1627,7 @@ fn wrapZigHookFn(comptime f: ZigHookFn) CHookFn {
                 .current_line = if (ar.?.currentline == -1) null else ar.?.currentline,
                 .private = ar.?.i_ci,
             };
-            @call(.always_inline, f, .{ &lua, @enumFromInt(Event, ar.?.event), &info });
+            @call(.always_inline, f, .{ &lua, @as(Event, @enumFromInt(ar.?.event)), &info });
         }
     }.inner;
 }
@@ -1650,11 +1650,12 @@ fn wrapZigReaderFn(comptime f: ZigReaderFn) CReaderFn {
 
 /// Wrap a ZigWriterFn in a CWriterFn for passing to the API
 fn wrapZigWriterFn(comptime f: ZigWriterFn) CWriterFn {
+    _ = f;
     return struct {
         fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
             // this is called by Lua, state should never be null
             var lua: Lua = .{ .state = state.? };
-            const buffer = @ptrCast([*]const u8, buf)[0..size];
+            const buffer = @as([*]const u8, @ptrCast(buf))[0..size];
             const result = @call(.always_inline, f, .{ &lua, buffer, data.? });
             // it makes more sense for the inner writer function to return false for failure,
             // so negate the result here

--- a/src/ziglua-5.1/tests.zig
+++ b/src/ziglua-5.1/tests.zig
@@ -45,7 +45,7 @@ fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callco
     _ = data;
 
     const alignment = @alignOf(std.c.max_align_t);
-    if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+    if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
         const prev_slice = prev_ptr[0..osize];
         if (nsize == 0) {
             testing.allocator.free(prev_slice);
@@ -617,7 +617,7 @@ test "userdata and uservalues" {
     std.mem.copy(u8, &data.code, "abcd");
 
     try expectEqual(data, try lua.toUserdata(Data, 1));
-    try expectEqual(@ptrCast(*const anyopaque, data), @alignCast(@alignOf(Data), try lua.toPointer(1)));
+    try expectEqual(@as(*const anyopaque, @ptrCast(data)), @as(*const anyopaque, try lua.toPointer(1)));
 }
 
 test "upvalues" {
@@ -768,7 +768,7 @@ test "debug interface" {
     // get information about the function
     try expectEqual(DebugInfo.FnType.lua, info.what);
     try expectEqual(DebugInfo.NameType.other, info.name_what);
-    const len = std.mem.len(@ptrCast([*:0]u8, &info.short_src));
+    const len = std.mem.len(@as([*:0]u8, @ptrCast(&info.short_src)));
     try expectEqualStrings("[string \"f = function(x)...\"]", info.short_src[0..len]);
     try expectEqual(@as(?i32, 1), info.first_line_defined);
     try expectEqual(@as(?i32, 5), info.last_line_defined);
@@ -1203,7 +1203,7 @@ test "userdata slices" {
     lua.setMetatable(-2);
 
     for (slice, 1..) |*item, index| {
-        item.* = @intCast(Integer, index);
+        item.* = @as(Integer, @intCast(index));
     }
 
     const udataFn = struct {

--- a/src/ziglua-5.2/lib.zig
+++ b/src/ziglua-5.2/lib.zig
@@ -304,7 +304,7 @@ pub const Lua = struct {
         // desire to allocate. use the largest alignment for the target
         const allocator = opaqueCast(Allocator, data.?);
 
-        if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+        if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
             const prev_slice = prev_ptr[0..osize];
 
             // when nsize is zero the allocator must behave like free and return null
@@ -525,7 +525,7 @@ pub const Lua = struct {
     pub fn getAllocFn(lua: *Lua, data: ?**anyopaque) AllocFn {
         // Assert cannot be null because it is impossible (and not useful) to pass null
         // to the functions that set the allocator (setallocf and newstate)
-        return c.lua_getallocf(lua.state, @ptrCast([*c]?*anyopaque, data)).?;
+        return c.lua_getallocf(lua.state, @as([*c]?*anyopaque, @ptrCast(data))).?;
     }
 
     /// Called by a continuation function to retrieve the status of the thread and context information
@@ -726,7 +726,7 @@ pub const Lua = struct {
     pub fn newUserdataSlice(lua: *Lua, comptime T: type, size: usize) []T {
         // safe to .? because this function throws a Lua error on out of memory
         const ptr = c.lua_newuserdata(lua.state, @sizeOf(T) * size).?;
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Pops a key from the stack, and pushes a key-value pair from the table at the given index
@@ -953,7 +953,7 @@ pub const Lua = struct {
             StatusCode.err_memory => return error.Memory,
             StatusCode.err_error => return error.MsgHandler,
             StatusCode.err_gcmm => return error.GCMetaMethod,
-            else => return @enumFromInt(ResumeStatus, thread_status),
+            else => return @as(ResumeStatus, @enumFromInt(thread_status)),
         }
     }
 
@@ -1008,7 +1008,7 @@ pub const Lua = struct {
     /// Returns the status of this thread
     /// See https://www.lua.org/manual/5.2/manual.html#lua_status
     pub fn status(lua: *Lua) Status {
-        return @enumFromInt(Status, c.lua_status(lua.state));
+        return @as(Status, @enumFromInt(c.lua_status(lua.state)));
     }
 
     /// Converts the Lua value at the given `index` into a boolean
@@ -1109,7 +1109,7 @@ pub const Lua = struct {
     pub fn toUserdataSlice(lua: *Lua, comptime T: type, index: i32) ![]T {
         if (c.lua_touserdata(lua.state, index)) |ptr| {
             const size = lua.rawLen(index) / @sizeOf(T);
-            return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
         }
         return error.Fail;
     }
@@ -1118,7 +1118,7 @@ pub const Lua = struct {
     /// Note that this is equivalent to lua_type but because type is a Zig primitive it is renamed to `typeOf`
     /// See https://www.lua.org/manual/5.2/manual.html#lua_type
     pub fn typeOf(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_type(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_type(lua.state, index)));
     }
 
     /// Returns the name of the given `LuaType` as a null-terminated slice
@@ -1195,7 +1195,7 @@ pub const Lua = struct {
         const str = options.toString();
 
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
 
         // should never fail because we are controlling options with the struct param
         _ = c.lua_getinfo(lua.state, &str, &ar);
@@ -1242,7 +1242,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.2/manual.html#lua_getlocal
     pub fn getLocal(lua: *Lua, info: *DebugInfo, n: i32) ![:0]const u8 {
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
         if (c.lua_getlocal(lua.state, &ar, n)) |name| {
             return std.mem.span(name);
         }
@@ -1279,7 +1279,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.2/manual.html#lua_setlocal
     pub fn setLocal(lua: *Lua, info: *DebugInfo, n: i32) ![:0]const u8 {
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
         if (c.lua_setlocal(lua.state, &ar, n)) |name| {
             return std.mem.span(name);
         }
@@ -1385,7 +1385,7 @@ pub const Lua = struct {
 
         inline for (std.meta.fields(T)) |field| {
             if (std.mem.eql(u8, field.name, name)) {
-                return @enumFromInt(T, field.value);
+                return @as(T, @enumFromInt(field.value));
             }
         }
 
@@ -1426,7 +1426,7 @@ pub const Lua = struct {
         // the returned pointer will not be null
         const ptr = c.luaL_checkudata(lua.state, arg, name.ptr).?;
         const size = lua.rawLen(arg) / @sizeOf(T);
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Checks whether the function argument arg is a number and returns this number cast to an unsigned
@@ -1482,7 +1482,7 @@ pub const Lua = struct {
     /// TODO: possibly return an error if nil
     /// See https://www.lua.org/manual/5.2/manual.html#luaL_getmetafield
     pub fn getMetaField(lua: *Lua, obj: i32, field: [:0]const u8) !LuaType {
-        const val_type = @enumFromInt(LuaType, c.luaL_getmetafield(lua.state, obj, field.ptr));
+        const val_type = @as(LuaType, @enumFromInt(c.luaL_getmetafield(lua.state, obj, field.ptr)));
         if (val_type == .nil) return error.Fail;
         return val_type;
     }
@@ -1577,7 +1577,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.2/manual.html#luaL_newlibtable
     pub fn newLibTable(lua: *Lua, list: []const FnReg) void {
         // translate-c failure
-        lua.createTable(0, @intCast(i32, list.len));
+        lua.createTable(0, @as(i32, @intCast(list.len)));
     }
 
     /// If the registry already has the key `key`, returns an error
@@ -1695,7 +1695,7 @@ pub const Lua = struct {
     pub fn testUserdataSlice(lua: *Lua, comptime T: type, arg: i32, name: [:0]const u8) ![]T {
         if (c.luaL_testudata(lua.state, arg, name.ptr)) |ptr| {
             const size = lua.rawLen(arg) / @sizeOf(T);
-            return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
         } else return error.Fail;
     }
 
@@ -1900,7 +1900,7 @@ pub const Buffer = struct {
 /// Casts the opaque pointer to a pointer of the given type with the proper alignment
 /// Useful for casting pointers from the Lua API like userdata or other data
 pub inline fn opaqueCast(comptime T: type, ptr: *anyopaque) *T {
-    return @ptrCast(*T, @alignCast(@alignOf(T), ptr));
+    return @as(*T, @ptrCast(@alignCast(ptr)));
 }
 
 pub const ZigFn = fn (lua: *Lua) i32;
@@ -1954,9 +1954,9 @@ fn wrapZigHookFn(comptime f: ZigHookFn) CHookFn {
             var lua: Lua = .{ .state = state.? };
             var info: DebugInfo = .{
                 .current_line = if (ar.?.currentline == -1) null else ar.?.currentline,
-                .private = @ptrCast(*anyopaque, ar.?.i_ci),
+                .private = @as(*anyopaque, @ptrCast(ar.?.i_ci)),
             };
-            @call(.always_inline, f, .{ &lua, @enumFromInt(Event, ar.?.event), &info });
+            @call(.always_inline, f, .{ &lua, @as(Event, @enumFromInt(ar.?.event)), &info });
         }
     }.inner;
 }
@@ -1983,7 +1983,7 @@ fn wrapZigWriterFn(comptime f: ZigWriterFn) CWriterFn {
         fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
             // this is called by Lua, state should never be null
             var lua: Lua = .{ .state = state.? };
-            const buffer = @ptrCast([*]const u8, buf)[0..size];
+            const buffer = @as([*]const u8, @ptrCast(buf))[0..size];
             const result = @call(.always_inline, f, .{ &lua, buffer, data.? });
             // it makes more sense for the inner writer function to return false for failure,
             // so negate the result here

--- a/src/ziglua-5.2/tests.zig
+++ b/src/ziglua-5.2/tests.zig
@@ -46,7 +46,7 @@ fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callco
     _ = data;
 
     const alignment = @alignOf(std.c.max_align_t);
-    if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+    if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
         const prev_slice = prev_ptr[0..osize];
         if (nsize == 0) {
             testing.allocator.free(prev_slice);
@@ -729,7 +729,7 @@ test "userdata and uservalues" {
     try expectEqual(LuaType.nil, lua.typeOf(-1));
 
     try expectEqual(data, try lua.toUserdata(Data, 1));
-    try expectEqual(@ptrCast(*const anyopaque, data), @alignCast(@alignOf(Data), try lua.toPointer(1)));
+    try expectEqual(@as(*const anyopaque, @ptrCast(data)), @as(*const anyopaque, try lua.toPointer(1)));
 }
 
 test "upvalues" {
@@ -887,7 +887,7 @@ test "debug interface" {
     // get information about the function
     try expectEqual(DebugInfo.FnType.lua, info.what);
     try expectEqual(DebugInfo.NameType.other, info.name_what);
-    const len = std.mem.len(@ptrCast([*:0]u8, &info.short_src));
+    const len = std.mem.len(@as([*:0]u8, @ptrCast(&info.short_src)));
     try expectEqualStrings("[string \"f = function(x)...\"]", info.short_src[0..len]);
     try expectEqual(@as(?i32, 1), info.first_line_defined);
     try expectEqual(@as(?i32, 5), info.last_line_defined);
@@ -1411,7 +1411,7 @@ test "userdata slices" {
     const slice = lua.newUserdataSlice(Integer, 10);
     lua.setMetatableRegistry("FixedArray");
     for (slice, 1..) |*item, index| {
-        item.* = @intCast(Integer, index);
+        item.* = @as(Integer, @intCast(index));
     }
 
     const udataFn = struct {

--- a/src/ziglua-5.3/lib.zig
+++ b/src/ziglua-5.3/lib.zig
@@ -321,7 +321,7 @@ pub const Lua = struct {
         // desire to allocate. use the largest alignment for the target
         const allocator = opaqueCast(Allocator, data.?);
 
-        if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+        if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
             const prev_slice = prev_ptr[0..osize];
 
             // when nsize is zero the allocator must behave like free and return null
@@ -531,7 +531,7 @@ pub const Lua = struct {
     pub fn getAllocFn(lua: *Lua, data: ?**anyopaque) AllocFn {
         // Assert cannot be null because it is impossible (and not useful) to pass null
         // to the functions that set the allocator (setallocf and newstate)
-        return c.lua_getallocf(lua.state, @ptrCast([*c]?*anyopaque, data)).?;
+        return c.lua_getallocf(lua.state, @as([*c]?*anyopaque, @ptrCast(data))).?;
     }
 
     /// Returns a slice of a raw memory area associated with the given Lua state
@@ -539,20 +539,20 @@ pub const Lua = struct {
     /// This area has a size of a pointer to void
     /// See https://www.lua.org/manual/5.3/manual.html#lua_getextraspace
     pub fn getExtraSpace(lua: *Lua) []u8 {
-        return @ptrCast([*]u8, c.lua_getextraspace(lua.state).?)[0..@sizeOf(isize)];
+        return @as([*]u8, @ptrCast(c.lua_getextraspace(lua.state).?))[0..@sizeOf(isize)];
     }
 
     /// Pushes onto the stack the value t[key] where t is the value at the given index
     /// See https://www.lua.org/manual/5.3/manual.html#lua_getfield
     pub fn getField(lua: *Lua, index: i32, key: [:0]const u8) LuaType {
-        return @enumFromInt(LuaType, c.lua_getfield(lua.state, index, key.ptr));
+        return @as(LuaType, @enumFromInt(c.lua_getfield(lua.state, index, key.ptr)));
     }
 
     /// Pushes onto the stack the value of the global name and returns the type of that value
     /// Returns an error if the global does not exist (is nil)
     /// See https://www.lua.org/manual/5.3/manual.html#lua_getglobal
     pub fn getGlobal(lua: *Lua, name: [:0]const u8) !LuaType {
-        const lua_type = @enumFromInt(LuaType, c.lua_getglobal(lua.state, name.ptr));
+        const lua_type = @as(LuaType, @enumFromInt(c.lua_getglobal(lua.state, name.ptr)));
         if (lua_type == .nil) return error.Fail;
         return lua_type;
     }
@@ -561,14 +561,14 @@ pub const Lua = struct {
     /// Returns the type of the pushed value
     /// See https://www.lua.org/manual/5.3/manual.html#lua_geti
     pub fn getIndex(lua: *Lua, index: i32, i: Integer) LuaType {
-        return @enumFromInt(LuaType, c.lua_geti(lua.state, index, i));
+        return @as(LuaType, @enumFromInt(c.lua_geti(lua.state, index, i)));
     }
 
     /// Pushes onto the stack the Lua value associated with the full userdata at the given index.
     /// Returns the type of the pushed value.
     /// See https://www.lua.org/manual/5.3/manual.html#lua_getuservalue
     pub fn getUserValue(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_getuservalue(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_getuservalue(lua.state, index)));
     }
 
     /// If the value at the given index has a metatable, the function pushes that metatable onto the stack
@@ -582,7 +582,7 @@ pub const Lua = struct {
     /// Returns the type of the pushed value
     /// See https://www.lua.org/manual/5.3/manual.html#lua_gettable
     pub fn getTable(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_gettable(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_gettable(lua.state, index)));
     }
 
     /// Returns the index of the top element in the stack
@@ -751,7 +751,7 @@ pub const Lua = struct {
     pub fn newUserdataSlice(lua: *Lua, comptime T: type, size: usize) []T {
         // safe to .? because this function throws a Lua error on out of memory
         const ptr = c.lua_newuserdata(lua.state, @sizeOf(T) * size).?;
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Pops a key from the stack, and pushes a key-value pair from the table at the given index
@@ -766,8 +766,8 @@ pub const Lua = struct {
     pub fn numberToInteger(n: Number, i: *Integer) !void {
         // translate-c failure
         // return c.lua_numbertointeger(n, i) != 0;
-        if (n >= @floatFromInt(Number, min_integer) and n < -@floatFromInt(Number, min_integer)) {
-            i.* = @intFromFloat(Integer, n);
+        if (n >= @as(Number, @floatFromInt(min_integer)) and n < -@as(Number, @floatFromInt(min_integer))) {
+            i.* = @as(Integer, @intFromFloat(n));
         } else return error.Fail;
     }
 
@@ -904,21 +904,21 @@ pub const Lua = struct {
     /// Similar to `Lua.getTable()` but does a raw access (without metamethods)
     /// See https://www.lua.org/manual/5.3/manual.html#lua_rawget
     pub fn rawGetTable(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_rawget(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_rawget(lua.state, index)));
     }
 
     /// Pushes onto the stack the value t[n], where `t` is the table at the given `index`
     /// Returns the `LuaType` of the pushed value
     /// See https://www.lua.org/manual/5.3/manual.html#lua_rawgeti
     pub fn rawGetIndex(lua: *Lua, index: i32, n: Integer) LuaType {
-        return @enumFromInt(LuaType, c.lua_rawgeti(lua.state, index, n));
+        return @as(LuaType, @enumFromInt(c.lua_rawgeti(lua.state, index, n)));
     }
 
     /// Pushes onto the stack the value t[k] where t is the table at the given `index` and
     /// k is the pointer `p` represented as a light userdata
     /// See https://www.lua.org/manual/5.3/manual.html#lua_rawgetp
     pub fn rawGetPtr(lua: *Lua, index: i32, p: *const anyopaque) LuaType {
-        return @enumFromInt(LuaType, c.lua_rawgetp(lua.state, index, p));
+        return @as(LuaType, @enumFromInt(c.lua_rawgetp(lua.state, index, p)));
     }
 
     /// Returns the raw length of the value at the given index
@@ -987,7 +987,7 @@ pub const Lua = struct {
             StatusCode.err_memory => return error.Memory,
             StatusCode.err_error => return error.MsgHandler,
             StatusCode.err_gcmm => return error.GCMetaMethod,
-            else => return @enumFromInt(ResumeStatus, thread_status),
+            else => return @as(ResumeStatus, @enumFromInt(thread_status)),
         }
     }
 
@@ -1059,7 +1059,7 @@ pub const Lua = struct {
     /// Returns the status of this thread
     /// See https://www.lua.org/manual/5.3/manual.html#lua_status
     pub fn status(lua: *Lua) Status {
-        return @enumFromInt(Status, c.lua_status(lua.state));
+        return @as(Status, @enumFromInt(c.lua_status(lua.state)));
     }
 
     /// Converts the zero-terminated string `str` to a number, pushes that number onto the stack,
@@ -1158,7 +1158,7 @@ pub const Lua = struct {
     pub fn toUserdataSlice(lua: *Lua, comptime T: type, index: i32) ![]T {
         if (c.lua_touserdata(lua.state, index)) |ptr| {
             const size = lua.rawLen(index) / @sizeOf(T);
-            return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
         }
         return error.Fail;
     }
@@ -1167,7 +1167,7 @@ pub const Lua = struct {
     /// Note that this is equivalent to lua_type but because type is a Zig primitive it is renamed to `typeOf`
     /// See https://www.lua.org/manual/5.3/manual.html#lua_typeof
     pub fn typeOf(lua: *Lua, index: i32) LuaType {
-        return @enumFromInt(LuaType, c.lua_type(lua.state, index));
+        return @as(LuaType, @enumFromInt(c.lua_type(lua.state, index)));
     }
 
     /// Returns the name of the given `LuaType` as a null-terminated slice
@@ -1245,7 +1245,7 @@ pub const Lua = struct {
         const str = options.toString();
 
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
 
         // should never fail because we are controlling options with the struct param
         _ = c.lua_getinfo(lua.state, &str, &ar);
@@ -1292,7 +1292,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.3/manual.html#lua_getlocal
     pub fn getLocal(lua: *Lua, info: *DebugInfo, n: i32) ![:0]const u8 {
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
         if (c.lua_getlocal(lua.state, &ar, n)) |name| {
             return std.mem.span(name);
         }
@@ -1329,7 +1329,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.3/manual.html#lua_setlocal
     pub fn setLocal(lua: *Lua, info: *DebugInfo, n: i32) ![:0]const u8 {
         var ar: Debug = undefined;
-        ar.i_ci = @ptrCast(*c.struct_CallInfo, info.private);
+        ar.i_ci = @as(*c.struct_CallInfo, @ptrCast(info.private));
         if (c.lua_setlocal(lua.state, &ar, n)) |name| {
             return std.mem.span(name);
         }
@@ -1429,7 +1429,7 @@ pub const Lua = struct {
 
         inline for (std.meta.fields(T)) |field| {
             if (std.mem.eql(u8, field.name, name)) {
-                return @enumFromInt(T, field.value);
+                return @as(T, @enumFromInt(field.value));
             }
         }
 
@@ -1470,7 +1470,7 @@ pub const Lua = struct {
         // the returned pointer will not be null
         const ptr = c.luaL_checkudata(lua.state, arg, name.ptr).?;
         const size = lua.rawLen(arg) / @sizeOf(T);
-        return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
     /// Checks whether the code making the call and the Lua library being called are using
@@ -1520,7 +1520,7 @@ pub const Lua = struct {
     /// TODO: possibly return an error if nil
     /// See https://www.lua.org/manual/5.3/manual.html#luaL_getmetafield
     pub fn getMetaField(lua: *Lua, obj: i32, field: [:0]const u8) !LuaType {
-        const val_type = @enumFromInt(LuaType, c.luaL_getmetafield(lua.state, obj, field.ptr));
+        const val_type = @as(LuaType, @enumFromInt(c.luaL_getmetafield(lua.state, obj, field.ptr)));
         if (val_type == .nil) return error.Fail;
         return val_type;
     }
@@ -1529,7 +1529,7 @@ pub const Lua = struct {
     /// or nil if there is no metatable associated with that name. Returns the type of the pushed value
     /// See https://www.lua.org/manual/5.3/manual.html#luaL_getmetatable
     pub fn getMetatableRegistry(lua: *Lua, table_name: [:0]const u8) LuaType {
-        return @enumFromInt(LuaType, c.luaL_getmetatable(lua.state, table_name.ptr));
+        return @as(LuaType, @enumFromInt(c.luaL_getmetatable(lua.state, table_name.ptr)));
     }
 
     /// Ensures that the value t[`field`], where t is the value at `index`, is a table, and pushes that table onto the stack.
@@ -1615,7 +1615,7 @@ pub const Lua = struct {
     /// See https://www.lua.org/manual/5.3/manual.html#luaL_newlibtable
     pub fn newLibTable(lua: *Lua, list: []const FnReg) void {
         // translate-c failure
-        lua.createTable(0, @intCast(i32, list.len));
+        lua.createTable(0, @as(i32, @intCast(list.len)));
     }
 
     /// If the registry already has the key `key`, returns an error
@@ -1719,7 +1719,7 @@ pub const Lua = struct {
     pub fn testUserdataSlice(lua: *Lua, comptime T: type, arg: i32, name: [:0]const u8) ![]T {
         if (c.luaL_testudata(lua.state, arg, name.ptr)) |ptr| {
             const size = lua.rawLen(arg) / @sizeOf(T);
-            return @ptrCast([*]T, @alignCast(@alignOf([*]T), ptr))[0..size];
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
         } else return error.Fail;
     }
 
@@ -1924,7 +1924,7 @@ pub const Buffer = struct {
 /// Casts the opaque pointer to a pointer of the given type with the proper alignment
 /// Useful for casting pointers from the Lua API like userdata or other data
 pub inline fn opaqueCast(comptime T: type, ptr: *anyopaque) *T {
-    return @ptrCast(*T, @alignCast(@alignOf(T), ptr));
+    return @as(*T, @ptrCast(@alignCast(ptr)));
 }
 
 pub const ZigFn = fn (lua: *Lua) i32;
@@ -1980,9 +1980,9 @@ fn wrapZigHookFn(comptime f: ZigHookFn) CHookFn {
             var lua: Lua = .{ .state = state.? };
             var info: DebugInfo = .{
                 .current_line = if (ar.?.currentline == -1) null else ar.?.currentline,
-                .private = @ptrCast(*anyopaque, ar.?.i_ci),
+                .private = @as(*anyopaque, @ptrCast(ar.?.i_ci)),
             };
-            @call(.always_inline, f, .{ &lua, @enumFromInt(Event, ar.?.event), &info });
+            @call(.always_inline, f, .{ &lua, @as(Event, @enumFromInt(ar.?.event)), &info });
         }
     }.inner;
 }
@@ -1993,7 +1993,7 @@ fn wrapZigContFn(comptime f: ZigContFn) CContFn {
         fn inner(state: ?*LuaState, status: c_int, ctx: Context) callconv(.C) c_int {
             // this is called by Lua, state should never be null
             var lua: Lua = .{ .state = state.? };
-            return @call(.always_inline, f, .{ &lua, @enumFromInt(Status, status), ctx });
+            return @call(.always_inline, f, .{ &lua, @as(Status, @enumFromInt(status)), ctx });
         }
     }.inner;
 }
@@ -2020,7 +2020,7 @@ fn wrapZigWriterFn(comptime f: ZigWriterFn) CWriterFn {
         fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
             // this is called by Lua, state should never be null
             var lua: Lua = .{ .state = state.? };
-            const buffer = @ptrCast([*]const u8, buf)[0..size];
+            const buffer = @as([*]const u8, @ptrCast(buf))[0..size];
             const result = @call(.always_inline, f, .{ &lua, buffer, data.? });
             // it makes more sense for the inner writer function to return false for failure,
             // so negate the result here

--- a/src/ziglua-5.3/tests.zig
+++ b/src/ziglua-5.3/tests.zig
@@ -45,7 +45,7 @@ fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callco
     _ = data;
 
     const alignment = @alignOf(std.c.max_align_t);
-    if (@ptrCast(?[*]align(alignment) u8, @alignCast(alignment, ptr))) |prev_ptr| {
+    if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
         const prev_slice = prev_ptr[0..osize];
         if (nsize == 0) {
             testing.allocator.free(prev_slice);
@@ -581,11 +581,11 @@ test "extra space" {
     var lua = try Lua.init(testing.allocator);
     defer lua.deinit();
 
-    var space = @ptrCast(*align(1) usize, lua.getExtraSpace().ptr);
+    var space = @as(*align(1) usize, @ptrCast(lua.getExtraSpace().ptr));
     space.* = 1024;
     // each new thread is initialized with a copy of the extra space from the main thread
     var thread = lua.newThread();
-    try expectEqual(@as(usize, 1024), @ptrCast(*align(1) usize, thread.getExtraSpace()).*);
+    try expectEqual(@as(usize, 1024), @as(*align(1) usize, @ptrCast(thread.getExtraSpace())).*);
 }
 
 test "table access" {
@@ -664,7 +664,7 @@ test "conversions" {
     var value: Integer = undefined;
     try Lua.numberToInteger(3.14, &value);
     try expectEqual(@as(Integer, 3), value);
-    try expectError(error.Fail, Lua.numberToInteger(@floatFromInt(Number, ziglua.max_integer) + 10, &value));
+    try expectError(error.Fail, Lua.numberToInteger(@as(Number, @floatFromInt(ziglua.max_integer)) + 10, &value));
 
     // string conversion
     try lua.stringToNumber("1");
@@ -770,7 +770,7 @@ test "userdata and uservalues" {
     try expectEqual(@as(Number, 1234.56), try lua.toNumber(-1));
 
     try expectEqual(data, try lua.toUserdata(Data, 1));
-    try expectEqual(@ptrCast(*const anyopaque, data), @alignCast(@alignOf(Data), try lua.toPointer(1)));
+    try expectEqual(@as(*const anyopaque, @ptrCast(data)), @as(*const anyopaque, try lua.toPointer(1)));
 }
 
 test "upvalues" {
@@ -931,7 +931,7 @@ test "debug interface" {
     // get information about the function
     try expectEqual(DebugInfo.FnType.lua, info.what);
     try expectEqual(DebugInfo.NameType.other, info.name_what);
-    const len = std.mem.len(@ptrCast([*:0]u8, &info.short_src));
+    const len = std.mem.len(@as([*:0]u8, @ptrCast(&info.short_src)));
     try expectEqualStrings("[string \"f = function(x)...\"]", info.short_src[0..len]);
     try expectEqual(@as(?i32, 1), info.first_line_defined);
     try expectEqual(@as(?i32, 5), info.last_line_defined);
@@ -1429,7 +1429,7 @@ test "userdata slices" {
     const slice = lua.newUserdataSlice(Integer, 10);
     lua.setMetatableRegistry("FixedArray");
     for (slice, 1..) |*item, index| {
-        item.* = @intCast(Integer, index);
+        item.* = @as(Integer, @intCast(index));
     }
 
     const udataFn = struct {


### PR DESCRIPTION
As of Zig 0.11.0+dev3859, since [zig: #16163](https://github.com/ziglang/zig/pull/16163) has been merged, `@Cast` directives take one argument. I made the changes sort of naïvely, by running `zig fmt` and then manually deleting things from `@alignCast` to make the compiler happy. For the tests I had to include an `@as` directive.