### PR TITLE
Add Luau support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
 
     steps:

--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,7 @@ pub fn build(b: *Build) void {
         },
     });
 
-    const lib = switch(lua_version) {
+    const lib = switch (lua_version) {
         .lua_51, .lua_52, .lua_53, .lua_54 => buildLua(b, target, optimize, lua_version, shared),
         .luau => buildLuau(b, target, optimize, shared),
     };
@@ -195,12 +195,16 @@ fn buildLuau(b: *Build, target: std.zig.CrossTarget, optimize: std.builtin.Optim
         const path = b.pathJoin(&.{ "lib/luau/Compiler/src", file });
         lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
     }
+    for (luau_source_files_ast) |file| {
+        lib.addCSourceFile(.{ .file = .{ .path = file }, .flags = &flags });
+    }
     lib.addCSourceFile(.{ .file = .{ .path = "src/zigluau/assert.cpp" }, .flags = &flags });
     lib.linkLibCpp();
 
     lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lua.h" }), "lua/lua.h");
     lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lualib.h" }), "lua/lualib.h");
     lib.installHeader(b.pathJoin(&.{ lib_dir, "include/luaconf.h" }), "lua/luaconf.h");
+    lib.installHeader("lib/luau/Compiler/include/luacode.h", "lua/luacode.h");
 
     return lib;
 }
@@ -391,4 +395,14 @@ const luau_source_files_vm = [_][]const u8{
     "lvmexecute.cpp",
     "lvmload.cpp",
     "lvmutils.cpp",
+};
+
+const luau_source_files_ast = [_][]const u8{
+    "lib/luau/Ast/src/Ast.cpp",
+    "lib/luau/Ast/src/Confusables.cpp",
+    "lib/luau/Ast/src/Lexer.cpp",
+    "lib/luau/Ast/src/Location.cpp",
+    "lib/luau/Ast/src/Parser.cpp",
+    "lib/luau/Ast/src/StringUtils.cpp",
+    "lib/luau/Ast/src/TimeTrace.cpp",
 };

--- a/build.zig
+++ b/build.zig
@@ -9,7 +9,6 @@ pub const LuaVersion = enum {
     lua_53,
     lua_54,
     luau,
-    // lua_jit,
 };
 
 pub fn build(b: *Build) void {
@@ -177,33 +176,21 @@ fn buildLuau(b: *Build, target: std.zig.CrossTarget, optimize: std.builtin.Optim
     _ = os_tag;
 
     const flags = [_][]const u8{
-        // Enable api check
-        // if (optimize == .Debug) "-DLUA_USE_APICHECK" else "",
-
         "-DLUA_USE_LONGJMP=1",
         "-DLUA_API=extern\"C\"",
         "-DLUACODE_API=extern\"C\"",
         "-DLUACODEGEN_API=extern\"C\"",
     };
 
-    const lua_source_files = &luau_source_files_vm;
-    for (lua_source_files) |file| {
-        const path = b.pathJoin(&.{ lib_dir, "src", file });
-        lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
-    }
-    for (luau_source_files_compiler) |file| {
-        const path = b.pathJoin(&.{ "lib/luau/Compiler/src", file });
-        lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
-    }
-    for (luau_source_files_ast) |file| {
+    for (luau_source_files) |file| {
         lib.addCSourceFile(.{ .file = .{ .path = file }, .flags = &flags });
     }
     lib.addCSourceFile(.{ .file = .{ .path = "src/zigluau/luau.cpp" }, .flags = &flags });
     lib.linkLibCpp();
 
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lua.h" }), "lua/lua.h");
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lualib.h" }), "lua/lualib.h");
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/luaconf.h" }), "lua/luaconf.h");
+    lib.installHeader("lib/luau/VM/include/lua.h", "lua/lua.h");
+    lib.installHeader("lib/luau/VM/include/lualib.h", "lua/lualib.h");
+    lib.installHeader("lib/luau/VM/include/luaconf.h", "lua/luaconf.h");
     lib.installHeader("lib/luau/Compiler/include/luacode.h", "lua/luacode.h");
 
     return lib;
@@ -347,57 +334,51 @@ const lua_54_source_files = [_][]const u8{
     "linit.c",
 };
 
-const luau_source_files_compiler = [_][]const u8{
-    // Compiler
-    "BuiltinFolding.cpp",
-    "Builtins.cpp",
-    "BytecodeBuilder.cpp",
-    "Compiler.cpp",
-    "ConstantFolding.cpp",
-    "CostModel.cpp",
-    "TableShape.cpp",
-    "Types.cpp",
-    "ValueTracking.cpp",
-    "lcode.cpp",
-};
+const luau_source_files = [_][]const u8{
+    "lib/luau/Compiler/src/BuiltinFolding.cpp",
+    "lib/luau/Compiler/src/Builtins.cpp",
+    "lib/luau/Compiler/src/BytecodeBuilder.cpp",
+    "lib/luau/Compiler/src/Compiler.cpp",
+    "lib/luau/Compiler/src/ConstantFolding.cpp",
+    "lib/luau/Compiler/src/CostModel.cpp",
+    "lib/luau/Compiler/src/TableShape.cpp",
+    "lib/luau/Compiler/src/Types.cpp",
+    "lib/luau/Compiler/src/ValueTracking.cpp",
+    "lib/luau/Compiler/src/lcode.cpp",
 
-const luau_source_files_vm = [_][]const u8{
-    // VM
-    "lapi.cpp",
-    "laux.cpp",
-    "lbaselib.cpp",
-    "lbitlib.cpp",
-    "lbuffer.cpp",
-    "lbuflib.cpp",
-    "lbuiltins.cpp",
-    "lcorolib.cpp",
-    "ldblib.cpp",
-    "ldebug.cpp",
-    "ldo.cpp",
-    "lfunc.cpp",
-    "lgc.cpp",
-    "lgcdebug.cpp",
-    "linit.cpp",
-    "lmathlib.cpp",
-    "lmem.cpp",
-    "lnumprint.cpp",
-    "lobject.cpp",
-    "loslib.cpp",
-    "lperf.cpp",
-    "lstate.cpp",
-    "lstring.cpp",
-    "lstrlib.cpp",
-    "ltable.cpp",
-    "ltablib.cpp",
-    "ltm.cpp",
-    "ludata.cpp",
-    "lutf8lib.cpp",
-    "lvmexecute.cpp",
-    "lvmload.cpp",
-    "lvmutils.cpp",
-};
+    "lib/luau/VM/src/lapi.cpp",
+    "lib/luau/VM/src/laux.cpp",
+    "lib/luau/VM/src/lbaselib.cpp",
+    "lib/luau/VM/src/lbitlib.cpp",
+    "lib/luau/VM/src/lbuffer.cpp",
+    "lib/luau/VM/src/lbuflib.cpp",
+    "lib/luau/VM/src/lbuiltins.cpp",
+    "lib/luau/VM/src/lcorolib.cpp",
+    "lib/luau/VM/src/ldblib.cpp",
+    "lib/luau/VM/src/ldebug.cpp",
+    "lib/luau/VM/src/ldo.cpp",
+    "lib/luau/VM/src/lfunc.cpp",
+    "lib/luau/VM/src/lgc.cpp",
+    "lib/luau/VM/src/lgcdebug.cpp",
+    "lib/luau/VM/src/linit.cpp",
+    "lib/luau/VM/src/lmathlib.cpp",
+    "lib/luau/VM/src/lmem.cpp",
+    "lib/luau/VM/src/lnumprint.cpp",
+    "lib/luau/VM/src/lobject.cpp",
+    "lib/luau/VM/src/loslib.cpp",
+    "lib/luau/VM/src/lperf.cpp",
+    "lib/luau/VM/src/lstate.cpp",
+    "lib/luau/VM/src/lstring.cpp",
+    "lib/luau/VM/src/lstrlib.cpp",
+    "lib/luau/VM/src/ltable.cpp",
+    "lib/luau/VM/src/ltablib.cpp",
+    "lib/luau/VM/src/ltm.cpp",
+    "lib/luau/VM/src/ludata.cpp",
+    "lib/luau/VM/src/lutf8lib.cpp",
+    "lib/luau/VM/src/lvmexecute.cpp",
+    "lib/luau/VM/src/lvmload.cpp",
+    "lib/luau/VM/src/lvmutils.cpp",
 
-const luau_source_files_ast = [_][]const u8{
     "lib/luau/Ast/src/Ast.cpp",
     "lib/luau/Ast/src/Confusables.cpp",
     "lib/luau/Ast/src/Lexer.cpp",

--- a/build.zig
+++ b/build.zig
@@ -1,12 +1,14 @@
 const std = @import("std");
 
 const Build = std.Build;
+const Step = std.Build.Step;
 
 pub const LuaVersion = enum {
     lua_51,
     lua_52,
     lua_53,
     lua_54,
+    luau,
     // lua_jit,
 };
 
@@ -27,69 +29,14 @@ pub fn build(b: *Build) void {
             .lua_52 => .{ .path = "src/ziglua-5.2/lib.zig" },
             .lua_53 => .{ .path = "src/ziglua-5.3/lib.zig" },
             .lua_54 => .{ .path = "src/ziglua-5.4/lib.zig" },
+            .luau => .{ .path = "src/zigluau/lib.zig" },
         },
     });
 
-    // Lua library artifact
-    const lib_opts = .{
-        .name = "lua",
-        .target = target,
-        .optimize = optimize,
-        .version = switch (lua_version) {
-            .lua_51 => std.SemanticVersion{ .major = 5, .minor = 1, .patch = 5 },
-            .lua_52 => std.SemanticVersion{ .major = 5, .minor = 2, .patch = 4 },
-            .lua_53 => std.SemanticVersion{ .major = 5, .minor = 3, .patch = 6 },
-            .lua_54 => std.SemanticVersion{ .major = 5, .minor = 4, .patch = 6 },
-        },
+    const lib = switch(lua_version) {
+        .lua_51, .lua_52, .lua_53, .lua_54 => buildLua(b, target, optimize, lua_version, shared),
+        .luau => buildLuau(b, target, optimize, shared),
     };
-    const lib = if (shared)
-        b.addSharedLibrary(lib_opts)
-    else
-        b.addStaticLibrary(lib_opts);
-
-    const lib_dir = switch (lua_version) {
-        .lua_51 => "lib/lua-5.1/src",
-        .lua_52 => "lib/lua-5.2/src",
-        .lua_53 => "lib/lua-5.3/src",
-        .lua_54 => "lib/lua-5.4/src",
-    };
-    lib.addIncludePath(.{ .path = lib_dir });
-
-    const os_tag = target.os_tag orelse
-        (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.os.tag;
-
-    const flags = [_][]const u8{
-        // Standard version used in Lua Makefile
-        "-std=gnu99",
-
-        // Define target-specific macro
-        switch (os_tag) {
-            .linux => "-DLUA_USE_LINUX",
-            .macos => "-DLUA_USE_MACOSX",
-            .windows => "-DLUA_USE_WINDOWS",
-            else => "-DLUA_USE_POSIX",
-        },
-
-        // Enable api check
-        if (optimize == .Debug) "-DLUA_USE_APICHECK" else "",
-    };
-
-    const lua_source_files = switch (lua_version) {
-        .lua_51 => &lua_51_source_files,
-        .lua_52 => &lua_52_source_files,
-        .lua_53 => &lua_53_source_files,
-        .lua_54 => &lua_54_source_files,
-    };
-    for (lua_source_files) |file| {
-        const path = std.fs.path.join(b.allocator, &.{ lib_dir, file }) catch unreachable;
-        lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
-    }
-    lib.linkLibC();
-
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "lua.h" }), "lua/lua.h");
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "lualib.h" }), "lua/lualib.h");
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "lauxlib.h" }), "lua/lauxlib.h");
-    lib.installHeader(b.pathJoin(&.{ lib_dir, "luaconf.h" }), "lua/luaconf.h");
 
     b.installArtifact(lib);
 
@@ -100,14 +47,16 @@ pub fn build(b: *Build) void {
             .lua_52 => .{ .path = "src/ziglua-5.2/tests.zig" },
             .lua_53 => .{ .path = "src/ziglua-5.3/tests.zig" },
             .lua_54 => .{ .path = "src/ziglua-5.4/tests.zig" },
+            .luau => .{ .path = "src/zigluau/tests.zig" },
         },
+        .target = target,
         .optimize = optimize,
     });
-    tests.addIncludePath(.{ .path = lib_dir });
     tests.linkLibrary(lib);
 
+    const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run ziglua tests");
-    test_step.dependOn(&tests.step);
+    test_step.dependOn(&run_tests.step);
 
     // Examples
     const examples = [_]struct { []const u8, []const u8 }{
@@ -136,6 +85,124 @@ pub fn build(b: *Build) void {
         const run_step = b.step(b.fmt("run-example-{s}", .{example[0]}), b.fmt("Run {s} example", .{example[0]}));
         run_step.dependOn(&run_cmd.step);
     }
+}
+
+fn buildLua(b: *Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode, lua_version: LuaVersion, shared: bool) *Step.Compile {
+    const lib_opts = .{
+        .name = "lua",
+        .target = target,
+        .optimize = optimize,
+        .version = switch (lua_version) {
+            .lua_51 => std.SemanticVersion{ .major = 5, .minor = 1, .patch = 5 },
+            .lua_52 => std.SemanticVersion{ .major = 5, .minor = 2, .patch = 4 },
+            .lua_53 => std.SemanticVersion{ .major = 5, .minor = 3, .patch = 6 },
+            .lua_54 => std.SemanticVersion{ .major = 5, .minor = 4, .patch = 6 },
+            else => unreachable,
+        },
+    };
+    const lib = if (shared)
+        b.addSharedLibrary(lib_opts)
+    else
+        b.addStaticLibrary(lib_opts);
+
+    const lib_dir = switch (lua_version) {
+        .lua_51 => "lib/lua-5.1/src",
+        .lua_52 => "lib/lua-5.2/src",
+        .lua_53 => "lib/lua-5.3/src",
+        .lua_54 => "lib/lua-5.4/src",
+        else => unreachable,
+    };
+    lib.addIncludePath(.{ .path = b.pathJoin(&.{ lib_dir, "include" }) });
+
+    const os_tag = target.os_tag orelse
+        (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.os.tag;
+
+    const flags = [_][]const u8{
+        // Standard version used in Lua Makefile
+        "-std=gnu99",
+
+        // Define target-specific macro
+        switch (os_tag) {
+            .linux => "-DLUA_USE_LINUX",
+            .macos => "-DLUA_USE_MACOSX",
+            .windows => "-DLUA_USE_WINDOWS",
+            else => "-DLUA_USE_POSIX",
+        },
+
+        // Enable api check
+        if (optimize == .Debug) "-DLUA_USE_APICHECK" else "",
+    };
+
+    const lua_source_files = switch (lua_version) {
+        .lua_51 => &lua_51_source_files,
+        .lua_52 => &lua_52_source_files,
+        .lua_53 => &lua_53_source_files,
+        .lua_54 => &lua_54_source_files,
+        else => unreachable,
+    };
+    for (lua_source_files) |file| {
+        lib.addCSourceFile(.{ .file = .{ .path = b.pathJoin(&.{ lib_dir, file }) }, .flags = &flags });
+    }
+    lib.linkLibC();
+
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lua.h" }), "lua/lua.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lualib.h" }), "lua/lualib.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "lauxlib.h" }), "lua/lauxlib.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "luaconf.h" }), "lua/luaconf.h");
+
+    return lib;
+}
+
+/// Luau has diverged enough from Lua (C++, project structure, ...) that it is easier to separate the build logic
+fn buildLuau(b: *Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode, shared: bool) *Step.Compile {
+    const lib_opts = .{
+        .name = "luau",
+        .target = target,
+        .optimize = optimize,
+        .version = std.SemanticVersion{ .major = 0, .minor = 607, .patch = 0 },
+    };
+    const lib = if (shared)
+        b.addSharedLibrary(lib_opts)
+    else
+        b.addStaticLibrary(lib_opts);
+
+    const lib_dir = "lib/luau/VM";
+    lib.addIncludePath(.{ .path = "lib/luau/Common/include" });
+    lib.addIncludePath(.{ .path = "lib/luau/Compiler/include" });
+    lib.addIncludePath(.{ .path = "lib/luau/Ast/include" });
+    lib.addIncludePath(.{ .path = b.pathJoin(&.{ lib_dir, "include" }) });
+
+    const os_tag = target.os_tag orelse
+        (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target.os.tag;
+    _ = os_tag;
+
+    const flags = [_][]const u8{
+        // Enable api check
+        // if (optimize == .Debug) "-DLUA_USE_APICHECK" else "",
+
+        "-DLUA_USE_LONGJMP=1",
+        "-DLUA_API=extern\"C\"",
+        "-DLUACODE_API=extern\"C\"",
+        "-DLUACODEGEN_API=extern\"C\"",
+    };
+
+    const lua_source_files = &luau_source_files_vm;
+    for (lua_source_files) |file| {
+        const path = b.pathJoin(&.{ lib_dir, "src", file });
+        lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
+    }
+    for (luau_source_files_compiler) |file| {
+        const path = b.pathJoin(&.{ "lib/luau/Compiler/src", file });
+        lib.addCSourceFile(.{ .file = .{ .path = path }, .flags = &flags });
+    }
+    lib.addCSourceFile(.{ .file = .{ .path = "src/zigluau/assert.cpp" }, .flags = &flags });
+    lib.linkLibCpp();
+
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lua.h" }), "lua/lua.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lualib.h" }), "lua/lualib.h");
+    lib.installHeader(b.pathJoin(&.{ lib_dir, "include/luaconf.h" }), "lua/luaconf.h");
+
+    return lib;
 }
 
 const lua_51_source_files = [_][]const u8{
@@ -274,4 +341,54 @@ const lua_54_source_files = [_][]const u8{
     "ltablib.c",
     "lutf8lib.c",
     "linit.c",
+};
+
+const luau_source_files_compiler = [_][]const u8{
+    // Compiler
+    "BuiltinFolding.cpp",
+    "Builtins.cpp",
+    "BytecodeBuilder.cpp",
+    "Compiler.cpp",
+    "ConstantFolding.cpp",
+    "CostModel.cpp",
+    "TableShape.cpp",
+    "Types.cpp",
+    "ValueTracking.cpp",
+    "lcode.cpp",
+};
+
+const luau_source_files_vm = [_][]const u8{
+    // VM
+    "lapi.cpp",
+    "laux.cpp",
+    "lbaselib.cpp",
+    "lbitlib.cpp",
+    "lbuffer.cpp",
+    "lbuflib.cpp",
+    "lbuiltins.cpp",
+    "lcorolib.cpp",
+    "ldblib.cpp",
+    "ldebug.cpp",
+    "ldo.cpp",
+    "lfunc.cpp",
+    "lgc.cpp",
+    "lgcdebug.cpp",
+    "linit.cpp",
+    "lmathlib.cpp",
+    "lmem.cpp",
+    "lnumprint.cpp",
+    "lobject.cpp",
+    "loslib.cpp",
+    "lperf.cpp",
+    "lstate.cpp",
+    "lstring.cpp",
+    "lstrlib.cpp",
+    "ltable.cpp",
+    "ltablib.cpp",
+    "ltm.cpp",
+    "ludata.cpp",
+    "lutf8lib.cpp",
+    "lvmexecute.cpp",
+    "lvmload.cpp",
+    "lvmutils.cpp",
 };

--- a/build.zig
+++ b/build.zig
@@ -198,7 +198,7 @@ fn buildLuau(b: *Build, target: std.zig.CrossTarget, optimize: std.builtin.Optim
     for (luau_source_files_ast) |file| {
         lib.addCSourceFile(.{ .file = .{ .path = file }, .flags = &flags });
     }
-    lib.addCSourceFile(.{ .file = .{ .path = "src/zigluau/assert.cpp" }, .flags = &flags });
+    lib.addCSourceFile(.{ .file = .{ .path = "src/zigluau/luau.cpp" }, .flags = &flags });
     lib.linkLibCpp();
 
     lib.installHeader(b.pathJoin(&.{ lib_dir, "include/lua.h" }), "lua/lua.h");

--- a/lib/luau/Ast/include/Luau/Ast.h
+++ b/lib/luau/Ast/include/Luau/Ast.h
@@ -1,0 +1,1369 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Location.h"
+
+#include <iterator>
+#include <optional>
+#include <functional>
+#include <string>
+
+#include <string.h>
+#include <stdint.h>
+
+namespace Luau
+{
+
+struct AstName
+{
+    const char* value;
+
+    AstName()
+        : value(nullptr)
+    {
+    }
+
+    explicit AstName(const char* value)
+        : value(value)
+    {
+    }
+
+    bool operator==(const AstName& rhs) const
+    {
+        return value == rhs.value;
+    }
+
+    bool operator!=(const AstName& rhs) const
+    {
+        return value != rhs.value;
+    }
+
+    bool operator==(const char* rhs) const
+    {
+        return value && strcmp(value, rhs) == 0;
+    }
+
+    bool operator!=(const char* rhs) const
+    {
+        return !value || strcmp(value, rhs) != 0;
+    }
+
+    bool operator<(const AstName& rhs) const
+    {
+        return (value && rhs.value) ? strcmp(value, rhs.value) < 0 : value < rhs.value;
+    }
+};
+
+class AstType;
+class AstVisitor;
+class AstStat;
+class AstStatBlock;
+class AstExpr;
+class AstTypePack;
+
+struct AstLocal
+{
+    AstName name;
+    Location location;
+    AstLocal* shadow;
+    size_t functionDepth;
+    size_t loopDepth;
+
+    AstType* annotation;
+
+    AstLocal(const AstName& name, const Location& location, AstLocal* shadow, size_t functionDepth, size_t loopDepth, AstType* annotation)
+        : name(name)
+        , location(location)
+        , shadow(shadow)
+        , functionDepth(functionDepth)
+        , loopDepth(loopDepth)
+        , annotation(annotation)
+    {
+    }
+};
+
+template<typename T>
+struct AstArray
+{
+    T* data;
+    size_t size;
+
+    const T* begin() const
+    {
+        return data;
+    }
+
+    const T* end() const
+    {
+        return data + size;
+    }
+
+    std::reverse_iterator<const T*> rbegin() const
+    {
+        return std::make_reverse_iterator(end());
+    }
+
+    std::reverse_iterator<const T*> rend() const
+    {
+        return std::make_reverse_iterator(begin());
+    }
+};
+
+struct AstTypeList
+{
+    AstArray<AstType*> types;
+    // Null indicates no tail, not an untyped tail.
+    AstTypePack* tailType = nullptr;
+};
+
+using AstArgumentName = std::pair<AstName, Location>; // TODO: remove and replace when we get a common struct for this pair instead of AstName
+
+struct AstGenericType
+{
+    AstName name;
+    Location location;
+    AstType* defaultValue = nullptr;
+};
+
+struct AstGenericTypePack
+{
+    AstName name;
+    Location location;
+    AstTypePack* defaultValue = nullptr;
+};
+
+extern int gAstRttiIndex;
+
+template<typename T>
+struct AstRtti
+{
+    static const int value;
+};
+
+template<typename T>
+const int AstRtti<T>::value = ++gAstRttiIndex;
+
+#define LUAU_RTTI(Class) \
+    static int ClassIndex() \
+    { \
+        return AstRtti<Class>::value; \
+    }
+
+class AstNode
+{
+public:
+    explicit AstNode(int classIndex, const Location& location)
+        : classIndex(classIndex)
+        , location(location)
+    {
+    }
+
+    virtual void visit(AstVisitor* visitor) = 0;
+
+    virtual AstExpr* asExpr()
+    {
+        return nullptr;
+    }
+    virtual AstStat* asStat()
+    {
+        return nullptr;
+    }
+    virtual AstType* asType()
+    {
+        return nullptr;
+    }
+
+    template<typename T>
+    bool is() const
+    {
+        return classIndex == T::ClassIndex();
+    }
+    template<typename T>
+    T* as()
+    {
+        return classIndex == T::ClassIndex() ? static_cast<T*>(this) : nullptr;
+    }
+    template<typename T>
+    const T* as() const
+    {
+        return classIndex == T::ClassIndex() ? static_cast<const T*>(this) : nullptr;
+    }
+
+    const int classIndex;
+    Location location;
+};
+
+class AstExpr : public AstNode
+{
+public:
+    explicit AstExpr(int classIndex, const Location& location)
+        : AstNode(classIndex, location)
+    {
+    }
+
+    AstExpr* asExpr() override
+    {
+        return this;
+    }
+};
+
+class AstStat : public AstNode
+{
+public:
+    explicit AstStat(int classIndex, const Location& location)
+        : AstNode(classIndex, location)
+        , hasSemicolon(false)
+    {
+    }
+
+    AstStat* asStat() override
+    {
+        return this;
+    }
+
+    bool hasSemicolon;
+};
+
+class AstExprGroup : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprGroup)
+
+    explicit AstExprGroup(const Location& location, AstExpr* expr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+};
+
+class AstExprConstantNil : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprConstantNil)
+
+    explicit AstExprConstantNil(const Location& location);
+
+    void visit(AstVisitor* visitor) override;
+};
+
+class AstExprConstantBool : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprConstantBool)
+
+    AstExprConstantBool(const Location& location, bool value);
+
+    void visit(AstVisitor* visitor) override;
+
+    bool value;
+};
+
+enum class ConstantNumberParseResult
+{
+    Ok,
+    Imprecise,
+    Malformed,
+    BinOverflow,
+    HexOverflow,
+};
+
+class AstExprConstantNumber : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprConstantNumber)
+
+    AstExprConstantNumber(const Location& location, double value, ConstantNumberParseResult parseResult = ConstantNumberParseResult::Ok);
+
+    void visit(AstVisitor* visitor) override;
+
+    double value;
+    ConstantNumberParseResult parseResult;
+};
+
+class AstExprConstantString : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprConstantString)
+
+    enum QuoteStyle
+    {
+        Quoted,
+        Unquoted
+    };
+
+    AstExprConstantString(const Location& location, const AstArray<char>& value, QuoteStyle quoteStyle = Quoted);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<char> value;
+    QuoteStyle quoteStyle = Quoted;
+};
+
+class AstExprLocal : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprLocal)
+
+    AstExprLocal(const Location& location, AstLocal* local, bool upvalue);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstLocal* local;
+    bool upvalue;
+};
+
+class AstExprGlobal : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprGlobal)
+
+    AstExprGlobal(const Location& location, const AstName& name);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName name;
+};
+
+class AstExprVarargs : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprVarargs)
+
+    AstExprVarargs(const Location& location);
+
+    void visit(AstVisitor* visitor) override;
+};
+
+class AstExprCall : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprCall)
+
+    AstExprCall(const Location& location, AstExpr* func, const AstArray<AstExpr*>& args, bool self, const Location& argLocation);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* func;
+    AstArray<AstExpr*> args;
+    bool self;
+    Location argLocation;
+};
+
+class AstExprIndexName : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprIndexName)
+
+    AstExprIndexName(
+        const Location& location, AstExpr* expr, const AstName& index, const Location& indexLocation, const Position& opPosition, char op);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+    AstName index;
+    Location indexLocation;
+    Position opPosition;
+    char op = '.';
+};
+
+class AstExprIndexExpr : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprIndexExpr)
+
+    AstExprIndexExpr(const Location& location, AstExpr* expr, AstExpr* index);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+    AstExpr* index;
+};
+
+class AstExprFunction : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprFunction)
+
+    AstExprFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+        AstLocal* self, const AstArray<AstLocal*>& args, bool vararg, const Location& varargLocation, AstStatBlock* body, size_t functionDepth,
+        const AstName& debugname, const std::optional<AstTypeList>& returnAnnotation = {}, AstTypePack* varargAnnotation = nullptr,
+        bool DEPRECATED_hasEnd = false, const std::optional<Location>& argLocation = std::nullopt);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstGenericType> generics;
+    AstArray<AstGenericTypePack> genericPacks;
+    AstLocal* self;
+    AstArray<AstLocal*> args;
+    std::optional<AstTypeList> returnAnnotation;
+    bool vararg = false;
+    Location varargLocation;
+    AstTypePack* varargAnnotation;
+
+    AstStatBlock* body;
+
+    size_t functionDepth;
+
+    AstName debugname;
+
+    // TODO clip with FFlag::LuauClipExtraHasEndProps
+    bool DEPRECATED_hasEnd = false;
+    std::optional<Location> argLocation;
+};
+
+class AstExprTable : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprTable)
+
+    struct Item
+    {
+        enum Kind
+        {
+            List,    // foo, in which case key is a nullptr
+            Record,  // foo=bar, in which case key is a AstExprConstantString
+            General, // [foo]=bar
+        };
+
+        Kind kind;
+
+        AstExpr* key; // can be nullptr!
+        AstExpr* value;
+    };
+
+    AstExprTable(const Location& location, const AstArray<Item>& items);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<Item> items;
+};
+
+class AstExprUnary : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprUnary)
+
+    enum Op
+    {
+        Not,
+        Minus,
+        Len
+    };
+
+    AstExprUnary(const Location& location, Op op, AstExpr* expr);
+
+    void visit(AstVisitor* visitor) override;
+
+    Op op;
+    AstExpr* expr;
+};
+
+std::string toString(AstExprUnary::Op op);
+
+class AstExprBinary : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprBinary)
+
+    enum Op
+    {
+        Add,
+        Sub,
+        Mul,
+        Div,
+        FloorDiv,
+        Mod,
+        Pow,
+        Concat,
+        CompareNe,
+        CompareEq,
+        CompareLt,
+        CompareLe,
+        CompareGt,
+        CompareGe,
+        And,
+        Or,
+
+        Op__Count
+    };
+
+    AstExprBinary(const Location& location, Op op, AstExpr* left, AstExpr* right);
+
+    void visit(AstVisitor* visitor) override;
+
+    Op op;
+    AstExpr* left;
+    AstExpr* right;
+};
+
+std::string toString(AstExprBinary::Op op);
+
+class AstExprTypeAssertion : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprTypeAssertion)
+
+    AstExprTypeAssertion(const Location& location, AstExpr* expr, AstType* annotation);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+    AstType* annotation;
+};
+
+class AstExprIfElse : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprIfElse)
+
+    AstExprIfElse(const Location& location, AstExpr* condition, bool hasThen, AstExpr* trueExpr, bool hasElse, AstExpr* falseExpr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* condition;
+    bool hasThen;
+    AstExpr* trueExpr;
+    bool hasElse;
+    AstExpr* falseExpr;
+};
+
+class AstExprInterpString : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprInterpString)
+
+    AstExprInterpString(const Location& location, const AstArray<AstArray<char>>& strings, const AstArray<AstExpr*>& expressions);
+
+    void visit(AstVisitor* visitor) override;
+
+    /// An interpolated string such as `foo{bar}baz` is represented as
+    /// an array of strings for "foo" and "bar", and an array of expressions for "baz".
+    /// `strings` will always have one more element than `expressions`.
+    AstArray<AstArray<char>> strings;
+    AstArray<AstExpr*> expressions;
+};
+
+class AstStatBlock : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatBlock)
+
+    AstStatBlock(const Location& location, const AstArray<AstStat*>& body, bool hasEnd = true);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstStat*> body;
+
+    /* Indicates whether or not this block has been terminated in a
+     * syntactically valid way.
+     *
+     * This is usually but not always done with the 'end' keyword.  AstStatIf
+     * and AstStatRepeat are the two main exceptions to this.
+     *
+     * The 'then' clause of an if statement can properly be closed by the
+     * keywords 'else' or 'elseif'.  A 'repeat' loop's body is closed with the
+     * 'until' keyword.
+     */
+    bool hasEnd = false;
+};
+
+class AstStatIf : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatIf)
+
+    AstStatIf(const Location& location, AstExpr* condition, AstStatBlock* thenbody, AstStat* elsebody, const std::optional<Location>& thenLocation,
+        const std::optional<Location>& elseLocation, bool DEPRECATED_hasEnd);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* condition;
+    AstStatBlock* thenbody;
+    AstStat* elsebody;
+
+    std::optional<Location> thenLocation;
+
+    // Active for 'elseif' as well
+    std::optional<Location> elseLocation;
+
+    // TODO clip with FFlag::LuauClipExtraHasEndProps
+    bool DEPRECATED_hasEnd = false;
+};
+
+class AstStatWhile : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatWhile)
+
+    AstStatWhile(const Location& location, AstExpr* condition, AstStatBlock* body, bool hasDo, const Location& doLocation, bool DEPRECATED_hasEnd);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* condition;
+    AstStatBlock* body;
+
+    bool hasDo = false;
+    Location doLocation;
+
+    // TODO clip with FFlag::LuauClipExtraHasEndProps
+    bool DEPRECATED_hasEnd = false;
+};
+
+class AstStatRepeat : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatRepeat)
+
+    AstStatRepeat(const Location& location, AstExpr* condition, AstStatBlock* body, bool DEPRECATED_hasUntil);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* condition;
+    AstStatBlock* body;
+
+    bool DEPRECATED_hasUntil = false;
+};
+
+class AstStatBreak : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatBreak)
+
+    AstStatBreak(const Location& location);
+
+    void visit(AstVisitor* visitor) override;
+};
+
+class AstStatContinue : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatContinue)
+
+    AstStatContinue(const Location& location);
+
+    void visit(AstVisitor* visitor) override;
+};
+
+class AstStatReturn : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatReturn)
+
+    AstStatReturn(const Location& location, const AstArray<AstExpr*>& list);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstExpr*> list;
+};
+
+class AstStatExpr : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatExpr)
+
+    AstStatExpr(const Location& location, AstExpr* expr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+};
+
+class AstStatLocal : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatLocal)
+
+    AstStatLocal(const Location& location, const AstArray<AstLocal*>& vars, const AstArray<AstExpr*>& values,
+        const std::optional<Location>& equalsSignLocation);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstLocal*> vars;
+    AstArray<AstExpr*> values;
+
+    std::optional<Location> equalsSignLocation;
+};
+
+class AstStatFor : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatFor)
+
+    AstStatFor(const Location& location, AstLocal* var, AstExpr* from, AstExpr* to, AstExpr* step, AstStatBlock* body, bool hasDo,
+        const Location& doLocation, bool DEPRECATED_hasEnd);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstLocal* var;
+    AstExpr* from;
+    AstExpr* to;
+    AstExpr* step;
+    AstStatBlock* body;
+
+    bool hasDo = false;
+    Location doLocation;
+
+    // TODO clip with FFlag::LuauClipExtraHasEndProps
+    bool DEPRECATED_hasEnd = false;
+};
+
+class AstStatForIn : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatForIn)
+
+    AstStatForIn(const Location& location, const AstArray<AstLocal*>& vars, const AstArray<AstExpr*>& values, AstStatBlock* body, bool hasIn,
+        const Location& inLocation, bool hasDo, const Location& doLocation, bool DEPRECATED_hasEnd);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstLocal*> vars;
+    AstArray<AstExpr*> values;
+    AstStatBlock* body;
+
+    bool hasIn = false;
+    Location inLocation;
+
+    bool hasDo = false;
+    Location doLocation;
+
+    // TODO clip with FFlag::LuauClipExtraHasEndProps
+    bool DEPRECATED_hasEnd = false;
+};
+
+class AstStatAssign : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatAssign)
+
+    AstStatAssign(const Location& location, const AstArray<AstExpr*>& vars, const AstArray<AstExpr*>& values);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstExpr*> vars;
+    AstArray<AstExpr*> values;
+};
+
+class AstStatCompoundAssign : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatCompoundAssign)
+
+    AstStatCompoundAssign(const Location& location, AstExprBinary::Op op, AstExpr* var, AstExpr* value);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExprBinary::Op op;
+    AstExpr* var;
+    AstExpr* value;
+};
+
+class AstStatFunction : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatFunction)
+
+    AstStatFunction(const Location& location, AstExpr* name, AstExprFunction* func);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* name;
+    AstExprFunction* func;
+};
+
+class AstStatLocalFunction : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatLocalFunction)
+
+    AstStatLocalFunction(const Location& location, AstLocal* name, AstExprFunction* func);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstLocal* name;
+    AstExprFunction* func;
+};
+
+class AstStatTypeAlias : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatTypeAlias)
+
+    AstStatTypeAlias(const Location& location, const AstName& name, const Location& nameLocation, const AstArray<AstGenericType>& generics,
+        const AstArray<AstGenericTypePack>& genericPacks, AstType* type, bool exported);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName name;
+    Location nameLocation;
+    AstArray<AstGenericType> generics;
+    AstArray<AstGenericTypePack> genericPacks;
+    AstType* type;
+    bool exported;
+};
+
+class AstStatDeclareGlobal : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatDeclareGlobal)
+
+    AstStatDeclareGlobal(const Location& location, const AstName& name, AstType* type);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName name;
+    AstType* type;
+};
+
+class AstStatDeclareFunction : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatDeclareFunction)
+
+    AstStatDeclareFunction(const Location& location, const AstName& name, const AstArray<AstGenericType>& generics,
+        const AstArray<AstGenericTypePack>& genericPacks, const AstTypeList& params, const AstArray<AstArgumentName>& paramNames,
+        const AstTypeList& retTypes);
+
+    AstStatDeclareFunction(const Location& location, const AstName& name, const AstArray<AstGenericType>& generics,
+        const AstArray<AstGenericTypePack>& genericPacks, const AstTypeList& params, const AstArray<AstArgumentName>& paramNames,
+        const AstTypeList& retTypes, bool checkedFunction);
+
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName name;
+    AstArray<AstGenericType> generics;
+    AstArray<AstGenericTypePack> genericPacks;
+    AstTypeList params;
+    AstArray<AstArgumentName> paramNames;
+    AstTypeList retTypes;
+    bool checkedFunction;
+};
+
+struct AstDeclaredClassProp
+{
+    AstName name;
+    AstType* ty = nullptr;
+    bool isMethod = false;
+};
+
+struct AstTableIndexer
+{
+    AstType* indexType;
+    AstType* resultType;
+    Location location;
+};
+
+class AstStatDeclareClass : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatDeclareClass)
+
+    AstStatDeclareClass(const Location& location, const AstName& name, std::optional<AstName> superName, const AstArray<AstDeclaredClassProp>& props,
+        AstTableIndexer* indexer = nullptr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName name;
+    std::optional<AstName> superName;
+
+    AstArray<AstDeclaredClassProp> props;
+    AstTableIndexer* indexer;
+};
+
+class AstType : public AstNode
+{
+public:
+    AstType(int classIndex, const Location& location)
+        : AstNode(classIndex, location)
+    {
+    }
+
+    AstType* asType() override
+    {
+        return this;
+    }
+};
+
+// Don't have Luau::Variant available, it's a bit of an overhead, but a plain struct is nice to use
+struct AstTypeOrPack
+{
+    AstType* type = nullptr;
+    AstTypePack* typePack = nullptr;
+};
+
+class AstTypeReference : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeReference)
+
+    AstTypeReference(const Location& location, std::optional<AstName> prefix, AstName name, std::optional<Location> prefixLocation,
+        const Location& nameLocation, bool hasParameterList = false, const AstArray<AstTypeOrPack>& parameters = {});
+
+    void visit(AstVisitor* visitor) override;
+
+    bool hasParameterList;
+    std::optional<AstName> prefix;
+    std::optional<Location> prefixLocation;
+    AstName name;
+    Location nameLocation;
+    AstArray<AstTypeOrPack> parameters;
+};
+
+struct AstTableProp
+{
+    AstName name;
+    Location location;
+    AstType* type;
+};
+
+class AstTypeTable : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeTable)
+
+    AstTypeTable(const Location& location, const AstArray<AstTableProp>& props, AstTableIndexer* indexer = nullptr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstTableProp> props;
+    AstTableIndexer* indexer;
+};
+
+class AstTypeFunction : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeFunction)
+
+    AstTypeFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+        const AstTypeList& argTypes, const AstArray<std::optional<AstArgumentName>>& argNames, const AstTypeList& returnTypes);
+
+    AstTypeFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+        const AstTypeList& argTypes, const AstArray<std::optional<AstArgumentName>>& argNames, const AstTypeList& returnTypes, bool checkedFunction);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstGenericType> generics;
+    AstArray<AstGenericTypePack> genericPacks;
+    AstTypeList argTypes;
+    AstArray<std::optional<AstArgumentName>> argNames;
+    AstTypeList returnTypes;
+    bool checkedFunction;
+};
+
+class AstTypeTypeof : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeTypeof)
+
+    AstTypeTypeof(const Location& location, AstExpr* expr);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstExpr* expr;
+};
+
+class AstTypeUnion : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeUnion)
+
+    AstTypeUnion(const Location& location, const AstArray<AstType*>& types);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstType*> types;
+};
+
+class AstTypeIntersection : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeIntersection)
+
+    AstTypeIntersection(const Location& location, const AstArray<AstType*>& types);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstType*> types;
+};
+
+class AstExprError : public AstExpr
+{
+public:
+    LUAU_RTTI(AstExprError)
+
+    AstExprError(const Location& location, const AstArray<AstExpr*>& expressions, unsigned messageIndex);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstExpr*> expressions;
+    unsigned messageIndex;
+};
+
+class AstStatError : public AstStat
+{
+public:
+    LUAU_RTTI(AstStatError)
+
+    AstStatError(const Location& location, const AstArray<AstExpr*>& expressions, const AstArray<AstStat*>& statements, unsigned messageIndex);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstExpr*> expressions;
+    AstArray<AstStat*> statements;
+    unsigned messageIndex;
+};
+
+class AstTypeError : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeError)
+
+    AstTypeError(const Location& location, const AstArray<AstType*>& types, bool isMissing, unsigned messageIndex);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstArray<AstType*> types;
+    bool isMissing;
+    unsigned messageIndex;
+};
+
+class AstTypeSingletonBool : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeSingletonBool)
+
+    AstTypeSingletonBool(const Location& location, bool value);
+
+    void visit(AstVisitor* visitor) override;
+
+    bool value;
+};
+
+class AstTypeSingletonString : public AstType
+{
+public:
+    LUAU_RTTI(AstTypeSingletonString)
+
+    AstTypeSingletonString(const Location& location, const AstArray<char>& value);
+
+    void visit(AstVisitor* visitor) override;
+
+    const AstArray<char> value;
+};
+
+class AstTypePack : public AstNode
+{
+public:
+    AstTypePack(int classIndex, const Location& location)
+        : AstNode(classIndex, location)
+    {
+    }
+};
+
+class AstTypePackExplicit : public AstTypePack
+{
+public:
+    LUAU_RTTI(AstTypePackExplicit)
+
+    AstTypePackExplicit(const Location& location, AstTypeList typeList);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstTypeList typeList;
+};
+
+class AstTypePackVariadic : public AstTypePack
+{
+public:
+    LUAU_RTTI(AstTypePackVariadic)
+
+    AstTypePackVariadic(const Location& location, AstType* variadicType);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstType* variadicType;
+};
+
+class AstTypePackGeneric : public AstTypePack
+{
+public:
+    LUAU_RTTI(AstTypePackGeneric)
+
+    AstTypePackGeneric(const Location& location, AstName name);
+
+    void visit(AstVisitor* visitor) override;
+
+    AstName genericName;
+};
+
+class AstVisitor
+{
+public:
+    virtual ~AstVisitor() {}
+
+    virtual bool visit(class AstNode*)
+    {
+        return true;
+    }
+
+    virtual bool visit(class AstExpr* node)
+    {
+        return visit(static_cast<AstNode*>(node));
+    }
+
+    virtual bool visit(class AstExprGroup* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprConstantNil* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprConstantBool* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprConstantNumber* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprConstantString* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprLocal* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprGlobal* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprVarargs* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprCall* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprIndexName* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprIndexExpr* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprFunction* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprTable* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprUnary* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprBinary* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprTypeAssertion* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprIfElse* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprInterpString* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+    virtual bool visit(class AstExprError* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
+
+    virtual bool visit(class AstStat* node)
+    {
+        return visit(static_cast<AstNode*>(node));
+    }
+
+    virtual bool visit(class AstStatBlock* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatIf* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatWhile* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatRepeat* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatBreak* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatContinue* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatReturn* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatExpr* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatLocal* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatFor* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatForIn* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatAssign* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatCompoundAssign* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatFunction* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatLocalFunction* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatTypeAlias* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatDeclareFunction* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatDeclareGlobal* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatDeclareClass* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+    virtual bool visit(class AstStatError* node)
+    {
+        return visit(static_cast<AstStat*>(node));
+    }
+
+    // By default visiting type annotations is disabled; override this in your visitor if you need to!
+    virtual bool visit(class AstType* node)
+    {
+        return false;
+    }
+
+    virtual bool visit(class AstTypeReference* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeTable* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeFunction* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeTypeof* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeUnion* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeIntersection* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeSingletonBool* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeSingletonString* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+    virtual bool visit(class AstTypeError* node)
+    {
+        return visit(static_cast<AstType*>(node));
+    }
+
+    virtual bool visit(class AstTypePack* node)
+    {
+        return false;
+    }
+    virtual bool visit(class AstTypePackExplicit* node)
+    {
+        return visit(static_cast<AstTypePack*>(node));
+    }
+    virtual bool visit(class AstTypePackVariadic* node)
+    {
+        return visit(static_cast<AstTypePack*>(node));
+    }
+    virtual bool visit(class AstTypePackGeneric* node)
+    {
+        return visit(static_cast<AstTypePack*>(node));
+    }
+};
+
+AstName getIdentifier(AstExpr*);
+Location getLocation(const AstTypeList& typeList);
+
+template<typename T> // AstNode, AstExpr, AstLocal, etc
+Location getLocation(AstArray<T*> array)
+{
+    if (0 == array.size)
+        return {};
+
+    return Location{array.data[0]->location.begin, array.data[array.size - 1]->location.end};
+}
+
+#undef LUAU_RTTI
+
+} // namespace Luau
+
+namespace std
+{
+
+template<>
+struct hash<Luau::AstName>
+{
+    size_t operator()(const Luau::AstName& value) const
+    {
+        // note: since operator== uses pointer identity, hashing function uses it as well
+        // the hasher is the same as DenseHashPointer (DenseHash.h)
+        return (uintptr_t(value.value) >> 4) ^ (uintptr_t(value.value) >> 9);
+    }
+};
+
+} // namespace std

--- a/lib/luau/Ast/include/Luau/Confusables.h
+++ b/lib/luau/Ast/include/Luau/Confusables.h
@@ -1,0 +1,9 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include <stdint.h>
+
+namespace Luau
+{
+const char* findConfusable(uint32_t codepoint);
+}

--- a/lib/luau/Ast/include/Luau/Lexer.h
+++ b/lib/luau/Ast/include/Luau/Lexer.h
@@ -1,0 +1,268 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/Location.h"
+#include "Luau/DenseHash.h"
+#include "Luau/Common.h"
+
+#include <vector>
+
+namespace Luau
+{
+
+class Allocator
+{
+public:
+    Allocator();
+    Allocator(Allocator&&);
+
+    Allocator& operator=(Allocator&&) = delete;
+
+    ~Allocator();
+
+    void* allocate(size_t size);
+
+    template<typename T, typename... Args>
+    T* alloc(Args&&... args)
+    {
+        static_assert(std::is_trivially_destructible<T>::value, "Objects allocated with this allocator will never have their destructors run!");
+
+        T* t = static_cast<T*>(allocate(sizeof(T)));
+        new (t) T(std::forward<Args>(args)...);
+        return t;
+    }
+
+private:
+    struct Page
+    {
+        Page* next;
+
+        char data[8192];
+    };
+
+    Page* root;
+    size_t offset;
+};
+
+struct Lexeme
+{
+    enum Type
+    {
+        Eof = 0,
+
+        // 1..255 means actual character values
+        Char_END = 256,
+
+        Equal,
+        LessEqual,
+        GreaterEqual,
+        NotEqual,
+        Dot2,
+        Dot3,
+        SkinnyArrow,
+        DoubleColon,
+        FloorDiv,
+
+        InterpStringBegin,
+        InterpStringMid,
+        InterpStringEnd,
+        // An interpolated string with no expressions (like `x`)
+        InterpStringSimple,
+
+        AddAssign,
+        SubAssign,
+        MulAssign,
+        DivAssign,
+        FloorDivAssign,
+        ModAssign,
+        PowAssign,
+        ConcatAssign,
+
+        RawString,
+        QuotedString,
+        Number,
+        Name,
+
+        Comment,
+        BlockComment,
+
+        BrokenString,
+        BrokenComment,
+        BrokenUnicode,
+        BrokenInterpDoubleBrace,
+        Error,
+
+        Reserved_BEGIN,
+        ReservedAnd = Reserved_BEGIN,
+        ReservedBreak,
+        ReservedDo,
+        ReservedElse,
+        ReservedElseif,
+        ReservedEnd,
+        ReservedFalse,
+        ReservedFor,
+        ReservedFunction,
+        ReservedIf,
+        ReservedIn,
+        ReservedLocal,
+        ReservedNil,
+        ReservedNot,
+        ReservedOr,
+        ReservedRepeat,
+        ReservedReturn,
+        ReservedThen,
+        ReservedTrue,
+        ReservedUntil,
+        ReservedWhile,
+        ReservedChecked,
+        Reserved_END
+    };
+
+    Type type;
+    Location location;
+    unsigned int length;
+
+    union
+    {
+        const char* data;       // String, Number, Comment
+        const char* name;       // Name
+        unsigned int codepoint; // BrokenUnicode
+    };
+
+    Lexeme(const Location& location, Type type);
+    Lexeme(const Location& location, char character);
+    Lexeme(const Location& location, Type type, const char* data, size_t size);
+    Lexeme(const Location& location, Type type, const char* name);
+
+    std::string toString() const;
+};
+
+class AstNameTable
+{
+public:
+    AstNameTable(Allocator& allocator);
+
+    AstName addStatic(const char* name, Lexeme::Type type = Lexeme::Name);
+
+    std::pair<AstName, Lexeme::Type> getOrAddWithType(const char* name, size_t length);
+    std::pair<AstName, Lexeme::Type> getWithType(const char* name, size_t length) const;
+
+    AstName getOrAdd(const char* name);
+    AstName get(const char* name) const;
+
+private:
+    struct Entry
+    {
+        AstName value;
+        uint32_t length;
+        Lexeme::Type type;
+
+        bool operator==(const Entry& other) const;
+    };
+
+    struct EntryHash
+    {
+        size_t operator()(const Entry& e) const;
+    };
+
+    DenseHashSet<Entry, EntryHash> data;
+
+    Allocator& allocator;
+};
+
+class Lexer
+{
+public:
+    Lexer(const char* buffer, std::size_t bufferSize, AstNameTable& names);
+
+    void setSkipComments(bool skip);
+    void setReadNames(bool read);
+
+    const Location& previousLocation() const
+    {
+        return prevLocation;
+    }
+
+    const Lexeme& next();
+    const Lexeme& next(bool skipComments, bool updatePrevLocation);
+    void nextline();
+
+    Lexeme lookahead();
+
+    const Lexeme& current() const
+    {
+        return lexeme;
+    }
+
+    static bool isReserved(const std::string& word);
+
+    static bool fixupQuotedString(std::string& data);
+    static void fixupMultilineString(std::string& data);
+
+private:
+    char peekch() const;
+    char peekch(unsigned int lookahead) const;
+
+    Position position() const;
+
+    // consume() assumes current character is not a newline for performance; when that is not known, consumeAny() should be used instead.
+    void consume();
+    void consumeAny();
+
+    Lexeme readCommentBody();
+
+    // Given a sequence [===[ or ]===], returns:
+    // 1. number of equal signs (or 0 if none present) between the brackets
+    // 2. -1 if this is not a long comment/string separator
+    // 3. -N if this is a malformed separator
+    // Does *not* consume the closing brace.
+    int skipLongSeparator();
+
+    Lexeme readLongString(const Position& start, int sep, Lexeme::Type ok, Lexeme::Type broken);
+    Lexeme readQuotedString();
+
+    Lexeme readInterpolatedStringBegin();
+    Lexeme readInterpolatedStringSection(Position start, Lexeme::Type formatType, Lexeme::Type endType);
+
+    void readBackslashInString();
+
+    std::pair<AstName, Lexeme::Type> readName();
+
+    Lexeme readNumber(const Position& start, unsigned int startOffset);
+
+    Lexeme readUtf8Error();
+    Lexeme readNext();
+
+    const char* buffer;
+    std::size_t bufferSize;
+
+    unsigned int offset;
+
+    unsigned int line;
+    unsigned int lineOffset;
+
+    Lexeme lexeme;
+
+    Location prevLocation;
+
+    AstNameTable& names;
+
+    bool skipComments;
+    bool readNames;
+
+    enum class BraceType
+    {
+        InterpolatedString,
+        Normal
+    };
+
+    std::vector<BraceType> braceStack;
+};
+
+inline bool isSpace(char ch)
+{
+    return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '\v' || ch == '\f';
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/Location.h
+++ b/lib/luau/Ast/include/Luau/Location.h
@@ -1,0 +1,66 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+namespace Luau
+{
+
+struct Position
+{
+    unsigned int line, column;
+
+    Position(unsigned int line, unsigned int column)
+        : line(line)
+        , column(column)
+    {
+    }
+
+    bool operator==(const Position& rhs) const;
+    bool operator!=(const Position& rhs) const;
+    bool operator<(const Position& rhs) const;
+    bool operator>(const Position& rhs) const;
+    bool operator<=(const Position& rhs) const;
+    bool operator>=(const Position& rhs) const;
+
+    void shift(const Position& start, const Position& oldEnd, const Position& newEnd);
+};
+
+struct Location
+{
+    Position begin, end;
+
+    Location()
+        : begin(0, 0)
+        , end(0, 0)
+    {
+    }
+
+    Location(const Position& begin, const Position& end)
+        : begin(begin)
+        , end(end)
+    {
+    }
+
+    Location(const Position& begin, unsigned int length)
+        : begin(begin)
+        , end(begin.line, begin.column + length)
+    {
+    }
+
+    Location(const Location& begin, const Location& end)
+        : begin(begin.begin)
+        , end(end.end)
+    {
+    }
+
+    bool operator==(const Location& rhs) const;
+    bool operator!=(const Location& rhs) const;
+
+    bool encloses(const Location& l) const;
+    bool overlaps(const Location& l) const;
+    bool contains(const Position& p) const;
+    bool containsClosed(const Position& p) const;
+    void extend(const Location& other);
+    void shift(const Position& start, const Position& oldEnd, const Position& newEnd);
+};
+
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/ParseOptions.h
+++ b/lib/luau/Ast/include/Luau/ParseOptions.h
@@ -1,0 +1,21 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+namespace Luau
+{
+
+enum class Mode
+{
+    NoCheck,    // Do not perform any inference
+    Nonstrict,  // Unannotated symbols are any
+    Strict,     // Unannotated symbols are inferred
+    Definition, // Type definition module, has special parsing rules
+};
+
+struct ParseOptions
+{
+    bool allowDeclarationSyntax = false;
+    bool captureComments = false;
+};
+
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/ParseResult.h
+++ b/lib/luau/Ast/include/Luau/ParseResult.h
@@ -1,0 +1,71 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Common.h"
+#include "Luau/Location.h"
+#include "Luau/Lexer.h"
+#include "Luau/StringUtils.h"
+
+namespace Luau
+{
+
+class AstStatBlock;
+
+class ParseError : public std::exception
+{
+public:
+    ParseError(const Location& location, const std::string& message);
+
+    virtual const char* what() const throw();
+
+    const Location& getLocation() const;
+    const std::string& getMessage() const;
+
+    static LUAU_NORETURN void raise(const Location& location, const char* format, ...) LUAU_PRINTF_ATTR(2, 3);
+
+private:
+    Location location;
+    std::string message;
+};
+
+class ParseErrors : public std::exception
+{
+public:
+    ParseErrors(std::vector<ParseError> errors);
+
+    virtual const char* what() const throw();
+
+    const std::vector<ParseError>& getErrors() const;
+
+private:
+    std::vector<ParseError> errors;
+    std::string message;
+};
+
+struct HotComment
+{
+    bool header;
+    Location location;
+    std::string content;
+};
+
+struct Comment
+{
+    Lexeme::Type type; // Comment, BlockComment, or BrokenComment
+    Location location;
+};
+
+struct ParseResult
+{
+    AstStatBlock* root;
+    size_t lines = 0;
+
+    std::vector<HotComment> hotcomments;
+    std::vector<ParseError> errors;
+
+    std::vector<Comment> commentLocations;
+};
+
+static constexpr const char* kParseNameError = "%error-id%";
+
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/Parser.h
+++ b/lib/luau/Ast/include/Luau/Parser.h
@@ -1,0 +1,416 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/Lexer.h"
+#include "Luau/ParseOptions.h"
+#include "Luau/ParseResult.h"
+#include "Luau/StringUtils.h"
+#include "Luau/DenseHash.h"
+#include "Luau/Common.h"
+
+#include <initializer_list>
+#include <optional>
+#include <tuple>
+
+namespace Luau
+{
+
+template<typename T>
+class TempVector
+{
+public:
+    explicit TempVector(std::vector<T>& storage);
+
+    ~TempVector();
+
+    const T& operator[](std::size_t index) const;
+
+    const T& front() const;
+
+    const T& back() const;
+
+    bool empty() const;
+
+    std::size_t size() const;
+
+    void push_back(const T& item);
+
+    typename std::vector<T>::const_iterator begin() const
+    {
+        return storage.begin() + offset;
+    }
+    typename std::vector<T>::const_iterator end() const
+    {
+        return storage.begin() + offset + size_;
+    }
+
+private:
+    std::vector<T>& storage;
+    size_t offset;
+    size_t size_;
+};
+
+class Parser
+{
+public:
+    static ParseResult parse(
+        const char* buffer, std::size_t bufferSize, AstNameTable& names, Allocator& allocator, ParseOptions options = ParseOptions());
+
+private:
+    struct Name;
+    struct Binding;
+
+    Parser(const char* buffer, std::size_t bufferSize, AstNameTable& names, Allocator& allocator, const ParseOptions& options);
+
+    bool blockFollow(const Lexeme& l);
+
+    AstStatBlock* parseChunk();
+
+    // chunk ::= {stat [`;']} [laststat [`;']]
+    // block ::= chunk
+    AstStatBlock* parseBlock();
+
+    AstStatBlock* parseBlockNoScope();
+
+    // stat ::=
+    // varlist `=' explist |
+    // functioncall |
+    // do block end |
+    // while exp do block end |
+    // repeat block until exp |
+    // if exp then block {elseif exp then block} [else block] end |
+    // for Name `=' exp `,' exp [`,' exp] do block end |
+    // for namelist in explist do block end |
+    // function funcname funcbody |
+    // local function Name funcbody |
+    // local namelist [`=' explist]
+    // laststat ::= return [explist] | break
+    AstStat* parseStat();
+
+    // if exp then block {elseif exp then block} [else block] end
+    AstStat* parseIf();
+
+    // while exp do block end
+    AstStat* parseWhile();
+
+    // repeat block until exp
+    AstStat* parseRepeat();
+
+    // do block end
+    AstStat* parseDo();
+
+    // break
+    AstStat* parseBreak();
+
+    // continue
+    AstStat* parseContinue(const Location& start);
+
+    // for Name `=' exp `,' exp [`,' exp] do block end |
+    // for namelist in explist do block end |
+    AstStat* parseFor();
+
+    // funcname ::= Name {`.' Name} [`:' Name]
+    AstExpr* parseFunctionName(Location start, bool& hasself, AstName& debugname);
+
+    // function funcname funcbody
+    AstStat* parseFunctionStat();
+
+    // local function Name funcbody |
+    // local namelist [`=' explist]
+    AstStat* parseLocal();
+
+    // return [explist]
+    AstStat* parseReturn();
+
+    // type Name `=' Type
+    AstStat* parseTypeAlias(const Location& start, bool exported);
+
+    AstDeclaredClassProp parseDeclaredClassMethod();
+
+    // `declare global' Name: Type |
+    // `declare function' Name`(' [parlist] `)' [`:` Type]
+    AstStat* parseDeclaration(const Location& start);
+
+    // varlist `=' explist
+    AstStat* parseAssignment(AstExpr* initial);
+
+    // var [`+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='] exp
+    AstStat* parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op);
+
+    std::pair<AstLocal*, AstArray<AstLocal*>> prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args);
+
+    // funcbodyhead ::= `(' [namelist [`,' `...'] | `...'] `)' [`:` Type]
+    // funcbody ::= funcbodyhead block end
+    std::pair<AstExprFunction*, AstLocal*> parseFunctionBody(
+        bool hasself, const Lexeme& matchFunction, const AstName& debugname, const Name* localName);
+
+    // explist ::= {exp `,'} exp
+    void parseExprList(TempVector<AstExpr*>& result);
+
+    // binding ::= Name [`:` Type]
+    Binding parseBinding();
+
+    // bindinglist ::= (binding | `...') {`,' bindinglist}
+    // Returns the location of the vararg ..., or std::nullopt if the function is not vararg.
+    std::tuple<bool, Location, AstTypePack*> parseBindingList(TempVector<Binding>& result, bool allowDot3 = false);
+
+    AstType* parseOptionalType();
+
+    // TypeList ::= Type [`,' TypeList]
+    // ReturnType ::= Type | `(' TypeList `)'
+    // TableProp ::= Name `:' Type
+    // TableIndexer ::= `[' Type `]' `:' Type
+    // PropList ::= (TableProp | TableIndexer) [`,' PropList]
+    // Type
+    //      ::= Name
+    //      |   `nil`
+    //      |   `{' [PropList] `}'
+    //      |   `(' [TypeList] `)' `->` ReturnType
+
+    // Returns the variadic annotation, if it exists.
+    AstTypePack* parseTypeList(TempVector<AstType*>& result, TempVector<std::optional<AstArgumentName>>& resultNames);
+
+    std::optional<AstTypeList> parseOptionalReturnType();
+    std::pair<Location, AstTypeList> parseReturnType();
+
+    AstTableIndexer* parseTableIndexer();
+
+    AstTypeOrPack parseFunctionType(bool allowPack, bool isCheckedFunction = false);
+    AstType* parseFunctionTypeTail(const Lexeme& begin, AstArray<AstGenericType> generics, AstArray<AstGenericTypePack> genericPacks,
+        AstArray<AstType*> params, AstArray<std::optional<AstArgumentName>> paramNames, AstTypePack* varargAnnotation,
+        bool isCheckedFunction = false);
+
+    AstType* parseTableType(bool inDeclarationContext = false);
+    AstTypeOrPack parseSimpleType(bool allowPack, bool inDeclarationContext = false);
+
+    AstTypeOrPack parseTypeOrPack();
+    AstType* parseType(bool inDeclarationContext = false);
+
+    AstTypePack* parseTypePack();
+    AstTypePack* parseVariadicArgumentTypePack();
+
+    AstType* parseTypeSuffix(AstType* type, const Location& begin);
+
+    static std::optional<AstExprUnary::Op> parseUnaryOp(const Lexeme& l);
+    static std::optional<AstExprBinary::Op> parseBinaryOp(const Lexeme& l);
+    static std::optional<AstExprBinary::Op> parseCompoundOp(const Lexeme& l);
+
+    struct BinaryOpPriority
+    {
+        unsigned char left, right;
+    };
+
+    std::optional<AstExprUnary::Op> checkUnaryConfusables();
+    std::optional<AstExprBinary::Op> checkBinaryConfusables(const BinaryOpPriority binaryPriority[], unsigned int limit);
+
+    // subexpr -> (asexp | unop subexpr) { binop subexpr }
+    // where `binop' is any binary operator with a priority higher than `limit'
+    AstExpr* parseExpr(unsigned int limit = 0);
+
+    // NAME
+    AstExpr* parseNameExpr(const char* context = nullptr);
+
+    // prefixexp -> NAME | '(' expr ')'
+    AstExpr* parsePrefixExpr();
+
+    // primaryexp -> prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
+    AstExpr* parsePrimaryExpr(bool asStatement);
+
+    // asexp -> simpleexp [`::' Type]
+    AstExpr* parseAssertionExpr();
+
+    // simpleexp -> NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
+    AstExpr* parseSimpleExpr();
+
+    // args ::=  `(' [explist] `)' | tableconstructor | String
+    AstExpr* parseFunctionArgs(AstExpr* func, bool self);
+
+    // tableconstructor ::= `{' [fieldlist] `}'
+    // fieldlist ::= field {fieldsep field} [fieldsep]
+    // field ::= `[' exp `]' `=' exp | Name `=' exp | exp
+    // fieldsep ::= `,' | `;'
+    AstExpr* parseTableConstructor();
+
+    // TODO: Add grammar rules here?
+    AstExpr* parseIfElseExpr();
+
+    // stringinterp ::= <INTERP_BEGIN> exp {<INTERP_MID> exp} <INTERP_END>
+    AstExpr* parseInterpString();
+
+    // Name
+    std::optional<Name> parseNameOpt(const char* context = nullptr);
+    Name parseName(const char* context = nullptr);
+    Name parseIndexName(const char* context, const Position& previous);
+
+    // `<' namelist `>'
+    std::pair<AstArray<AstGenericType>, AstArray<AstGenericTypePack>> parseGenericTypeList(bool withDefaultValues);
+
+    // `<' Type[, ...] `>'
+    AstArray<AstTypeOrPack> parseTypeParams();
+
+    std::optional<AstArray<char>> parseCharArray();
+    AstExpr* parseString();
+    AstExpr* parseNumber();
+
+    AstLocal* pushLocal(const Binding& binding);
+
+    unsigned int saveLocals();
+
+    void restoreLocals(unsigned int offset);
+
+    // check that parser is at lexeme/symbol, move to next lexeme/symbol on success, report failure and continue on failure
+    bool expectAndConsume(char value, const char* context = nullptr);
+    bool expectAndConsume(Lexeme::Type type, const char* context = nullptr);
+    void expectAndConsumeFail(Lexeme::Type type, const char* context);
+
+    struct MatchLexeme
+    {
+        MatchLexeme(const Lexeme& l)
+            : type(l.type)
+            , position(l.location.begin)
+        {
+        }
+
+        Lexeme::Type type;
+        Position position;
+    };
+
+    bool expectMatchAndConsume(char value, const MatchLexeme& begin, bool searchForMissing = false);
+    void expectMatchAndConsumeFail(Lexeme::Type type, const MatchLexeme& begin, const char* extra = nullptr);
+    bool expectMatchAndConsumeRecover(char value, const MatchLexeme& begin, bool searchForMissing);
+
+    bool expectMatchEndAndConsume(Lexeme::Type type, const MatchLexeme& begin);
+    void expectMatchEndAndConsumeFail(Lexeme::Type type, const MatchLexeme& begin);
+
+    template<typename T>
+    AstArray<T> copy(const T* data, std::size_t size);
+
+    template<typename T>
+    AstArray<T> copy(const TempVector<T>& data);
+
+    template<typename T>
+    AstArray<T> copy(std::initializer_list<T> data);
+
+    AstArray<char> copy(const std::string& data);
+
+    void incrementRecursionCounter(const char* context);
+
+    void report(const Location& location, const char* format, va_list args);
+    void report(const Location& location, const char* format, ...) LUAU_PRINTF_ATTR(3, 4);
+
+    void reportNameError(const char* context);
+
+    AstStatError* reportStatError(const Location& location, const AstArray<AstExpr*>& expressions, const AstArray<AstStat*>& statements,
+        const char* format, ...) LUAU_PRINTF_ATTR(5, 6);
+    AstExprError* reportExprError(const Location& location, const AstArray<AstExpr*>& expressions, const char* format, ...) LUAU_PRINTF_ATTR(4, 5);
+    AstTypeError* reportTypeError(const Location& location, const AstArray<AstType*>& types, const char* format, ...) LUAU_PRINTF_ATTR(4, 5);
+    // `parseErrorLocation` is associated with the parser error
+    // `astErrorLocation` is associated with the AstTypeError created
+    // It can be useful to have different error locations so that the parse error can include the next lexeme, while the AstTypeError can precisely
+    // define the location (possibly of zero size) where a type annotation is expected.
+    AstTypeError* reportMissingTypeError(const Location& parseErrorLocation, const Location& astErrorLocation, const char* format, ...)
+        LUAU_PRINTF_ATTR(4, 5);
+
+    AstExpr* reportFunctionArgsError(AstExpr* func, bool self);
+    void reportAmbiguousCallError();
+
+    void nextLexeme();
+
+    struct Function
+    {
+        bool vararg;
+        unsigned int loopDepth;
+
+        Function()
+            : vararg(false)
+            , loopDepth(0)
+        {
+        }
+    };
+
+    struct Local
+    {
+        AstLocal* local;
+        unsigned int offset;
+
+        Local()
+            : local(nullptr)
+            , offset(0)
+        {
+        }
+    };
+
+    struct Name
+    {
+        AstName name;
+        Location location;
+
+        Name(const AstName& name, const Location& location)
+            : name(name)
+            , location(location)
+        {
+        }
+    };
+
+    struct Binding
+    {
+        Name name;
+        AstType* annotation;
+
+        explicit Binding(const Name& name, AstType* annotation = nullptr)
+            : name(name)
+            , annotation(annotation)
+        {
+        }
+    };
+
+    ParseOptions options;
+
+    Lexer lexer;
+    Allocator& allocator;
+
+    std::vector<Comment> commentLocations;
+    std::vector<HotComment> hotcomments;
+
+    bool hotcommentHeader = true;
+
+    unsigned int recursionCounter;
+
+    AstName nameSelf;
+    AstName nameNumber;
+    AstName nameError;
+    AstName nameNil;
+
+    MatchLexeme endMismatchSuspect;
+
+    std::vector<Function> functionStack;
+
+    DenseHashMap<AstName, AstLocal*> localMap;
+    std::vector<AstLocal*> localStack;
+
+    std::vector<ParseError> parseErrors;
+
+    std::vector<unsigned int> matchRecoveryStopOnToken;
+
+    std::vector<AstStat*> scratchStat;
+    std::vector<AstArray<char>> scratchString;
+    std::vector<AstExpr*> scratchExpr;
+    std::vector<AstExpr*> scratchExprAux;
+    std::vector<AstName> scratchName;
+    std::vector<AstName> scratchPackName;
+    std::vector<Binding> scratchBinding;
+    std::vector<AstLocal*> scratchLocal;
+    std::vector<AstTableProp> scratchTableTypeProps;
+    std::vector<AstType*> scratchType;
+    std::vector<AstTypeOrPack> scratchTypeOrPack;
+    std::vector<AstDeclaredClassProp> scratchDeclaredClassProps;
+    std::vector<AstExprTable::Item> scratchItem;
+    std::vector<AstArgumentName> scratchArgName;
+    std::vector<AstGenericType> scratchGenericTypes;
+    std::vector<AstGenericTypePack> scratchGenericTypePacks;
+    std::vector<std::optional<AstArgumentName>> scratchOptArgName;
+    std::string scratchData;
+};
+
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/StringUtils.h
+++ b/lib/luau/Ast/include/Luau/StringUtils.h
@@ -1,0 +1,36 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Common.h"
+
+#include <vector>
+#include <string>
+
+#include <stdarg.h>
+
+namespace Luau
+{
+
+std::string format(const char* fmt, ...) LUAU_PRINTF_ATTR(1, 2);
+std::string vformat(const char* fmt, va_list args);
+
+void formatAppend(std::string& str, const char* fmt, ...) LUAU_PRINTF_ATTR(2, 3);
+void vformatAppend(std::string& ret, const char* fmt, va_list args);
+
+std::string join(const std::vector<std::string_view>& segments, std::string_view delimiter);
+std::string join(const std::vector<std::string>& segments, std::string_view delimiter);
+
+std::vector<std::string_view> split(std::string_view s, char delimiter);
+
+// Computes the Damerau-Levenshtein distance of A and B.
+// https://en.wikipedia.org/wiki/Damerau-Levenshtein_distance#Distance_with_adjacent_transpositions
+size_t editDistance(std::string_view a, std::string_view b);
+
+bool startsWith(std::string_view lhs, std::string_view rhs);
+bool equalsLower(std::string_view lhs, std::string_view rhs);
+
+size_t hashRange(const char* data, size_t size);
+
+std::string escape(std::string_view s, bool escapeForInterpString = false);
+bool isIdentifier(std::string_view s);
+} // namespace Luau

--- a/lib/luau/Ast/include/Luau/TimeTrace.h
+++ b/lib/luau/Ast/include/Luau/TimeTrace.h
@@ -1,0 +1,231 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Common.h"
+
+#include <vector>
+#include <memory>
+
+#include <stdint.h>
+
+LUAU_FASTFLAG(DebugLuauTimeTracing)
+
+namespace Luau
+{
+namespace TimeTrace
+{
+double getClock();
+uint32_t getClockMicroseconds();
+} // namespace TimeTrace
+} // namespace Luau
+
+#if defined(LUAU_ENABLE_TIME_TRACE)
+
+namespace Luau
+{
+namespace TimeTrace
+{
+struct Token
+{
+    const char* name;
+    const char* category;
+};
+
+enum class EventType : uint8_t
+{
+    Enter,
+    Leave,
+
+    ArgName,
+    ArgValue,
+};
+
+struct Event
+{
+    EventType type;
+    uint16_t token;
+
+    union
+    {
+        uint32_t microsec; // 1 hour trace limit
+        uint32_t dataPos;
+    } data;
+};
+
+struct GlobalContext;
+struct ThreadContext;
+
+std::shared_ptr<GlobalContext> getGlobalContext();
+
+uint16_t createToken(GlobalContext& context, const char* name, const char* category);
+uint32_t createThread(GlobalContext& context, ThreadContext* threadContext);
+void releaseThread(GlobalContext& context, ThreadContext* threadContext);
+void flushEvents(GlobalContext& context, uint32_t threadId, const std::vector<Event>& events, const std::vector<char>& data);
+
+struct ThreadContext
+{
+    ThreadContext()
+        : globalContext(getGlobalContext())
+    {
+        threadId = createThread(*globalContext, this);
+    }
+
+    ~ThreadContext()
+    {
+        if (!events.empty())
+            flushEvents();
+
+        releaseThread(*globalContext, this);
+    }
+
+    void flushEvents()
+    {
+        static uint16_t flushToken = createToken(*globalContext, "flushEvents", "TimeTrace");
+
+        events.push_back({EventType::Enter, flushToken, {getClockMicroseconds()}});
+
+        TimeTrace::flushEvents(*globalContext, threadId, events, data);
+
+        events.clear();
+        data.clear();
+
+        events.push_back({EventType::Leave, 0, {getClockMicroseconds()}});
+    }
+
+    void eventEnter(uint16_t token)
+    {
+        eventEnter(token, getClockMicroseconds());
+    }
+
+    void eventEnter(uint16_t token, uint32_t microsec)
+    {
+        events.push_back({EventType::Enter, token, {microsec}});
+    }
+
+    void eventLeave()
+    {
+        eventLeave(getClockMicroseconds());
+    }
+
+    void eventLeave(uint32_t microsec)
+    {
+        events.push_back({EventType::Leave, 0, {microsec}});
+
+        if (events.size() > kEventFlushLimit)
+            flushEvents();
+    }
+
+    void eventArgument(const char* name, const char* value)
+    {
+        uint32_t pos = uint32_t(data.size());
+        data.insert(data.end(), name, name + strlen(name) + 1);
+        events.push_back({EventType::ArgName, 0, {pos}});
+
+        pos = uint32_t(data.size());
+        data.insert(data.end(), value, value + strlen(value) + 1);
+        events.push_back({EventType::ArgValue, 0, {pos}});
+    }
+
+    std::shared_ptr<GlobalContext> globalContext;
+    uint32_t threadId;
+    std::vector<Event> events;
+    std::vector<char> data;
+
+    static constexpr size_t kEventFlushLimit = 8192;
+};
+
+ThreadContext& getThreadContext();
+
+struct Scope
+{
+    explicit Scope(uint16_t token)
+        : context(getThreadContext())
+    {
+        if (!FFlag::DebugLuauTimeTracing)
+            return;
+
+        context.eventEnter(token);
+    }
+
+    ~Scope()
+    {
+        if (!FFlag::DebugLuauTimeTracing)
+            return;
+
+        context.eventLeave();
+    }
+
+    ThreadContext& context;
+};
+
+struct OptionalTailScope
+{
+    explicit OptionalTailScope(uint16_t token, uint32_t threshold)
+        : context(getThreadContext())
+        , token(token)
+        , threshold(threshold)
+    {
+        if (!FFlag::DebugLuauTimeTracing)
+            return;
+
+        pos = uint32_t(context.events.size());
+        microsec = getClockMicroseconds();
+    }
+
+    ~OptionalTailScope()
+    {
+        if (!FFlag::DebugLuauTimeTracing)
+            return;
+
+        if (pos == context.events.size())
+        {
+            uint32_t curr = getClockMicroseconds();
+
+            if (curr - microsec > threshold)
+            {
+                context.eventEnter(token, microsec);
+                context.eventLeave(curr);
+            }
+        }
+    }
+
+    ThreadContext& context;
+    uint16_t token;
+    uint32_t threshold;
+    uint32_t microsec;
+    uint32_t pos;
+};
+
+LUAU_NOINLINE uint16_t createScopeData(const char* name, const char* category);
+
+} // namespace TimeTrace
+} // namespace Luau
+
+// Regular scope
+#define LUAU_TIMETRACE_SCOPE(name, category) \
+    static uint16_t lttScopeStatic = Luau::TimeTrace::createScopeData(name, category); \
+    Luau::TimeTrace::Scope lttScope(lttScopeStatic)
+
+// A scope without nested scopes that may be skipped if the time it took is less than the threshold
+#define LUAU_TIMETRACE_OPTIONAL_TAIL_SCOPE(name, category, microsec) \
+    static uint16_t lttScopeStaticOptTail = Luau::TimeTrace::createScopeData(name, category); \
+    Luau::TimeTrace::OptionalTailScope lttScope(lttScopeStaticOptTail, microsec)
+
+// Extra key/value data can be added to regular scopes
+#define LUAU_TIMETRACE_ARGUMENT(name, value) \
+    do \
+    { \
+        if (FFlag::DebugLuauTimeTracing) \
+            lttScope.context.eventArgument(name, value); \
+    } while (false)
+
+#else
+
+#define LUAU_TIMETRACE_SCOPE(name, category)
+#define LUAU_TIMETRACE_OPTIONAL_TAIL_SCOPE(name, category, microsec)
+#define LUAU_TIMETRACE_ARGUMENT(name, value) \
+    do \
+    { \
+    } while (false)
+
+#endif

--- a/lib/luau/Ast/src/Ast.cpp
+++ b/lib/luau/Ast/src/Ast.cpp
@@ -1,0 +1,1006 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Ast.h"
+
+#include "Luau/Common.h"
+
+
+namespace Luau
+{
+
+static void visitTypeList(AstVisitor* visitor, const AstTypeList& list)
+{
+    for (AstType* ty : list.types)
+        ty->visit(visitor);
+
+    if (list.tailType)
+        list.tailType->visit(visitor);
+}
+
+int gAstRttiIndex = 0;
+
+AstExprGroup::AstExprGroup(const Location& location, AstExpr* expr)
+    : AstExpr(ClassIndex(), location)
+    , expr(expr)
+{
+}
+
+void AstExprGroup::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        expr->visit(visitor);
+}
+
+AstExprConstantNil::AstExprConstantNil(const Location& location)
+    : AstExpr(ClassIndex(), location)
+{
+}
+
+void AstExprConstantNil::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprConstantBool::AstExprConstantBool(const Location& location, bool value)
+    : AstExpr(ClassIndex(), location)
+    , value(value)
+{
+}
+
+void AstExprConstantBool::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprConstantNumber::AstExprConstantNumber(const Location& location, double value, ConstantNumberParseResult parseResult)
+    : AstExpr(ClassIndex(), location)
+    , value(value)
+    , parseResult(parseResult)
+{
+}
+
+void AstExprConstantNumber::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprConstantString::AstExprConstantString(const Location& location, const AstArray<char>& value, QuoteStyle quoteStyle)
+    : AstExpr(ClassIndex(), location)
+    , value(value)
+    , quoteStyle(quoteStyle)
+{
+}
+
+void AstExprConstantString::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprLocal::AstExprLocal(const Location& location, AstLocal* local, bool upvalue)
+    : AstExpr(ClassIndex(), location)
+    , local(local)
+    , upvalue(upvalue)
+{
+}
+
+void AstExprLocal::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprGlobal::AstExprGlobal(const Location& location, const AstName& name)
+    : AstExpr(ClassIndex(), location)
+    , name(name)
+{
+}
+
+void AstExprGlobal::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprVarargs::AstExprVarargs(const Location& location)
+    : AstExpr(ClassIndex(), location)
+{
+}
+
+void AstExprVarargs::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstExprCall::AstExprCall(const Location& location, AstExpr* func, const AstArray<AstExpr*>& args, bool self, const Location& argLocation)
+    : AstExpr(ClassIndex(), location)
+    , func(func)
+    , args(args)
+    , self(self)
+    , argLocation(argLocation)
+{
+}
+
+void AstExprCall::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        func->visit(visitor);
+
+        for (AstExpr* arg : args)
+            arg->visit(visitor);
+    }
+}
+
+AstExprIndexName::AstExprIndexName(
+    const Location& location, AstExpr* expr, const AstName& index, const Location& indexLocation, const Position& opPosition, char op)
+    : AstExpr(ClassIndex(), location)
+    , expr(expr)
+    , index(index)
+    , indexLocation(indexLocation)
+    , opPosition(opPosition)
+    , op(op)
+{
+}
+
+void AstExprIndexName::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        expr->visit(visitor);
+}
+
+AstExprIndexExpr::AstExprIndexExpr(const Location& location, AstExpr* expr, AstExpr* index)
+    : AstExpr(ClassIndex(), location)
+    , expr(expr)
+    , index(index)
+{
+}
+
+void AstExprIndexExpr::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        expr->visit(visitor);
+        index->visit(visitor);
+    }
+}
+
+AstExprFunction::AstExprFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+    AstLocal* self, const AstArray<AstLocal*>& args, bool vararg, const Location& varargLocation, AstStatBlock* body, size_t functionDepth,
+    const AstName& debugname, const std::optional<AstTypeList>& returnAnnotation, AstTypePack* varargAnnotation, bool DEPRECATED_hasEnd,
+    const std::optional<Location>& argLocation)
+    : AstExpr(ClassIndex(), location)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , self(self)
+    , args(args)
+    , returnAnnotation(returnAnnotation)
+    , vararg(vararg)
+    , varargLocation(varargLocation)
+    , varargAnnotation(varargAnnotation)
+    , body(body)
+    , functionDepth(functionDepth)
+    , debugname(debugname)
+    , DEPRECATED_hasEnd(DEPRECATED_hasEnd)
+    , argLocation(argLocation)
+{
+}
+
+void AstExprFunction::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstLocal* arg : args)
+        {
+            if (arg->annotation)
+                arg->annotation->visit(visitor);
+        }
+
+        if (varargAnnotation)
+            varargAnnotation->visit(visitor);
+
+        if (returnAnnotation)
+            visitTypeList(visitor, *returnAnnotation);
+
+        body->visit(visitor);
+    }
+}
+
+AstExprTable::AstExprTable(const Location& location, const AstArray<Item>& items)
+    : AstExpr(ClassIndex(), location)
+    , items(items)
+{
+}
+
+void AstExprTable::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (const Item& item : items)
+        {
+            if (item.key)
+                item.key->visit(visitor);
+
+            item.value->visit(visitor);
+        }
+    }
+}
+
+AstExprUnary::AstExprUnary(const Location& location, Op op, AstExpr* expr)
+    : AstExpr(ClassIndex(), location)
+    , op(op)
+    , expr(expr)
+{
+}
+
+void AstExprUnary::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        expr->visit(visitor);
+}
+
+std::string toString(AstExprUnary::Op op)
+{
+    switch (op)
+    {
+    case AstExprUnary::Minus:
+        return "-";
+    case AstExprUnary::Not:
+        return "not";
+    case AstExprUnary::Len:
+        return "#";
+    default:
+        LUAU_ASSERT(false);
+        return ""; // MSVC requires this even though the switch/case is exhaustive
+    }
+}
+
+AstExprBinary::AstExprBinary(const Location& location, Op op, AstExpr* left, AstExpr* right)
+    : AstExpr(ClassIndex(), location)
+    , op(op)
+    , left(left)
+    , right(right)
+{
+}
+
+void AstExprBinary::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        left->visit(visitor);
+        right->visit(visitor);
+    }
+}
+
+std::string toString(AstExprBinary::Op op)
+{
+    switch (op)
+    {
+    case AstExprBinary::Add:
+        return "+";
+    case AstExprBinary::Sub:
+        return "-";
+    case AstExprBinary::Mul:
+        return "*";
+    case AstExprBinary::Div:
+        return "/";
+    case AstExprBinary::FloorDiv:
+        return "//";
+    case AstExprBinary::Mod:
+        return "%";
+    case AstExprBinary::Pow:
+        return "^";
+    case AstExprBinary::Concat:
+        return "..";
+    case AstExprBinary::CompareNe:
+        return "~=";
+    case AstExprBinary::CompareEq:
+        return "==";
+    case AstExprBinary::CompareLt:
+        return "<";
+    case AstExprBinary::CompareLe:
+        return "<=";
+    case AstExprBinary::CompareGt:
+        return ">";
+    case AstExprBinary::CompareGe:
+        return ">=";
+    case AstExprBinary::And:
+        return "and";
+    case AstExprBinary::Or:
+        return "or";
+    default:
+        LUAU_ASSERT(false);
+        return ""; // MSVC requires this even though the switch/case is exhaustive
+    }
+}
+
+AstExprTypeAssertion::AstExprTypeAssertion(const Location& location, AstExpr* expr, AstType* annotation)
+    : AstExpr(ClassIndex(), location)
+    , expr(expr)
+    , annotation(annotation)
+{
+}
+
+void AstExprTypeAssertion::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        expr->visit(visitor);
+        annotation->visit(visitor);
+    }
+}
+
+AstExprIfElse::AstExprIfElse(const Location& location, AstExpr* condition, bool hasThen, AstExpr* trueExpr, bool hasElse, AstExpr* falseExpr)
+    : AstExpr(ClassIndex(), location)
+    , condition(condition)
+    , hasThen(hasThen)
+    , trueExpr(trueExpr)
+    , hasElse(hasElse)
+    , falseExpr(falseExpr)
+{
+}
+
+void AstExprIfElse::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        condition->visit(visitor);
+        trueExpr->visit(visitor);
+        falseExpr->visit(visitor);
+    }
+}
+
+AstExprError::AstExprError(const Location& location, const AstArray<AstExpr*>& expressions, unsigned messageIndex)
+    : AstExpr(ClassIndex(), location)
+    , expressions(expressions)
+    , messageIndex(messageIndex)
+{
+}
+
+AstExprInterpString::AstExprInterpString(const Location& location, const AstArray<AstArray<char>>& strings, const AstArray<AstExpr*>& expressions)
+    : AstExpr(ClassIndex(), location)
+    , strings(strings)
+    , expressions(expressions)
+{
+}
+
+void AstExprInterpString::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstExpr* expr : expressions)
+            expr->visit(visitor);
+    }
+}
+
+void AstExprError::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstExpr* expression : expressions)
+            expression->visit(visitor);
+    }
+}
+
+AstStatBlock::AstStatBlock(const Location& location, const AstArray<AstStat*>& body, bool hasEnd)
+    : AstStat(ClassIndex(), location)
+    , body(body)
+    , hasEnd(hasEnd)
+{
+}
+
+void AstStatBlock::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstStat* stat : body)
+            stat->visit(visitor);
+    }
+}
+
+AstStatIf::AstStatIf(const Location& location, AstExpr* condition, AstStatBlock* thenbody, AstStat* elsebody,
+    const std::optional<Location>& thenLocation, const std::optional<Location>& elseLocation, bool DEPRECATED_hasEnd)
+    : AstStat(ClassIndex(), location)
+    , condition(condition)
+    , thenbody(thenbody)
+    , elsebody(elsebody)
+    , thenLocation(thenLocation)
+    , elseLocation(elseLocation)
+    , DEPRECATED_hasEnd(DEPRECATED_hasEnd)
+{
+}
+
+void AstStatIf::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        condition->visit(visitor);
+        thenbody->visit(visitor);
+
+        if (elsebody)
+            elsebody->visit(visitor);
+    }
+}
+
+AstStatWhile::AstStatWhile(const Location& location, AstExpr* condition, AstStatBlock* body, bool hasDo, const Location& doLocation, bool DEPRECATED_hasEnd)
+    : AstStat(ClassIndex(), location)
+    , condition(condition)
+    , body(body)
+    , hasDo(hasDo)
+    , doLocation(doLocation)
+    , DEPRECATED_hasEnd(DEPRECATED_hasEnd)
+{
+}
+
+void AstStatWhile::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        condition->visit(visitor);
+        body->visit(visitor);
+    }
+}
+
+AstStatRepeat::AstStatRepeat(const Location& location, AstExpr* condition, AstStatBlock* body, bool DEPRECATED_hasUntil)
+    : AstStat(ClassIndex(), location)
+    , condition(condition)
+    , body(body)
+    , DEPRECATED_hasUntil(DEPRECATED_hasUntil)
+{
+}
+
+void AstStatRepeat::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        body->visit(visitor);
+        condition->visit(visitor);
+    }
+}
+
+AstStatBreak::AstStatBreak(const Location& location)
+    : AstStat(ClassIndex(), location)
+{
+}
+
+void AstStatBreak::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstStatContinue::AstStatContinue(const Location& location)
+    : AstStat(ClassIndex(), location)
+{
+}
+
+void AstStatContinue::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstStatReturn::AstStatReturn(const Location& location, const AstArray<AstExpr*>& list)
+    : AstStat(ClassIndex(), location)
+    , list(list)
+{
+}
+
+void AstStatReturn::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstExpr* expr : list)
+            expr->visit(visitor);
+    }
+}
+
+AstStatExpr::AstStatExpr(const Location& location, AstExpr* expr)
+    : AstStat(ClassIndex(), location)
+    , expr(expr)
+{
+}
+
+void AstStatExpr::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        expr->visit(visitor);
+}
+
+AstStatLocal::AstStatLocal(
+    const Location& location, const AstArray<AstLocal*>& vars, const AstArray<AstExpr*>& values, const std::optional<Location>& equalsSignLocation)
+    : AstStat(ClassIndex(), location)
+    , vars(vars)
+    , values(values)
+    , equalsSignLocation(equalsSignLocation)
+{
+}
+
+void AstStatLocal::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstLocal* var : vars)
+        {
+            if (var->annotation)
+                var->annotation->visit(visitor);
+        }
+
+        for (AstExpr* expr : values)
+            expr->visit(visitor);
+    }
+}
+
+AstStatFor::AstStatFor(const Location& location, AstLocal* var, AstExpr* from, AstExpr* to, AstExpr* step, AstStatBlock* body, bool hasDo,
+    const Location& doLocation, bool DEPRECATED_hasEnd)
+    : AstStat(ClassIndex(), location)
+    , var(var)
+    , from(from)
+    , to(to)
+    , step(step)
+    , body(body)
+    , hasDo(hasDo)
+    , doLocation(doLocation)
+    , DEPRECATED_hasEnd(DEPRECATED_hasEnd)
+{
+}
+
+void AstStatFor::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        if (var->annotation)
+            var->annotation->visit(visitor);
+
+        from->visit(visitor);
+        to->visit(visitor);
+
+        if (step)
+            step->visit(visitor);
+
+        body->visit(visitor);
+    }
+}
+
+AstStatForIn::AstStatForIn(const Location& location, const AstArray<AstLocal*>& vars, const AstArray<AstExpr*>& values, AstStatBlock* body,
+    bool hasIn, const Location& inLocation, bool hasDo, const Location& doLocation, bool DEPRECATED_hasEnd)
+    : AstStat(ClassIndex(), location)
+    , vars(vars)
+    , values(values)
+    , body(body)
+    , hasIn(hasIn)
+    , inLocation(inLocation)
+    , hasDo(hasDo)
+    , doLocation(doLocation)
+    , DEPRECATED_hasEnd(DEPRECATED_hasEnd)
+{
+}
+
+void AstStatForIn::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstLocal* var : vars)
+        {
+            if (var->annotation)
+                var->annotation->visit(visitor);
+        }
+
+        for (AstExpr* expr : values)
+            expr->visit(visitor);
+
+        body->visit(visitor);
+    }
+}
+
+AstStatAssign::AstStatAssign(const Location& location, const AstArray<AstExpr*>& vars, const AstArray<AstExpr*>& values)
+    : AstStat(ClassIndex(), location)
+    , vars(vars)
+    , values(values)
+{
+}
+
+void AstStatAssign::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstExpr* lvalue : vars)
+            lvalue->visit(visitor);
+
+        for (AstExpr* expr : values)
+            expr->visit(visitor);
+    }
+}
+
+AstStatCompoundAssign::AstStatCompoundAssign(const Location& location, AstExprBinary::Op op, AstExpr* var, AstExpr* value)
+    : AstStat(ClassIndex(), location)
+    , op(op)
+    , var(var)
+    , value(value)
+{
+}
+
+void AstStatCompoundAssign::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        var->visit(visitor);
+        value->visit(visitor);
+    }
+}
+
+AstStatFunction::AstStatFunction(const Location& location, AstExpr* name, AstExprFunction* func)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , func(func)
+{
+}
+
+void AstStatFunction::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        name->visit(visitor);
+        func->visit(visitor);
+    }
+}
+
+AstStatLocalFunction::AstStatLocalFunction(const Location& location, AstLocal* name, AstExprFunction* func)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , func(func)
+{
+}
+
+void AstStatLocalFunction::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        func->visit(visitor);
+}
+
+AstStatTypeAlias::AstStatTypeAlias(const Location& location, const AstName& name, const Location& nameLocation,
+    const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks, AstType* type, bool exported)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , nameLocation(nameLocation)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , type(type)
+    , exported(exported)
+{
+}
+
+void AstStatTypeAlias::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (const AstGenericType& el : generics)
+        {
+            if (el.defaultValue)
+                el.defaultValue->visit(visitor);
+        }
+
+        for (const AstGenericTypePack& el : genericPacks)
+        {
+            if (el.defaultValue)
+                el.defaultValue->visit(visitor);
+        }
+
+        type->visit(visitor);
+    }
+}
+
+AstStatDeclareGlobal::AstStatDeclareGlobal(const Location& location, const AstName& name, AstType* type)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , type(type)
+{
+}
+
+void AstStatDeclareGlobal::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        type->visit(visitor);
+}
+
+AstStatDeclareFunction::AstStatDeclareFunction(const Location& location, const AstName& name, const AstArray<AstGenericType>& generics,
+    const AstArray<AstGenericTypePack>& genericPacks, const AstTypeList& params, const AstArray<AstArgumentName>& paramNames,
+    const AstTypeList& retTypes)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , params(params)
+    , paramNames(paramNames)
+    , retTypes(retTypes)
+    , checkedFunction(false)
+{
+}
+
+AstStatDeclareFunction::AstStatDeclareFunction(const Location& location, const AstName& name, const AstArray<AstGenericType>& generics,
+    const AstArray<AstGenericTypePack>& genericPacks, const AstTypeList& params, const AstArray<AstArgumentName>& paramNames,
+    const AstTypeList& retTypes, bool checkedFunction)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , params(params)
+    , paramNames(paramNames)
+    , retTypes(retTypes)
+    , checkedFunction(checkedFunction)
+{
+}
+
+void AstStatDeclareFunction::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        visitTypeList(visitor, params);
+        visitTypeList(visitor, retTypes);
+    }
+}
+
+AstStatDeclareClass::AstStatDeclareClass(const Location& location, const AstName& name, std::optional<AstName> superName,
+    const AstArray<AstDeclaredClassProp>& props, AstTableIndexer* indexer)
+    : AstStat(ClassIndex(), location)
+    , name(name)
+    , superName(superName)
+    , props(props)
+    , indexer(indexer)
+{
+}
+
+void AstStatDeclareClass::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (const AstDeclaredClassProp& prop : props)
+            prop.ty->visit(visitor);
+    }
+}
+
+AstStatError::AstStatError(
+    const Location& location, const AstArray<AstExpr*>& expressions, const AstArray<AstStat*>& statements, unsigned messageIndex)
+    : AstStat(ClassIndex(), location)
+    , expressions(expressions)
+    , statements(statements)
+    , messageIndex(messageIndex)
+{
+}
+
+void AstStatError::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstNode* expression : expressions)
+            expression->visit(visitor);
+
+        for (AstNode* statement : statements)
+            statement->visit(visitor);
+    }
+}
+
+AstTypeReference::AstTypeReference(const Location& location, std::optional<AstName> prefix, AstName name, std::optional<Location> prefixLocation,
+    const Location& nameLocation, bool hasParameterList, const AstArray<AstTypeOrPack>& parameters)
+    : AstType(ClassIndex(), location)
+    , hasParameterList(hasParameterList)
+    , prefix(prefix)
+    , prefixLocation(prefixLocation)
+    , name(name)
+    , nameLocation(nameLocation)
+    , parameters(parameters)
+{
+}
+
+void AstTypeReference::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (const AstTypeOrPack& param : parameters)
+        {
+            if (param.type)
+                param.type->visit(visitor);
+            else
+                param.typePack->visit(visitor);
+        }
+    }
+}
+
+AstTypeTable::AstTypeTable(const Location& location, const AstArray<AstTableProp>& props, AstTableIndexer* indexer)
+    : AstType(ClassIndex(), location)
+    , props(props)
+    , indexer(indexer)
+{
+}
+
+void AstTypeTable::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (const AstTableProp& prop : props)
+            prop.type->visit(visitor);
+
+        if (indexer)
+        {
+            indexer->indexType->visit(visitor);
+            indexer->resultType->visit(visitor);
+        }
+    }
+}
+
+AstTypeFunction::AstTypeFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+    const AstTypeList& argTypes, const AstArray<std::optional<AstArgumentName>>& argNames, const AstTypeList& returnTypes)
+    : AstType(ClassIndex(), location)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , argTypes(argTypes)
+    , argNames(argNames)
+    , returnTypes(returnTypes)
+    , checkedFunction(false)
+{
+    LUAU_ASSERT(argNames.size == 0 || argNames.size == argTypes.types.size);
+}
+
+AstTypeFunction::AstTypeFunction(const Location& location, const AstArray<AstGenericType>& generics, const AstArray<AstGenericTypePack>& genericPacks,
+    const AstTypeList& argTypes, const AstArray<std::optional<AstArgumentName>>& argNames, const AstTypeList& returnTypes, bool checkedFunction)
+    : AstType(ClassIndex(), location)
+    , generics(generics)
+    , genericPacks(genericPacks)
+    , argTypes(argTypes)
+    , argNames(argNames)
+    , returnTypes(returnTypes)
+    , checkedFunction(checkedFunction)
+{
+    LUAU_ASSERT(argNames.size == 0 || argNames.size == argTypes.types.size);
+}
+
+void AstTypeFunction::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        visitTypeList(visitor, argTypes);
+        visitTypeList(visitor, returnTypes);
+    }
+}
+
+AstTypeTypeof::AstTypeTypeof(const Location& location, AstExpr* expr)
+    : AstType(ClassIndex(), location)
+    , expr(expr)
+{
+}
+
+void AstTypeTypeof::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        expr->visit(visitor);
+}
+
+AstTypeUnion::AstTypeUnion(const Location& location, const AstArray<AstType*>& types)
+    : AstType(ClassIndex(), location)
+    , types(types)
+{
+}
+
+void AstTypeUnion::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstType* type : types)
+            type->visit(visitor);
+    }
+}
+
+AstTypeIntersection::AstTypeIntersection(const Location& location, const AstArray<AstType*>& types)
+    : AstType(ClassIndex(), location)
+    , types(types)
+{
+}
+
+void AstTypeIntersection::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstType* type : types)
+            type->visit(visitor);
+    }
+}
+
+AstTypeSingletonBool::AstTypeSingletonBool(const Location& location, bool value)
+    : AstType(ClassIndex(), location)
+    , value(value)
+{
+}
+
+void AstTypeSingletonBool::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstTypeSingletonString::AstTypeSingletonString(const Location& location, const AstArray<char>& value)
+    : AstType(ClassIndex(), location)
+    , value(value)
+{
+}
+
+void AstTypeSingletonString::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstTypeError::AstTypeError(const Location& location, const AstArray<AstType*>& types, bool isMissing, unsigned messageIndex)
+    : AstType(ClassIndex(), location)
+    , types(types)
+    , isMissing(isMissing)
+    , messageIndex(messageIndex)
+{
+}
+
+void AstTypeError::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstType* type : types)
+            type->visit(visitor);
+    }
+}
+
+AstTypePackExplicit::AstTypePackExplicit(const Location& location, AstTypeList typeList)
+    : AstTypePack(ClassIndex(), location)
+    , typeList(typeList)
+{
+}
+
+void AstTypePackExplicit::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+    {
+        for (AstType* type : typeList.types)
+            type->visit(visitor);
+
+        if (typeList.tailType)
+            typeList.tailType->visit(visitor);
+    }
+}
+
+AstTypePackVariadic::AstTypePackVariadic(const Location& location, AstType* variadicType)
+    : AstTypePack(ClassIndex(), location)
+    , variadicType(variadicType)
+{
+}
+
+void AstTypePackVariadic::visit(AstVisitor* visitor)
+{
+    if (visitor->visit(this))
+        variadicType->visit(visitor);
+}
+
+AstTypePackGeneric::AstTypePackGeneric(const Location& location, AstName name)
+    : AstTypePack(ClassIndex(), location)
+    , genericName(name)
+{
+}
+
+void AstTypePackGeneric::visit(AstVisitor* visitor)
+{
+    visitor->visit(this);
+}
+
+AstName getIdentifier(AstExpr* node)
+{
+    if (AstExprGlobal* expr = node->as<AstExprGlobal>())
+        return expr->name;
+
+    if (AstExprLocal* expr = node->as<AstExprLocal>())
+        return expr->local->name;
+
+    return AstName();
+}
+
+Location getLocation(const AstTypeList& typeList)
+{
+    Location result;
+    if (typeList.types.size)
+    {
+        result = Location{typeList.types.data[0]->location, typeList.types.data[typeList.types.size - 1]->location};
+    }
+    if (typeList.tailType)
+        result.end = typeList.tailType->location.end;
+
+    return result;
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/src/Confusables.cpp
+++ b/lib/luau/Ast/src/Confusables.cpp
@@ -1,0 +1,1818 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Confusables.h"
+
+#include <algorithm>
+#include <array>
+
+namespace Luau
+{
+
+struct Confusable
+{
+    unsigned codepoint : 24;
+    char text[5];
+};
+
+// Derived from http://www.unicode.org/Public/security/10.0.0/confusables.txt; sorted by codepoint
+// clang-format off
+static const Confusable kConfusables[] =
+{
+    {34, "\""},      // MA#* ( " → '' ) QUOTATION MARK → APOSTROPHE, APOSTROPHE# # Converted to a quote.
+    {48, "O"},       // MA# ( 0 → O ) DIGIT ZERO → LATIN CAPITAL LETTER O#
+    {49, "l"},       // MA# ( 1 → l ) DIGIT ONE → LATIN SMALL LETTER L#
+    {73, "l"},       // MA# ( I → l ) LATIN CAPITAL LETTER I → LATIN SMALL LETTER L#
+    {96, "'"},       // MA#* ( ` → ' ) GRAVE ACCENT → APOSTROPHE# →ˋ→→｀→→‘→
+    {109, "rn"},     // MA# ( m → rn ) LATIN SMALL LETTER M → LATIN SMALL LETTER R, LATIN SMALL LETTER N#
+    {124, "l"},      // MA#* ( | → l ) VERTICAL LINE → LATIN SMALL LETTER L#
+    {160, " "},      // MA#* (   →   ) NO-BREAK SPACE → SPACE#
+    {180, "'"},      // MA#* ( ´ → ' ) ACUTE ACCENT → APOSTROPHE# →΄→→ʹ→
+    {184, ","},      // MA#* ( ¸ → , ) CEDILLA → COMMA#
+    {198, "AE"},     // MA# ( Æ → AE ) LATIN CAPITAL LETTER AE → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER E#
+    {215, "x"},      // MA#* ( × → x ) MULTIPLICATION SIGN → LATIN SMALL LETTER X#
+    {230, "ae"},     // MA# ( æ → ae ) LATIN SMALL LETTER AE → LATIN SMALL LETTER A, LATIN SMALL LETTER E#
+    {305, "i"},      // MA# ( ı → i ) LATIN SMALL LETTER DOTLESS I → LATIN SMALL LETTER I#
+    {306, "lJ"},     // MA# ( Ĳ → lJ ) LATIN CAPITAL LIGATURE IJ → LATIN SMALL LETTER L, LATIN CAPITAL LETTER J# →IJ→
+    {307, "ij"},     // MA# ( ĳ → ij ) LATIN SMALL LIGATURE IJ → LATIN SMALL LETTER I, LATIN SMALL LETTER J#
+    {329, "'n"},     // MA# ( ŉ → 'n ) LATIN SMALL LETTER N PRECEDED BY APOSTROPHE → APOSTROPHE, LATIN SMALL LETTER N# →ʼn→
+    {338, "OE"},     // MA# ( Œ → OE ) LATIN CAPITAL LIGATURE OE → LATIN CAPITAL LETTER O, LATIN CAPITAL LETTER E#
+    {339, "oe"},     // MA# ( œ → oe ) LATIN SMALL LIGATURE OE → LATIN SMALL LETTER O, LATIN SMALL LETTER E#
+    {383, "f"},      // MA# ( ſ → f ) LATIN SMALL LETTER LONG S → LATIN SMALL LETTER F#
+    {385, "'B"},     // MA# ( Ɓ → 'B ) LATIN CAPITAL LETTER B WITH HOOK → APOSTROPHE, LATIN CAPITAL LETTER B# →ʽB→
+    {388, "b"},      // MA# ( Ƅ → b ) LATIN CAPITAL LETTER TONE SIX → LATIN SMALL LETTER B#
+    {391, "C'"},     // MA# ( Ƈ → C' ) LATIN CAPITAL LETTER C WITH HOOK → LATIN CAPITAL LETTER C, APOSTROPHE# →Cʽ→
+    {394, "'D"},     // MA# ( Ɗ → 'D ) LATIN CAPITAL LETTER D WITH HOOK → APOSTROPHE, LATIN CAPITAL LETTER D# →ʽD→
+    {397, "g"},      // MA# ( ƍ → g ) LATIN SMALL LETTER TURNED DELTA → LATIN SMALL LETTER G#
+    {403, "G'"},     // MA# ( Ɠ → G' ) LATIN CAPITAL LETTER G WITH HOOK → LATIN CAPITAL LETTER G, APOSTROPHE# →Gʽ→
+    {406, "l"},      // MA# ( Ɩ → l ) LATIN CAPITAL LETTER IOTA → LATIN SMALL LETTER L#
+    {408, "K'"},     // MA# ( Ƙ → K' ) LATIN CAPITAL LETTER K WITH HOOK → LATIN CAPITAL LETTER K, APOSTROPHE# →Kʽ→
+    {416, "O'"},     // MA# ( Ơ → O' ) LATIN CAPITAL LETTER O WITH HORN → LATIN CAPITAL LETTER O, APOSTROPHE# →Oʼ→
+    {417, "o'"},     // MA# ( ơ → o' ) LATIN SMALL LETTER O WITH HORN → LATIN SMALL LETTER O, APOSTROPHE# →oʼ→
+    {420, "'P"},     // MA# ( Ƥ → 'P ) LATIN CAPITAL LETTER P WITH HOOK → APOSTROPHE, LATIN CAPITAL LETTER P# →ʽP→
+    {422, "R"},      // MA# ( Ʀ → R ) LATIN LETTER YR → LATIN CAPITAL LETTER R#
+    {423, "2"},      // MA# ( Ƨ → 2 ) LATIN CAPITAL LETTER TONE TWO → DIGIT TWO#
+    {428, "'T"},     // MA# ( Ƭ → 'T ) LATIN CAPITAL LETTER T WITH HOOK → APOSTROPHE, LATIN CAPITAL LETTER T# →ʽT→
+    {435, "'Y"},     // MA# ( Ƴ → 'Y ) LATIN CAPITAL LETTER Y WITH HOOK → APOSTROPHE, LATIN CAPITAL LETTER Y# →ʽY→
+    {439, "3"},      // MA# ( Ʒ → 3 ) LATIN CAPITAL LETTER EZH → DIGIT THREE#
+    {444, "5"},      // MA# ( Ƽ → 5 ) LATIN CAPITAL LETTER TONE FIVE → DIGIT FIVE#
+    {445, "s"},      // MA# ( ƽ → s ) LATIN SMALL LETTER TONE FIVE → LATIN SMALL LETTER S#
+    {448, "l"},      // MA# ( ǀ → l ) LATIN LETTER DENTAL CLICK → LATIN SMALL LETTER L#
+    {449, "ll"},     // MA# ( ǁ → ll ) LATIN LETTER LATERAL CLICK → LATIN SMALL LETTER L, LATIN SMALL LETTER L# →‖→→∥→→||→
+    {451, "!"},      // MA# ( ǃ → ! ) LATIN LETTER RETROFLEX CLICK → EXCLAMATION MARK#
+    {455, "LJ"},     // MA# ( Ǉ → LJ ) LATIN CAPITAL LETTER LJ → LATIN CAPITAL LETTER L, LATIN CAPITAL LETTER J#
+    {456, "Lj"},     // MA# ( ǈ → Lj ) LATIN CAPITAL LETTER L WITH SMALL LETTER J → LATIN CAPITAL LETTER L, LATIN SMALL LETTER J#
+    {457, "lj"},     // MA# ( ǉ → lj ) LATIN SMALL LETTER LJ → LATIN SMALL LETTER L, LATIN SMALL LETTER J#
+    {458, "NJ"},     // MA# ( Ǌ → NJ ) LATIN CAPITAL LETTER NJ → LATIN CAPITAL LETTER N, LATIN CAPITAL LETTER J#
+    {459, "Nj"},     // MA# ( ǋ → Nj ) LATIN CAPITAL LETTER N WITH SMALL LETTER J → LATIN CAPITAL LETTER N, LATIN SMALL LETTER J#
+    {460, "nj"},     // MA# ( ǌ → nj ) LATIN SMALL LETTER NJ → LATIN SMALL LETTER N, LATIN SMALL LETTER J#
+    {497, "DZ"},     // MA# ( Ǳ → DZ ) LATIN CAPITAL LETTER DZ → LATIN CAPITAL LETTER D, LATIN CAPITAL LETTER Z#
+    {498, "Dz"},     // MA# ( ǲ → Dz ) LATIN CAPITAL LETTER D WITH SMALL LETTER Z → LATIN CAPITAL LETTER D, LATIN SMALL LETTER Z#
+    {499, "dz"},     // MA# ( ǳ → dz ) LATIN SMALL LETTER DZ → LATIN SMALL LETTER D, LATIN SMALL LETTER Z#
+    {540, "3"},      // MA# ( Ȝ → 3 ) LATIN CAPITAL LETTER YOGH → DIGIT THREE# →Ʒ→
+    {546, "8"},      // MA# ( Ȣ → 8 ) LATIN CAPITAL LETTER OU → DIGIT EIGHT#
+    {547, "8"},      // MA# ( ȣ → 8 ) LATIN SMALL LETTER OU → DIGIT EIGHT#
+    {577, "?"},      // MA# ( Ɂ → ? ) LATIN CAPITAL LETTER GLOTTAL STOP → QUESTION MARK# →ʔ→
+    {593, "a"},      // MA# ( ɑ → a ) LATIN SMALL LETTER ALPHA → LATIN SMALL LETTER A#
+    {609, "g"},      // MA# ( ɡ → g ) LATIN SMALL LETTER SCRIPT G → LATIN SMALL LETTER G#
+    {611, "y"},      // MA# ( ɣ → y ) LATIN SMALL LETTER GAMMA → LATIN SMALL LETTER Y# →γ→
+    {617, "i"},      // MA# ( ɩ → i ) LATIN SMALL LETTER IOTA → LATIN SMALL LETTER I#
+    {618, "i"},      // MA# ( ɪ → i ) LATIN LETTER SMALL CAPITAL I → LATIN SMALL LETTER I# →ı→
+    {623, "w"},      // MA# ( ɯ → w ) LATIN SMALL LETTER TURNED M → LATIN SMALL LETTER W#
+    {651, "u"},      // MA# ( ʋ → u ) LATIN SMALL LETTER V WITH HOOK → LATIN SMALL LETTER U#
+    {655, "y"},      // MA# ( ʏ → y ) LATIN LETTER SMALL CAPITAL Y → LATIN SMALL LETTER Y# →ү→→γ→
+    {660, "?"},      // MA# ( ʔ → ? ) LATIN LETTER GLOTTAL STOP → QUESTION MARK#
+    {675, "dz"},     // MA# ( ʣ → dz ) LATIN SMALL LETTER DZ DIGRAPH → LATIN SMALL LETTER D, LATIN SMALL LETTER Z#
+    {678, "ts"},     // MA# ( ʦ → ts ) LATIN SMALL LETTER TS DIGRAPH → LATIN SMALL LETTER T, LATIN SMALL LETTER S#
+    {682, "ls"},     // MA# ( ʪ → ls ) LATIN SMALL LETTER LS DIGRAPH → LATIN SMALL LETTER L, LATIN SMALL LETTER S#
+    {683, "lz"},     // MA# ( ʫ → lz ) LATIN SMALL LETTER LZ DIGRAPH → LATIN SMALL LETTER L, LATIN SMALL LETTER Z#
+    {697, "'"},      // MA# ( ʹ → ' ) MODIFIER LETTER PRIME → APOSTROPHE#
+    {698, "\""},     // MA# ( ʺ → '' ) MODIFIER LETTER DOUBLE PRIME → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {699, "'"},      // MA# ( ʻ → ' ) MODIFIER LETTER TURNED COMMA → APOSTROPHE# →‘→
+    {700, "'"},      // MA# ( ʼ → ' ) MODIFIER LETTER APOSTROPHE → APOSTROPHE# →′→
+    {701, "'"},      // MA# ( ʽ → ' ) MODIFIER LETTER REVERSED COMMA → APOSTROPHE# →‘→
+    {702, "'"},      // MA# ( ʾ → ' ) MODIFIER LETTER RIGHT HALF RING → APOSTROPHE# →ʼ→→′→
+    {706, "<"},      // MA#* ( ˂ → < ) MODIFIER LETTER LEFT ARROWHEAD → LESS-THAN SIGN#
+    {707, ">"},      // MA#* ( ˃ → > ) MODIFIER LETTER RIGHT ARROWHEAD → GREATER-THAN SIGN#
+    {708, "^"},      // MA#* ( ˄ → ^ ) MODIFIER LETTER UP ARROWHEAD → CIRCUMFLEX ACCENT#
+    {710, "^"},      // MA# ( ˆ → ^ ) MODIFIER LETTER CIRCUMFLEX ACCENT → CIRCUMFLEX ACCENT#
+    {712, "'"},      // MA# ( ˈ → ' ) MODIFIER LETTER VERTICAL LINE → APOSTROPHE#
+    {714, "'"},      // MA# ( ˊ → ' ) MODIFIER LETTER ACUTE ACCENT → APOSTROPHE# →ʹ→→′→
+    {715, "'"},      // MA# ( ˋ → ' ) MODIFIER LETTER GRAVE ACCENT → APOSTROPHE# →｀→→‘→
+    {720, ":"},      // MA# ( ː → : ) MODIFIER LETTER TRIANGULAR COLON → COLON#
+    {727, "-"},      // MA#* ( ˗ → - ) MODIFIER LETTER MINUS SIGN → HYPHEN-MINUS#
+    {731, "i"},      // MA#* ( ˛ → i ) OGONEK → LATIN SMALL LETTER I# →ͺ→→ι→→ι→
+    {732, "~"},      // MA#* ( ˜ → ~ ) SMALL TILDE → TILDE#
+    {733, "\""},     // MA#* ( ˝ → '' ) DOUBLE ACUTE ACCENT → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {750, "\""},     // MA# ( ˮ → '' ) MODIFIER LETTER DOUBLE APOSTROPHE → APOSTROPHE, APOSTROPHE# →″→→"→# Converted to a quote.
+    {756, "'"},      // MA#* ( ˴ → ' ) MODIFIER LETTER MIDDLE GRAVE ACCENT → APOSTROPHE# →ˋ→→｀→→‘→
+    {758, "\""},     // MA#* ( ˶ → '' ) MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT → APOSTROPHE, APOSTROPHE# →˝→→"→# Converted to a quote.
+    {760, ":"},      // MA#* ( ˸ → : ) MODIFIER LETTER RAISED COLON → COLON#
+    {884, "'"},      // MA# ( ʹ → ' ) GREEK NUMERAL SIGN → APOSTROPHE# →′→
+    {890, "i"},      // MA#* ( ͺ → i ) GREEK YPOGEGRAMMENI → LATIN SMALL LETTER I# →ι→→ι→
+    {894, ";"},      // MA#* ( ; → ; ) GREEK QUESTION MARK → SEMICOLON#
+    {895, "J"},      // MA# ( Ϳ → J ) GREEK CAPITAL LETTER YOT → LATIN CAPITAL LETTER J#
+    {900, "'"},      // MA#* ( ΄ → ' ) GREEK TONOS → APOSTROPHE# →ʹ→
+    {913, "A"},      // MA# ( Α → A ) GREEK CAPITAL LETTER ALPHA → LATIN CAPITAL LETTER A#
+    {914, "B"},      // MA# ( Β → B ) GREEK CAPITAL LETTER BETA → LATIN CAPITAL LETTER B#
+    {917, "E"},      // MA# ( Ε → E ) GREEK CAPITAL LETTER EPSILON → LATIN CAPITAL LETTER E#
+    {918, "Z"},      // MA# ( Ζ → Z ) GREEK CAPITAL LETTER ZETA → LATIN CAPITAL LETTER Z#
+    {919, "H"},      // MA# ( Η → H ) GREEK CAPITAL LETTER ETA → LATIN CAPITAL LETTER H#
+    {921, "l"},      // MA# ( Ι → l ) GREEK CAPITAL LETTER IOTA → LATIN SMALL LETTER L#
+    {922, "K"},      // MA# ( Κ → K ) GREEK CAPITAL LETTER KAPPA → LATIN CAPITAL LETTER K#
+    {924, "M"},      // MA# ( Μ → M ) GREEK CAPITAL LETTER MU → LATIN CAPITAL LETTER M#
+    {925, "N"},      // MA# ( Ν → N ) GREEK CAPITAL LETTER NU → LATIN CAPITAL LETTER N#
+    {927, "O"},      // MA# ( Ο → O ) GREEK CAPITAL LETTER OMICRON → LATIN CAPITAL LETTER O#
+    {929, "P"},      // MA# ( Ρ → P ) GREEK CAPITAL LETTER RHO → LATIN CAPITAL LETTER P#
+    {932, "T"},      // MA# ( Τ → T ) GREEK CAPITAL LETTER TAU → LATIN CAPITAL LETTER T#
+    {933, "Y"},      // MA# ( Υ → Y ) GREEK CAPITAL LETTER UPSILON → LATIN CAPITAL LETTER Y#
+    {935, "X"},      // MA# ( Χ → X ) GREEK CAPITAL LETTER CHI → LATIN CAPITAL LETTER X#
+    {945, "a"},      // MA# ( α → a ) GREEK SMALL LETTER ALPHA → LATIN SMALL LETTER A#
+    {947, "y"},      // MA# ( γ → y ) GREEK SMALL LETTER GAMMA → LATIN SMALL LETTER Y#
+    {953, "i"},      // MA# ( ι → i ) GREEK SMALL LETTER IOTA → LATIN SMALL LETTER I#
+    {957, "v"},      // MA# ( ν → v ) GREEK SMALL LETTER NU → LATIN SMALL LETTER V#
+    {959, "o"},      // MA# ( ο → o ) GREEK SMALL LETTER OMICRON → LATIN SMALL LETTER O#
+    {961, "p"},      // MA# ( ρ → p ) GREEK SMALL LETTER RHO → LATIN SMALL LETTER P#
+    {963, "o"},      // MA# ( σ → o ) GREEK SMALL LETTER SIGMA → LATIN SMALL LETTER O#
+    {965, "u"},      // MA# ( υ → u ) GREEK SMALL LETTER UPSILON → LATIN SMALL LETTER U# →ʋ→
+    {978, "Y"},      // MA# ( ϒ → Y ) GREEK UPSILON WITH HOOK SYMBOL → LATIN CAPITAL LETTER Y#
+    {988, "F"},      // MA# ( Ϝ → F ) GREEK LETTER DIGAMMA → LATIN CAPITAL LETTER F#
+    {1000, "2"},     // MA# ( Ϩ → 2 ) COPTIC CAPITAL LETTER HORI → DIGIT TWO# →Ƨ→
+    {1009, "p"},     // MA# ( ϱ → p ) GREEK RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {1010, "c"},     // MA# ( ϲ → c ) GREEK LUNATE SIGMA SYMBOL → LATIN SMALL LETTER C#
+    {1011, "j"},     // MA# ( ϳ → j ) GREEK LETTER YOT → LATIN SMALL LETTER J#
+    {1017, "C"},     // MA# ( Ϲ → C ) GREEK CAPITAL LUNATE SIGMA SYMBOL → LATIN CAPITAL LETTER C#
+    {1018, "M"},     // MA# ( Ϻ → M ) GREEK CAPITAL LETTER SAN → LATIN CAPITAL LETTER M#
+    {1029, "S"},     // MA# ( Ѕ → S ) CYRILLIC CAPITAL LETTER DZE → LATIN CAPITAL LETTER S#
+    {1030, "l"},     // MA# ( І → l ) CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I → LATIN SMALL LETTER L#
+    {1032, "J"},     // MA# ( Ј → J ) CYRILLIC CAPITAL LETTER JE → LATIN CAPITAL LETTER J#
+    {1040, "A"},     // MA# ( А → A ) CYRILLIC CAPITAL LETTER A → LATIN CAPITAL LETTER A#
+    {1042, "B"},     // MA# ( В → B ) CYRILLIC CAPITAL LETTER VE → LATIN CAPITAL LETTER B#
+    {1045, "E"},     // MA# ( Е → E ) CYRILLIC CAPITAL LETTER IE → LATIN CAPITAL LETTER E#
+    {1047, "3"},     // MA# ( З → 3 ) CYRILLIC CAPITAL LETTER ZE → DIGIT THREE#
+    {1050, "K"},     // MA# ( К → K ) CYRILLIC CAPITAL LETTER KA → LATIN CAPITAL LETTER K#
+    {1052, "M"},     // MA# ( М → M ) CYRILLIC CAPITAL LETTER EM → LATIN CAPITAL LETTER M#
+    {1053, "H"},     // MA# ( Н → H ) CYRILLIC CAPITAL LETTER EN → LATIN CAPITAL LETTER H#
+    {1054, "O"},     // MA# ( О → O ) CYRILLIC CAPITAL LETTER O → LATIN CAPITAL LETTER O#
+    {1056, "P"},     // MA# ( Р → P ) CYRILLIC CAPITAL LETTER ER → LATIN CAPITAL LETTER P#
+    {1057, "C"},     // MA# ( С → C ) CYRILLIC CAPITAL LETTER ES → LATIN CAPITAL LETTER C#
+    {1058, "T"},     // MA# ( Т → T ) CYRILLIC CAPITAL LETTER TE → LATIN CAPITAL LETTER T#
+    {1059, "Y"},     // MA# ( У → Y ) CYRILLIC CAPITAL LETTER U → LATIN CAPITAL LETTER Y#
+    {1061, "X"},     // MA# ( Х → X ) CYRILLIC CAPITAL LETTER HA → LATIN CAPITAL LETTER X#
+    {1067, "bl"},    // MA# ( Ы → bl ) CYRILLIC CAPITAL LETTER YERU → LATIN SMALL LETTER B, LATIN SMALL LETTER L# →ЬІ→→Ь1→
+    {1068, "b"},     // MA# ( Ь → b ) CYRILLIC CAPITAL LETTER SOFT SIGN → LATIN SMALL LETTER B# →Ƅ→
+    {1070, "lO"},    // MA# ( Ю → lO ) CYRILLIC CAPITAL LETTER YU → LATIN SMALL LETTER L, LATIN CAPITAL LETTER O# →IO→
+    {1072, "a"},     // MA# ( а → a ) CYRILLIC SMALL LETTER A → LATIN SMALL LETTER A#
+    {1073, "6"},     // MA# ( б → 6 ) CYRILLIC SMALL LETTER BE → DIGIT SIX#
+    {1075, "r"},     // MA# ( г → r ) CYRILLIC SMALL LETTER GHE → LATIN SMALL LETTER R#
+    {1077, "e"},     // MA# ( е → e ) CYRILLIC SMALL LETTER IE → LATIN SMALL LETTER E#
+    {1086, "o"},     // MA# ( о → o ) CYRILLIC SMALL LETTER O → LATIN SMALL LETTER O#
+    {1088, "p"},     // MA# ( р → p ) CYRILLIC SMALL LETTER ER → LATIN SMALL LETTER P#
+    {1089, "c"},     // MA# ( с → c ) CYRILLIC SMALL LETTER ES → LATIN SMALL LETTER C#
+    {1091, "y"},     // MA# ( у → y ) CYRILLIC SMALL LETTER U → LATIN SMALL LETTER Y#
+    {1093, "x"},     // MA# ( х → x ) CYRILLIC SMALL LETTER HA → LATIN SMALL LETTER X#
+    {1109, "s"},     // MA# ( ѕ → s ) CYRILLIC SMALL LETTER DZE → LATIN SMALL LETTER S#
+    {1110, "i"},     // MA# ( і → i ) CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I → LATIN SMALL LETTER I#
+    {1112, "j"},     // MA# ( ј → j ) CYRILLIC SMALL LETTER JE → LATIN SMALL LETTER J#
+    {1121, "w"},     // MA# ( ѡ → w ) CYRILLIC SMALL LETTER OMEGA → LATIN SMALL LETTER W#
+    {1140, "V"},     // MA# ( Ѵ → V ) CYRILLIC CAPITAL LETTER IZHITSA → LATIN CAPITAL LETTER V#
+    {1141, "v"},     // MA# ( ѵ → v ) CYRILLIC SMALL LETTER IZHITSA → LATIN SMALL LETTER V#
+    {1169, "r'"},    // MA# ( ґ → r' ) CYRILLIC SMALL LETTER GHE WITH UPTURN → LATIN SMALL LETTER R, APOSTROPHE# →гˈ→
+    {1198, "Y"},     // MA# ( Ү → Y ) CYRILLIC CAPITAL LETTER STRAIGHT U → LATIN CAPITAL LETTER Y#
+    {1199, "y"},     // MA# ( ү → y ) CYRILLIC SMALL LETTER STRAIGHT U → LATIN SMALL LETTER Y# →γ→
+    {1211, "h"},     // MA# ( һ → h ) CYRILLIC SMALL LETTER SHHA → LATIN SMALL LETTER H#
+    {1213, "e"},     // MA# ( ҽ → e ) CYRILLIC SMALL LETTER ABKHASIAN CHE → LATIN SMALL LETTER E#
+    {1216, "l"},     // MA# ( Ӏ → l ) CYRILLIC LETTER PALOCHKA → LATIN SMALL LETTER L#
+    {1231, "i"},     // MA# ( ӏ → i ) CYRILLIC SMALL LETTER PALOCHKA → LATIN SMALL LETTER I# →ı→
+    {1236, "AE"},    // MA# ( Ӕ → AE ) CYRILLIC CAPITAL LIGATURE A IE → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER E# →Æ→
+    {1237, "ae"},    // MA# ( ӕ → ae ) CYRILLIC SMALL LIGATURE A IE → LATIN SMALL LETTER A, LATIN SMALL LETTER E# →ае→
+    {1248, "3"},     // MA# ( Ӡ → 3 ) CYRILLIC CAPITAL LETTER ABKHASIAN DZE → DIGIT THREE# →Ʒ→
+    {1281, "d"},     // MA# ( ԁ → d ) CYRILLIC SMALL LETTER KOMI DE → LATIN SMALL LETTER D#
+    {1292, "G"},     // MA# ( Ԍ → G ) CYRILLIC CAPITAL LETTER KOMI SJE → LATIN CAPITAL LETTER G#
+    {1307, "q"},     // MA# ( ԛ → q ) CYRILLIC SMALL LETTER QA → LATIN SMALL LETTER Q#
+    {1308, "W"},     // MA# ( Ԝ → W ) CYRILLIC CAPITAL LETTER WE → LATIN CAPITAL LETTER W#
+    {1309, "w"},     // MA# ( ԝ → w ) CYRILLIC SMALL LETTER WE → LATIN SMALL LETTER W#
+    {1357, "U"},     // MA# ( Ս → U ) ARMENIAN CAPITAL LETTER SEH → LATIN CAPITAL LETTER U#
+    {1359, "S"},     // MA# ( Տ → S ) ARMENIAN CAPITAL LETTER TIWN → LATIN CAPITAL LETTER S#
+    {1365, "O"},     // MA# ( Օ → O ) ARMENIAN CAPITAL LETTER OH → LATIN CAPITAL LETTER O#
+    {1370, "'"},     // MA#* ( ՚ → ' ) ARMENIAN APOSTROPHE → APOSTROPHE# →’→
+    {1373, "'"},     // MA#* ( ՝ → ' ) ARMENIAN COMMA → APOSTROPHE# →ˋ→→｀→→‘→
+    {1377, "w"},     // MA# ( ա → w ) ARMENIAN SMALL LETTER AYB → LATIN SMALL LETTER W# →ɯ→
+    {1379, "q"},     // MA# ( գ → q ) ARMENIAN SMALL LETTER GIM → LATIN SMALL LETTER Q#
+    {1382, "q"},     // MA# ( զ → q ) ARMENIAN SMALL LETTER ZA → LATIN SMALL LETTER Q#
+    {1392, "h"},     // MA# ( հ → h ) ARMENIAN SMALL LETTER HO → LATIN SMALL LETTER H#
+    {1400, "n"},     // MA# ( ո → n ) ARMENIAN SMALL LETTER VO → LATIN SMALL LETTER N#
+    {1404, "n"},     // MA# ( ռ → n ) ARMENIAN SMALL LETTER RA → LATIN SMALL LETTER N#
+    {1405, "u"},     // MA# ( ս → u ) ARMENIAN SMALL LETTER SEH → LATIN SMALL LETTER U#
+    {1409, "g"},     // MA# ( ց → g ) ARMENIAN SMALL LETTER CO → LATIN SMALL LETTER G#
+    {1412, "f"},     // MA# ( ք → f ) ARMENIAN SMALL LETTER KEH → LATIN SMALL LETTER F#
+    {1413, "o"},     // MA# ( օ → o ) ARMENIAN SMALL LETTER OH → LATIN SMALL LETTER O#
+    {1417, ":"},     // MA#* ( ։ → : ) ARMENIAN FULL STOP → COLON#
+    {1472, "l"},     // MA#* ( ‎׀‎ → l ) HEBREW PUNCTUATION PASEQ → LATIN SMALL LETTER L# →|→
+    {1475, ":"},     // MA#* ( ‎׃‎ → : ) HEBREW PUNCTUATION SOF PASUQ → COLON#
+    {1493, "l"},     // MA# ( ‎ו‎ → l ) HEBREW LETTER VAV → LATIN SMALL LETTER L#
+    {1496, "v"},     // MA# ( ‎ט‎ → v ) HEBREW LETTER TET → LATIN SMALL LETTER V#
+    {1497, "'"},     // MA# ( ‎י‎ → ' ) HEBREW LETTER YOD → APOSTROPHE#
+    {1503, "l"},     // MA# ( ‎ן‎ → l ) HEBREW LETTER FINAL NUN → LATIN SMALL LETTER L#
+    {1505, "o"},     // MA# ( ‎ס‎ → o ) HEBREW LETTER SAMEKH → LATIN SMALL LETTER O#
+    {1520, "ll"},    // MA# ( ‎װ‎ → ll ) HEBREW LIGATURE YIDDISH DOUBLE VAV → LATIN SMALL LETTER L, LATIN SMALL LETTER L# →‎וו‎→
+    {1521, "l'"},    // MA# ( ‎ױ‎ → l' ) HEBREW LIGATURE YIDDISH VAV YOD → LATIN SMALL LETTER L, APOSTROPHE# →‎וי‎→
+    {1522, "\""},    // MA# ( ‎ײ‎ → '' ) HEBREW LIGATURE YIDDISH DOUBLE YOD → APOSTROPHE, APOSTROPHE# →‎יי‎→# Converted to a quote.
+    {1523, "'"},     // MA#* ( ‎׳‎ → ' ) HEBREW PUNCTUATION GERESH → APOSTROPHE#
+    {1524, "\""},    // MA#* ( ‎״‎ → '' ) HEBREW PUNCTUATION GERSHAYIM → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {1549, ","},     // MA#* ( ‎؍‎ → , ) ARABIC DATE SEPARATOR → COMMA# →‎٫‎→
+    {1575, "l"},     // MA# ( ‎ا‎ → l ) ARABIC LETTER ALEF → LATIN SMALL LETTER L# →1→
+    {1607, "o"},     // MA# ( ‎ه‎ → o ) ARABIC LETTER HEH → LATIN SMALL LETTER O#
+    {1632, "."},     // MA# ( ‎٠‎ → . ) ARABIC-INDIC DIGIT ZERO → FULL STOP#
+    {1633, "l"},     // MA# ( ‎١‎ → l ) ARABIC-INDIC DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {1637, "o"},     // MA# ( ‎٥‎ → o ) ARABIC-INDIC DIGIT FIVE → LATIN SMALL LETTER O#
+    {1639, "V"},     // MA# ( ‎٧‎ → V ) ARABIC-INDIC DIGIT SEVEN → LATIN CAPITAL LETTER V#
+    {1643, ","},     // MA#* ( ‎٫‎ → , ) ARABIC DECIMAL SEPARATOR → COMMA#
+    {1645, "*"},     // MA#* ( ‎٭‎ → * ) ARABIC FIVE POINTED STAR → ASTERISK#
+    {1726, "o"},     // MA# ( ‎ھ‎ → o ) ARABIC LETTER HEH DOACHASHMEE → LATIN SMALL LETTER O# →‎ه‎→
+    {1729, "o"},     // MA# ( ‎ہ‎ → o ) ARABIC LETTER HEH GOAL → LATIN SMALL LETTER O# →‎ه‎→
+    {1748, "-"},     // MA#* ( ‎۔‎ → - ) ARABIC FULL STOP → HYPHEN-MINUS# →‐→
+    {1749, "o"},     // MA# ( ‎ە‎ → o ) ARABIC LETTER AE → LATIN SMALL LETTER O# →‎ه‎→
+    {1776, "."},     // MA# ( ۰ → . ) EXTENDED ARABIC-INDIC DIGIT ZERO → FULL STOP# →‎٠‎→
+    {1777, "l"},     // MA# ( ۱ → l ) EXTENDED ARABIC-INDIC DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {1781, "o"},     // MA# ( ۵ → o ) EXTENDED ARABIC-INDIC DIGIT FIVE → LATIN SMALL LETTER O# →‎٥‎→
+    {1783, "V"},     // MA# ( ۷ → V ) EXTENDED ARABIC-INDIC DIGIT SEVEN → LATIN CAPITAL LETTER V# →‎٧‎→
+    {1793, "."},     // MA#* ( ‎܁‎ → . ) SYRIAC SUPRALINEAR FULL STOP → FULL STOP#
+    {1794, "."},     // MA#* ( ‎܂‎ → . ) SYRIAC SUBLINEAR FULL STOP → FULL STOP#
+    {1795, ":"},     // MA#* ( ‎܃‎ → : ) SYRIAC SUPRALINEAR COLON → COLON#
+    {1796, ":"},     // MA#* ( ‎܄‎ → : ) SYRIAC SUBLINEAR COLON → COLON#
+    {1984, "O"},     // MA# ( ‎߀‎ → O ) NKO DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {1994, "l"},     // MA# ( ‎ߊ‎ → l ) NKO LETTER A → LATIN SMALL LETTER L# →∣→→ǀ→
+    {2036, "'"},     // MA# ( ‎ߴ‎ → ' ) NKO HIGH TONE APOSTROPHE → APOSTROPHE# →’→
+    {2037, "'"},     // MA# ( ‎ߵ‎ → ' ) NKO LOW TONE APOSTROPHE → APOSTROPHE# →‘→
+    {2042, "_"},     // MA# ( ‎ߺ‎ → _ ) NKO LAJANYALAN → LOW LINE#
+    {2307, ":"},     // MA# ( ः → : ) DEVANAGARI SIGN VISARGA → COLON#
+    {2406, "o"},     // MA# ( ० → o ) DEVANAGARI DIGIT ZERO → LATIN SMALL LETTER O#
+    {2429, "?"},     // MA# ( ॽ → ? ) DEVANAGARI LETTER GLOTTAL STOP → QUESTION MARK#
+    {2534, "O"},     // MA# ( ০ → O ) BENGALI DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {2538, "8"},     // MA# ( ৪ → 8 ) BENGALI DIGIT FOUR → DIGIT EIGHT#
+    {2541, "9"},     // MA# ( ৭ → 9 ) BENGALI DIGIT SEVEN → DIGIT NINE#
+    {2662, "o"},     // MA# ( ੦ → o ) GURMUKHI DIGIT ZERO → LATIN SMALL LETTER O#
+    {2663, "9"},     // MA# ( ੧ → 9 ) GURMUKHI DIGIT ONE → DIGIT NINE#
+    {2666, "8"},     // MA# ( ੪ → 8 ) GURMUKHI DIGIT FOUR → DIGIT EIGHT#
+    {2691, ":"},     // MA# ( ઃ → : ) GUJARATI SIGN VISARGA → COLON#
+    {2790, "o"},     // MA# ( ૦ → o ) GUJARATI DIGIT ZERO → LATIN SMALL LETTER O#
+    {2819, "8"},     // MA# ( ଃ → 8 ) ORIYA SIGN VISARGA → DIGIT EIGHT#
+    {2848, "O"},     // MA# ( ଠ → O ) ORIYA LETTER TTHA → LATIN CAPITAL LETTER O# →୦→→0→
+    {2918, "O"},     // MA# ( ୦ → O ) ORIYA DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {2920, "9"},     // MA# ( ୨ → 9 ) ORIYA DIGIT TWO → DIGIT NINE#
+    {3046, "o"},     // MA# ( ௦ → o ) TAMIL DIGIT ZERO → LATIN SMALL LETTER O#
+    {3074, "o"},     // MA# ( ం → o ) TELUGU SIGN ANUSVARA → LATIN SMALL LETTER O#
+    {3174, "o"},     // MA# ( ౦ → o ) TELUGU DIGIT ZERO → LATIN SMALL LETTER O#
+    {3202, "o"},     // MA# ( ಂ → o ) KANNADA SIGN ANUSVARA → LATIN SMALL LETTER O#
+    {3302, "o"},     // MA# ( ೦ → o ) KANNADA DIGIT ZERO → LATIN SMALL LETTER O# →౦→
+    {3330, "o"},     // MA# ( ം → o ) MALAYALAM SIGN ANUSVARA → LATIN SMALL LETTER O#
+    {3360, "o"},     // MA# ( ഠ → o ) MALAYALAM LETTER TTHA → LATIN SMALL LETTER O#
+    {3430, "o"},     // MA# ( ൦ → o ) MALAYALAM DIGIT ZERO → LATIN SMALL LETTER O#
+    {3437, "9"},     // MA# ( ൭ → 9 ) MALAYALAM DIGIT SEVEN → DIGIT NINE#
+    {3458, "o"},     // MA# ( ං → o ) SINHALA SIGN ANUSVARAYA → LATIN SMALL LETTER O#
+    {3664, "o"},     // MA# ( ๐ → o ) THAI DIGIT ZERO → LATIN SMALL LETTER O#
+    {3792, "o"},     // MA# ( ໐ → o ) LAO DIGIT ZERO → LATIN SMALL LETTER O#
+    {4125, "o"},     // MA# ( ဝ → o ) MYANMAR LETTER WA → LATIN SMALL LETTER O#
+    {4160, "o"},     // MA# ( ၀ → o ) MYANMAR DIGIT ZERO → LATIN SMALL LETTER O#
+    {4327, "y"},     // MA# ( ყ → y ) GEORGIAN LETTER QAR → LATIN SMALL LETTER Y#
+    {4351, "o"},     // MA# ( ჿ → o ) GEORGIAN LETTER LABIAL SIGN → LATIN SMALL LETTER O#
+    {4608, "U"},     // MA# ( ሀ → U ) ETHIOPIC SYLLABLE HA → LATIN CAPITAL LETTER U# →Ս→
+    {4816, "O"},     // MA# ( ዐ → O ) ETHIOPIC SYLLABLE PHARYNGEAL A → LATIN CAPITAL LETTER O# →Օ→
+    {5024, "D"},     // MA# ( Ꭰ → D ) CHEROKEE LETTER A → LATIN CAPITAL LETTER D#
+    {5025, "R"},     // MA# ( Ꭱ → R ) CHEROKEE LETTER E → LATIN CAPITAL LETTER R#
+    {5026, "T"},     // MA# ( Ꭲ → T ) CHEROKEE LETTER I → LATIN CAPITAL LETTER T#
+    {5028, "O'"},    // MA# ( Ꭴ → O' ) CHEROKEE LETTER U → LATIN CAPITAL LETTER O, APOSTROPHE# →Ơ→→Oʼ→
+    {5029, "i"},     // MA# ( Ꭵ → i ) CHEROKEE LETTER V → LATIN SMALL LETTER I#
+    {5033, "Y"},     // MA# ( Ꭹ → Y ) CHEROKEE LETTER GI → LATIN CAPITAL LETTER Y#
+    {5034, "A"},     // MA# ( Ꭺ → A ) CHEROKEE LETTER GO → LATIN CAPITAL LETTER A#
+    {5035, "J"},     // MA# ( Ꭻ → J ) CHEROKEE LETTER GU → LATIN CAPITAL LETTER J#
+    {5036, "E"},     // MA# ( Ꭼ → E ) CHEROKEE LETTER GV → LATIN CAPITAL LETTER E#
+    {5038, "?"},     // MA# ( Ꭾ → ? ) CHEROKEE LETTER HE → QUESTION MARK# →Ɂ→→ʔ→
+    {5043, "W"},     // MA# ( Ꮃ → W ) CHEROKEE LETTER LA → LATIN CAPITAL LETTER W#
+    {5047, "M"},     // MA# ( Ꮇ → M ) CHEROKEE LETTER LU → LATIN CAPITAL LETTER M#
+    {5051, "H"},     // MA# ( Ꮋ → H ) CHEROKEE LETTER MI → LATIN CAPITAL LETTER H#
+    {5053, "Y"},     // MA# ( Ꮍ → Y ) CHEROKEE LETTER MU → LATIN CAPITAL LETTER Y# →Ꭹ→
+    {5056, "G"},     // MA# ( Ꮐ → G ) CHEROKEE LETTER NAH → LATIN CAPITAL LETTER G#
+    {5058, "h"},     // MA# ( Ꮒ → h ) CHEROKEE LETTER NI → LATIN SMALL LETTER H#
+    {5059, "Z"},     // MA# ( Ꮓ → Z ) CHEROKEE LETTER NO → LATIN CAPITAL LETTER Z#
+    {5070, "4"},     // MA# ( Ꮞ → 4 ) CHEROKEE LETTER SE → DIGIT FOUR#
+    {5071, "b"},     // MA# ( Ꮟ → b ) CHEROKEE LETTER SI → LATIN SMALL LETTER B#
+    {5074, "R"},     // MA# ( Ꮢ → R ) CHEROKEE LETTER SV → LATIN CAPITAL LETTER R#
+    {5076, "W"},     // MA# ( Ꮤ → W ) CHEROKEE LETTER TA → LATIN CAPITAL LETTER W#
+    {5077, "S"},     // MA# ( Ꮥ → S ) CHEROKEE LETTER DE → LATIN CAPITAL LETTER S#
+    {5081, "V"},     // MA# ( Ꮩ → V ) CHEROKEE LETTER DO → LATIN CAPITAL LETTER V#
+    {5082, "S"},     // MA# ( Ꮪ → S ) CHEROKEE LETTER DU → LATIN CAPITAL LETTER S#
+    {5086, "L"},     // MA# ( Ꮮ → L ) CHEROKEE LETTER TLE → LATIN CAPITAL LETTER L#
+    {5087, "C"},     // MA# ( Ꮯ → C ) CHEROKEE LETTER TLI → LATIN CAPITAL LETTER C#
+    {5090, "P"},     // MA# ( Ꮲ → P ) CHEROKEE LETTER TLV → LATIN CAPITAL LETTER P#
+    {5094, "K"},     // MA# ( Ꮶ → K ) CHEROKEE LETTER TSO → LATIN CAPITAL LETTER K#
+    {5095, "d"},     // MA# ( Ꮷ → d ) CHEROKEE LETTER TSU → LATIN SMALL LETTER D#
+    {5102, "6"},     // MA# ( Ꮾ → 6 ) CHEROKEE LETTER WV → DIGIT SIX#
+    {5107, "G"},     // MA# ( Ᏻ → G ) CHEROKEE LETTER YU → LATIN CAPITAL LETTER G#
+    {5108, "B"},     // MA# ( Ᏼ → B ) CHEROKEE LETTER YV → LATIN CAPITAL LETTER B#
+    {5120, "="},     // MA#* ( ᐀ → = ) CANADIAN SYLLABICS HYPHEN → EQUALS SIGN#
+    {5167, "V"},     // MA# ( ᐯ → V ) CANADIAN SYLLABICS PE → LATIN CAPITAL LETTER V#
+    {5171, ">"},     // MA# ( ᐳ → > ) CANADIAN SYLLABICS PO → GREATER-THAN SIGN#
+    {5176, "<"},     // MA# ( ᐸ → < ) CANADIAN SYLLABICS PA → LESS-THAN SIGN#
+    {5194, "'"},     // MA# ( ᑊ → ' ) CANADIAN SYLLABICS WEST-CREE P → APOSTROPHE# →ˈ→
+    {5196, "U"},     // MA# ( ᑌ → U ) CANADIAN SYLLABICS TE → LATIN CAPITAL LETTER U#
+    {5223, "U'"},    // MA# ( ᑧ → U' ) CANADIAN SYLLABICS TTE → LATIN CAPITAL LETTER U, APOSTROPHE# →ᑌᑊ→→ᑌ'→
+    {5229, "P"},     // MA# ( ᑭ → P ) CANADIAN SYLLABICS KI → LATIN CAPITAL LETTER P#
+    {5231, "d"},     // MA# ( ᑯ → d ) CANADIAN SYLLABICS KO → LATIN SMALL LETTER D#
+    {5254, "P'"},    // MA# ( ᒆ → P' ) CANADIAN SYLLABICS SOUTH-SLAVEY KIH → LATIN CAPITAL LETTER P, APOSTROPHE# →ᑭᑊ→
+    {5255, "d'"},    // MA# ( ᒇ → d' ) CANADIAN SYLLABICS SOUTH-SLAVEY KOH → LATIN SMALL LETTER D, APOSTROPHE# →ᑯᑊ→
+    {5261, "J"},     // MA# ( ᒍ → J ) CANADIAN SYLLABICS CO → LATIN CAPITAL LETTER J#
+    {5290, "L"},     // MA# ( ᒪ → L ) CANADIAN SYLLABICS MA → LATIN CAPITAL LETTER L#
+    {5311, "2"},     // MA# ( ᒿ → 2 ) CANADIAN SYLLABICS SAYISI M → DIGIT TWO#
+    {5441, "x"},     // MA# ( ᕁ → x ) CANADIAN SYLLABICS SAYISI YI → LATIN SMALL LETTER X# →᙮→
+    {5500, "H"},     // MA# ( ᕼ → H ) CANADIAN SYLLABICS NUNAVUT H → LATIN CAPITAL LETTER H#
+    {5501, "x"},     // MA# ( ᕽ → x ) CANADIAN SYLLABICS HK → LATIN SMALL LETTER X# →ᕁ→→᙮→
+    {5511, "R"},     // MA# ( ᖇ → R ) CANADIAN SYLLABICS TLHI → LATIN CAPITAL LETTER R#
+    {5551, "b"},     // MA# ( ᖯ → b ) CANADIAN SYLLABICS AIVILIK B → LATIN SMALL LETTER B#
+    {5556, "F"},     // MA# ( ᖴ → F ) CANADIAN SYLLABICS BLACKFOOT WE → LATIN CAPITAL LETTER F#
+    {5573, "A"},     // MA# ( ᗅ → A ) CANADIAN SYLLABICS CARRIER GHO → LATIN CAPITAL LETTER A#
+    {5598, "D"},     // MA# ( ᗞ → D ) CANADIAN SYLLABICS CARRIER THE → LATIN CAPITAL LETTER D#
+    {5610, "D"},     // MA# ( ᗪ → D ) CANADIAN SYLLABICS CARRIER PE → LATIN CAPITAL LETTER D# →ᗞ→
+    {5616, "M"},     // MA# ( ᗰ → M ) CANADIAN SYLLABICS CARRIER GO → LATIN CAPITAL LETTER M#
+    {5623, "B"},     // MA# ( ᗷ → B ) CANADIAN SYLLABICS CARRIER KHE → LATIN CAPITAL LETTER B#
+    {5741, "X"},     // MA#* ( ᙭ → X ) CANADIAN SYLLABICS CHI SIGN → LATIN CAPITAL LETTER X#
+    {5742, "x"},     // MA#* ( ᙮ → x ) CANADIAN SYLLABICS FULL STOP → LATIN SMALL LETTER X#
+    {5760, " "},     // MA#* (   →   ) OGHAM SPACE MARK → SPACE#
+    {5810, "<"},     // MA# ( ᚲ → < ) RUNIC LETTER KAUNA → LESS-THAN SIGN#
+    {5815, "X"},     // MA# ( ᚷ → X ) RUNIC LETTER GEBO GYFU G → LATIN CAPITAL LETTER X#
+    {5825, "l"},     // MA# ( ᛁ → l ) RUNIC LETTER ISAZ IS ISS I → LATIN SMALL LETTER L# →I→
+    {5836, "'"},     // MA# ( ᛌ → ' ) RUNIC LETTER SHORT-TWIG-SOL S → APOSTROPHE#
+    {5845, "K"},     // MA# ( ᛕ → K ) RUNIC LETTER OPEN-P → LATIN CAPITAL LETTER K#
+    {5846, "M"},     // MA# ( ᛖ → M ) RUNIC LETTER EHWAZ EH E → LATIN CAPITAL LETTER M#
+    {5868, ":"},     // MA#* ( ᛬ → : ) RUNIC MULTIPLE PUNCTUATION → COLON#
+    {5869, "+"},     // MA#* ( ᛭ → + ) RUNIC CROSS PUNCTUATION → PLUS SIGN#
+    {5941, "/"},     // MA#* ( ᜵ → / ) PHILIPPINE SINGLE PUNCTUATION → SOLIDUS#
+    {6147, ":"},     // MA#* ( ᠃ → : ) MONGOLIAN FULL STOP → COLON#
+    {6153, ":"},     // MA#* ( ᠉ → : ) MONGOLIAN MANCHU FULL STOP → COLON#
+    {7379, "\""},    // MA#* ( ᳓ → '' ) VEDIC SIGN NIHSHVASA → APOSTROPHE, APOSTROPHE# →″→→"→# Converted to a quote.
+    {7428, "c"},     // MA# ( ᴄ → c ) LATIN LETTER SMALL CAPITAL C → LATIN SMALL LETTER C#
+    {7439, "o"},     // MA# ( ᴏ → o ) LATIN LETTER SMALL CAPITAL O → LATIN SMALL LETTER O#
+    {7441, "o"},     // MA# ( ᴑ → o ) LATIN SMALL LETTER SIDEWAYS O → LATIN SMALL LETTER O#
+    {7452, "u"},     // MA# ( ᴜ → u ) LATIN LETTER SMALL CAPITAL U → LATIN SMALL LETTER U#
+    {7456, "v"},     // MA# ( ᴠ → v ) LATIN LETTER SMALL CAPITAL V → LATIN SMALL LETTER V#
+    {7457, "w"},     // MA# ( ᴡ → w ) LATIN LETTER SMALL CAPITAL W → LATIN SMALL LETTER W#
+    {7458, "z"},     // MA# ( ᴢ → z ) LATIN LETTER SMALL CAPITAL Z → LATIN SMALL LETTER Z#
+    {7462, "r"},     // MA# ( ᴦ → r ) GREEK LETTER SMALL CAPITAL GAMMA → LATIN SMALL LETTER R# →г→
+    {7531, "ue"},    // MA# ( ᵫ → ue ) LATIN SMALL LETTER UE → LATIN SMALL LETTER U, LATIN SMALL LETTER E#
+    {7555, "g"},     // MA# ( ᶃ → g ) LATIN SMALL LETTER G WITH PALATAL HOOK → LATIN SMALL LETTER G#
+    {7564, "y"},     // MA# ( ᶌ → y ) LATIN SMALL LETTER V WITH PALATAL HOOK → LATIN SMALL LETTER Y#
+    {7837, "f"},     // MA# ( ẝ → f ) LATIN SMALL LETTER LONG S WITH HIGH STROKE → LATIN SMALL LETTER F#
+    {7935, "y"},     // MA# ( ỿ → y ) LATIN SMALL LETTER Y WITH LOOP → LATIN SMALL LETTER Y#
+    {8125, "'"},     // MA#* ( ᾽ → ' ) GREEK KORONIS → APOSTROPHE# →’→
+    {8126, "i"},     // MA# ( ι → i ) GREEK PROSGEGRAMMENI → LATIN SMALL LETTER I# →ι→
+    {8127, "'"},     // MA#* ( ᾿ → ' ) GREEK PSILI → APOSTROPHE# →’→
+    {8128, "~"},     // MA#* ( ῀ → ~ ) GREEK PERISPOMENI → TILDE# →˜→
+    {8175, "'"},     // MA#* ( ` → ' ) GREEK VARIA → APOSTROPHE# →ˋ→→｀→→‘→
+    {8189, "'"},     // MA#* ( ´ → ' ) GREEK OXIA → APOSTROPHE# →´→→΄→→ʹ→
+    {8190, "'"},     // MA#* ( ῾ → ' ) GREEK DASIA → APOSTROPHE# →‛→→′→
+    {8192, " "},     // MA#* (   →   ) EN QUAD → SPACE#
+    {8193, " "},     // MA#* (   →   ) EM QUAD → SPACE#
+    {8194, " "},     // MA#* (   →   ) EN SPACE → SPACE#
+    {8195, " "},     // MA#* (   →   ) EM SPACE → SPACE#
+    {8196, " "},     // MA#* (   →   ) THREE-PER-EM SPACE → SPACE#
+    {8197, " "},     // MA#* (   →   ) FOUR-PER-EM SPACE → SPACE#
+    {8198, " "},     // MA#* (   →   ) SIX-PER-EM SPACE → SPACE#
+    {8199, " "},     // MA#* (   →   ) FIGURE SPACE → SPACE#
+    {8200, " "},     // MA#* (   →   ) PUNCTUATION SPACE → SPACE#
+    {8201, " "},     // MA#* (   →   ) THIN SPACE → SPACE#
+    {8202, " "},     // MA#* (   →   ) HAIR SPACE → SPACE#
+    {8208, "-"},     // MA#* ( ‐ → - ) HYPHEN → HYPHEN-MINUS#
+    {8209, "-"},     // MA#* ( ‑ → - ) NON-BREAKING HYPHEN → HYPHEN-MINUS#
+    {8210, "-"},     // MA#* ( ‒ → - ) FIGURE DASH → HYPHEN-MINUS#
+    {8211, "-"},     // MA#* ( – → - ) EN DASH → HYPHEN-MINUS#
+    {8214, "ll"},    // MA#* ( ‖ → ll ) DOUBLE VERTICAL LINE → LATIN SMALL LETTER L, LATIN SMALL LETTER L# →∥→→||→
+    {8216, "'"},     // MA#* ( ‘ → ' ) LEFT SINGLE QUOTATION MARK → APOSTROPHE#
+    {8217, "'"},     // MA#* ( ’ → ' ) RIGHT SINGLE QUOTATION MARK → APOSTROPHE#
+    {8218, ","},     // MA#* ( ‚ → , ) SINGLE LOW-9 QUOTATION MARK → COMMA#
+    {8219, "'"},     // MA#* ( ‛ → ' ) SINGLE HIGH-REVERSED-9 QUOTATION MARK → APOSTROPHE# →′→
+    {8220, "\""},    // MA#* ( “ → '' ) LEFT DOUBLE QUOTATION MARK → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {8221, "\""},    // MA#* ( ” → '' ) RIGHT DOUBLE QUOTATION MARK → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {8223, "\""},    // MA#* ( ‟ → '' ) DOUBLE HIGH-REVERSED-9 QUOTATION MARK → APOSTROPHE, APOSTROPHE# →“→→"→# Converted to a quote.
+    {8228, "."},     // MA#* ( ․ → . ) ONE DOT LEADER → FULL STOP#
+    {8229, ".."},    // MA#* ( ‥ → .. ) TWO DOT LEADER → FULL STOP, FULL STOP#
+    {8230, "..."},   // MA#* ( … → ... ) HORIZONTAL ELLIPSIS → FULL STOP, FULL STOP, FULL STOP#
+    {8232, " "},     // MA#* (  →   ) LINE SEPARATOR → SPACE#
+    {8233, " "},     // MA#* (  →   ) PARAGRAPH SEPARATOR → SPACE#
+    {8239, " "},     // MA#* (   →   ) NARROW NO-BREAK SPACE → SPACE#
+    {8242, "'"},     // MA#* ( ′ → ' ) PRIME → APOSTROPHE#
+    {8243, "\""},    // MA#* ( ″ → '' ) DOUBLE PRIME → APOSTROPHE, APOSTROPHE# →"→# Converted to a quote.
+    {8244, "'''"},   // MA#* ( ‴ → ''' ) TRIPLE PRIME → APOSTROPHE, APOSTROPHE, APOSTROPHE# →′′′→
+    {8245, "'"},     // MA#* ( ‵ → ' ) REVERSED PRIME → APOSTROPHE# →ʽ→→‘→
+    {8246, "\""},    // MA#* ( ‶ → '' ) REVERSED DOUBLE PRIME → APOSTROPHE, APOSTROPHE# →‵‵→# Converted to a quote.
+    {8247, "'''"},   // MA#* ( ‷ → ''' ) REVERSED TRIPLE PRIME → APOSTROPHE, APOSTROPHE, APOSTROPHE# →‵‵‵→
+    {8249, "<"},     // MA#* ( ‹ → < ) SINGLE LEFT-POINTING ANGLE QUOTATION MARK → LESS-THAN SIGN#
+    {8250, ">"},     // MA#* ( › → > ) SINGLE RIGHT-POINTING ANGLE QUOTATION MARK → GREATER-THAN SIGN#
+    {8252, "!!"},    // MA#* ( ‼ → !! ) DOUBLE EXCLAMATION MARK → EXCLAMATION MARK, EXCLAMATION MARK#
+    {8257, "/"},     // MA#* ( ⁁ → / ) CARET INSERTION POINT → SOLIDUS#
+    {8259, "-"},     // MA#* ( ⁃ → - ) HYPHEN BULLET → HYPHEN-MINUS# →‐→
+    {8260, "/"},     // MA#* ( ⁄ → / ) FRACTION SLASH → SOLIDUS#
+    {8263, "??"},    // MA#* ( ⁇ → ?? ) DOUBLE QUESTION MARK → QUESTION MARK, QUESTION MARK#
+    {8264, "?!"},    // MA#* ( ⁈ → ?! ) QUESTION EXCLAMATION MARK → QUESTION MARK, EXCLAMATION MARK#
+    {8265, "!?"},    // MA#* ( ⁉ → !? ) EXCLAMATION QUESTION MARK → EXCLAMATION MARK, QUESTION MARK#
+    {8270, "*"},     // MA#* ( ⁎ → * ) LOW ASTERISK → ASTERISK#
+    {8275, "~"},     // MA#* ( ⁓ → ~ ) SWUNG DASH → TILDE#
+    {8279, "''''"},  // MA#* ( ⁗ → '''' ) QUADRUPLE PRIME → APOSTROPHE, APOSTROPHE, APOSTROPHE, APOSTROPHE# →′′′′→
+    {8282, ":"},     // MA#* ( ⁚ → : ) TWO DOT PUNCTUATION → COLON#
+    {8287, " "},     // MA#* (   →   ) MEDIUM MATHEMATICAL SPACE → SPACE#
+    {8360, "Rs"},    // MA#* ( ₨ → Rs ) RUPEE SIGN → LATIN CAPITAL LETTER R, LATIN SMALL LETTER S#
+    {8374, "lt"},    // MA#* ( ₶ → lt ) LIVRE TOURNOIS SIGN → LATIN SMALL LETTER L, LATIN SMALL LETTER T#
+    {8448, "a/c"},   // MA#* ( ℀ → a/c ) ACCOUNT OF → LATIN SMALL LETTER A, SOLIDUS, LATIN SMALL LETTER C#
+    {8449, "a/s"},   // MA#* ( ℁ → a/s ) ADDRESSED TO THE SUBJECT → LATIN SMALL LETTER A, SOLIDUS, LATIN SMALL LETTER S#
+    {8450, "C"},     // MA# ( ℂ → C ) DOUBLE-STRUCK CAPITAL C → LATIN CAPITAL LETTER C#
+    {8453, "c/o"},   // MA#* ( ℅ → c/o ) CARE OF → LATIN SMALL LETTER C, SOLIDUS, LATIN SMALL LETTER O#
+    {8454, "c/u"},   // MA#* ( ℆ → c/u ) CADA UNA → LATIN SMALL LETTER C, SOLIDUS, LATIN SMALL LETTER U#
+    {8458, "g"},     // MA# ( ℊ → g ) SCRIPT SMALL G → LATIN SMALL LETTER G#
+    {8459, "H"},     // MA# ( ℋ → H ) SCRIPT CAPITAL H → LATIN CAPITAL LETTER H#
+    {8460, "H"},     // MA# ( ℌ → H ) BLACK-LETTER CAPITAL H → LATIN CAPITAL LETTER H#
+    {8461, "H"},     // MA# ( ℍ → H ) DOUBLE-STRUCK CAPITAL H → LATIN CAPITAL LETTER H#
+    {8462, "h"},     // MA# ( ℎ → h ) PLANCK CONSTANT → LATIN SMALL LETTER H#
+    {8464, "l"},     // MA# ( ℐ → l ) SCRIPT CAPITAL I → LATIN SMALL LETTER L# →I→
+    {8465, "l"},     // MA# ( ℑ → l ) BLACK-LETTER CAPITAL I → LATIN SMALL LETTER L# →I→
+    {8466, "L"},     // MA# ( ℒ → L ) SCRIPT CAPITAL L → LATIN CAPITAL LETTER L#
+    {8467, "l"},     // MA# ( ℓ → l ) SCRIPT SMALL L → LATIN SMALL LETTER L#
+    {8469, "N"},     // MA# ( ℕ → N ) DOUBLE-STRUCK CAPITAL N → LATIN CAPITAL LETTER N#
+    {8470, "No"},    // MA#* ( № → No ) NUMERO SIGN → LATIN CAPITAL LETTER N, LATIN SMALL LETTER O#
+    {8473, "P"},     // MA# ( ℙ → P ) DOUBLE-STRUCK CAPITAL P → LATIN CAPITAL LETTER P#
+    {8474, "Q"},     // MA# ( ℚ → Q ) DOUBLE-STRUCK CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {8475, "R"},     // MA# ( ℛ → R ) SCRIPT CAPITAL R → LATIN CAPITAL LETTER R#
+    {8476, "R"},     // MA# ( ℜ → R ) BLACK-LETTER CAPITAL R → LATIN CAPITAL LETTER R#
+    {8477, "R"},     // MA# ( ℝ → R ) DOUBLE-STRUCK CAPITAL R → LATIN CAPITAL LETTER R#
+    {8481, "TEL"},   // MA#* ( ℡ → TEL ) TELEPHONE SIGN → LATIN CAPITAL LETTER T, LATIN CAPITAL LETTER E, LATIN CAPITAL LETTER L#
+    {8484, "Z"},     // MA# ( ℤ → Z ) DOUBLE-STRUCK CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {8488, "Z"},     // MA# ( ℨ → Z ) BLACK-LETTER CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {8490, "K"},     // MA# ( K → K ) KELVIN SIGN → LATIN CAPITAL LETTER K#
+    {8492, "B"},     // MA# ( ℬ → B ) SCRIPT CAPITAL B → LATIN CAPITAL LETTER B#
+    {8493, "C"},     // MA# ( ℭ → C ) BLACK-LETTER CAPITAL C → LATIN CAPITAL LETTER C#
+    {8494, "e"},     // MA# ( ℮ → e ) ESTIMATED SYMBOL → LATIN SMALL LETTER E#
+    {8495, "e"},     // MA# ( ℯ → e ) SCRIPT SMALL E → LATIN SMALL LETTER E#
+    {8496, "E"},     // MA# ( ℰ → E ) SCRIPT CAPITAL E → LATIN CAPITAL LETTER E#
+    {8497, "F"},     // MA# ( ℱ → F ) SCRIPT CAPITAL F → LATIN CAPITAL LETTER F#
+    {8499, "M"},     // MA# ( ℳ → M ) SCRIPT CAPITAL M → LATIN CAPITAL LETTER M#
+    {8500, "o"},     // MA# ( ℴ → o ) SCRIPT SMALL O → LATIN SMALL LETTER O#
+    {8505, "i"},     // MA# ( ℹ → i ) INFORMATION SOURCE → LATIN SMALL LETTER I#
+    {8507, "FAX"},   // MA#* ( ℻ → FAX ) FACSIMILE SIGN → LATIN CAPITAL LETTER F, LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER X#
+    {8509, "y"},     // MA# ( ℽ → y ) DOUBLE-STRUCK SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {8517, "D"},     // MA# ( ⅅ → D ) DOUBLE-STRUCK ITALIC CAPITAL D → LATIN CAPITAL LETTER D#
+    {8518, "d"},     // MA# ( ⅆ → d ) DOUBLE-STRUCK ITALIC SMALL D → LATIN SMALL LETTER D#
+    {8519, "e"},     // MA# ( ⅇ → e ) DOUBLE-STRUCK ITALIC SMALL E → LATIN SMALL LETTER E#
+    {8520, "i"},     // MA# ( ⅈ → i ) DOUBLE-STRUCK ITALIC SMALL I → LATIN SMALL LETTER I#
+    {8521, "j"},     // MA# ( ⅉ → j ) DOUBLE-STRUCK ITALIC SMALL J → LATIN SMALL LETTER J#
+    {8544, "l"},     // MA# ( Ⅰ → l ) ROMAN NUMERAL ONE → LATIN SMALL LETTER L# →Ӏ→
+    {8545, "ll"},    // MA# ( Ⅱ → ll ) ROMAN NUMERAL TWO → LATIN SMALL LETTER L, LATIN SMALL LETTER L# →II→
+    {8546, "lll"},   // MA# ( Ⅲ → lll ) ROMAN NUMERAL THREE → LATIN SMALL LETTER L, LATIN SMALL LETTER L, LATIN SMALL LETTER L# →III→
+    {8547, "lV"},    // MA# ( Ⅳ → lV ) ROMAN NUMERAL FOUR → LATIN SMALL LETTER L, LATIN CAPITAL LETTER V# →IV→
+    {8548, "V"},     // MA# ( Ⅴ → V ) ROMAN NUMERAL FIVE → LATIN CAPITAL LETTER V#
+    {8549, "Vl"},    // MA# ( Ⅵ → Vl ) ROMAN NUMERAL SIX → LATIN CAPITAL LETTER V, LATIN SMALL LETTER L# →VI→
+    {8550, "Vll"},   // MA# ( Ⅶ → Vll ) ROMAN NUMERAL SEVEN → LATIN CAPITAL LETTER V, LATIN SMALL LETTER L, LATIN SMALL LETTER L# →VII→
+    {8551, "Vlll"},  // MA# ( Ⅷ → Vlll ) ROMAN NUMERAL EIGHT → LATIN CAPITAL LETTER V, LATIN SMALL LETTER L, LATIN SMALL LETTER L, LATIN SMALL LETTER L# →VIII→
+    {8552, "lX"},    // MA# ( Ⅸ → lX ) ROMAN NUMERAL NINE → LATIN SMALL LETTER L, LATIN CAPITAL LETTER X# →IX→
+    {8553, "X"},     // MA# ( Ⅹ → X ) ROMAN NUMERAL TEN → LATIN CAPITAL LETTER X#
+    {8554, "Xl"},    // MA# ( Ⅺ → Xl ) ROMAN NUMERAL ELEVEN → LATIN CAPITAL LETTER X, LATIN SMALL LETTER L# →XI→
+    {8555, "Xll"},   // MA# ( Ⅻ → Xll ) ROMAN NUMERAL TWELVE → LATIN CAPITAL LETTER X, LATIN SMALL LETTER L, LATIN SMALL LETTER L# →XII→
+    {8556, "L"},     // MA# ( Ⅼ → L ) ROMAN NUMERAL FIFTY → LATIN CAPITAL LETTER L#
+    {8557, "C"},     // MA# ( Ⅽ → C ) ROMAN NUMERAL ONE HUNDRED → LATIN CAPITAL LETTER C#
+    {8558, "D"},     // MA# ( Ⅾ → D ) ROMAN NUMERAL FIVE HUNDRED → LATIN CAPITAL LETTER D#
+    {8559, "M"},     // MA# ( Ⅿ → M ) ROMAN NUMERAL ONE THOUSAND → LATIN CAPITAL LETTER M#
+    {8560, "i"},     // MA# ( ⅰ → i ) SMALL ROMAN NUMERAL ONE → LATIN SMALL LETTER I#
+    {8561, "ii"},    // MA# ( ⅱ → ii ) SMALL ROMAN NUMERAL TWO → LATIN SMALL LETTER I, LATIN SMALL LETTER I#
+    {8562, "iii"},   // MA# ( ⅲ → iii ) SMALL ROMAN NUMERAL THREE → LATIN SMALL LETTER I, LATIN SMALL LETTER I, LATIN SMALL LETTER I#
+    {8563, "iv"},    // MA# ( ⅳ → iv ) SMALL ROMAN NUMERAL FOUR → LATIN SMALL LETTER I, LATIN SMALL LETTER V#
+    {8564, "v"},     // MA# ( ⅴ → v ) SMALL ROMAN NUMERAL FIVE → LATIN SMALL LETTER V#
+    {8565, "vi"},    // MA# ( ⅵ → vi ) SMALL ROMAN NUMERAL SIX → LATIN SMALL LETTER V, LATIN SMALL LETTER I#
+    {8566, "vii"},   // MA# ( ⅶ → vii ) SMALL ROMAN NUMERAL SEVEN → LATIN SMALL LETTER V, LATIN SMALL LETTER I, LATIN SMALL LETTER I#
+    {8567, "viii"},  // MA# ( ⅷ → viii ) SMALL ROMAN NUMERAL EIGHT → LATIN SMALL LETTER V, LATIN SMALL LETTER I, LATIN SMALL LETTER I, LATIN SMALL LETTER I#
+    {8568, "ix"},    // MA# ( ⅸ → ix ) SMALL ROMAN NUMERAL NINE → LATIN SMALL LETTER I, LATIN SMALL LETTER X#
+    {8569, "x"},     // MA# ( ⅹ → x ) SMALL ROMAN NUMERAL TEN → LATIN SMALL LETTER X#
+    {8570, "xi"},    // MA# ( ⅺ → xi ) SMALL ROMAN NUMERAL ELEVEN → LATIN SMALL LETTER X, LATIN SMALL LETTER I#
+    {8571, "xii"},   // MA# ( ⅻ → xii ) SMALL ROMAN NUMERAL TWELVE → LATIN SMALL LETTER X, LATIN SMALL LETTER I, LATIN SMALL LETTER I#
+    {8572, "l"},     // MA# ( ⅼ → l ) SMALL ROMAN NUMERAL FIFTY → LATIN SMALL LETTER L#
+    {8573, "c"},     // MA# ( ⅽ → c ) SMALL ROMAN NUMERAL ONE HUNDRED → LATIN SMALL LETTER C#
+    {8574, "d"},     // MA# ( ⅾ → d ) SMALL ROMAN NUMERAL FIVE HUNDRED → LATIN SMALL LETTER D#
+    {8575, "rn"},    // MA# ( ⅿ → rn ) SMALL ROMAN NUMERAL ONE THOUSAND → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {8722, "-"},     // MA#* ( − → - ) MINUS SIGN → HYPHEN-MINUS#
+    {8725, "/"},     // MA#* ( ∕ → / ) DIVISION SLASH → SOLIDUS#
+    {8726, "\\"},    // MA#* ( ∖ → \ ) SET MINUS → REVERSE SOLIDUS#
+    {8727, "*"},     // MA#* ( ∗ → * ) ASTERISK OPERATOR → ASTERISK#
+    {8734, "oo"},    // MA#* ( ∞ → oo ) INFINITY → LATIN SMALL LETTER O, LATIN SMALL LETTER O# →ꝏ→
+    {8739, "l"},     // MA#* ( ∣ → l ) DIVIDES → LATIN SMALL LETTER L# →ǀ→
+    {8741, "ll"},    // MA#* ( ∥ → ll ) PARALLEL TO → LATIN SMALL LETTER L, LATIN SMALL LETTER L# →||→
+    {8744, "v"},     // MA#* ( ∨ → v ) LOGICAL OR → LATIN SMALL LETTER V#
+    {8746, "U"},     // MA#* ( ∪ → U ) UNION → LATIN CAPITAL LETTER U# →ᑌ→
+    {8758, ":"},     // MA#* ( ∶ → : ) RATIO → COLON#
+    {8764, "~"},     // MA#* ( ∼ → ~ ) TILDE OPERATOR → TILDE#
+    {8810, "<<"},    // MA#* ( ≪ → << ) MUCH LESS-THAN → LESS-THAN SIGN, LESS-THAN SIGN#
+    {8811, ">>"},    // MA#* ( ≫ → >> ) MUCH GREATER-THAN → GREATER-THAN SIGN, GREATER-THAN SIGN#
+    {8868, "T"},     // MA#* ( ⊤ → T ) DOWN TACK → LATIN CAPITAL LETTER T#
+    {8897, "v"},     // MA#* ( ⋁ → v ) N-ARY LOGICAL OR → LATIN SMALL LETTER V# →∨→
+    {8899, "U"},     // MA#* ( ⋃ → U ) N-ARY UNION → LATIN CAPITAL LETTER U# →∪→→ᑌ→
+    {8920, "<<<"},   // MA#* ( ⋘ → <<< ) VERY MUCH LESS-THAN → LESS-THAN SIGN, LESS-THAN SIGN, LESS-THAN SIGN#
+    {8921, ">>>"},   // MA#* ( ⋙ → >>> ) VERY MUCH GREATER-THAN → GREATER-THAN SIGN, GREATER-THAN SIGN, GREATER-THAN SIGN#
+    {8959, "E"},     // MA#* ( ⋿ → E ) Z NOTATION BAG MEMBERSHIP → LATIN CAPITAL LETTER E#
+    {9075, "i"},     // MA#* ( ⍳ → i ) APL FUNCTIONAL SYMBOL IOTA → LATIN SMALL LETTER I# →ι→
+    {9076, "p"},     // MA#* ( ⍴ → p ) APL FUNCTIONAL SYMBOL RHO → LATIN SMALL LETTER P# →ρ→
+    {9082, "a"},     // MA#* ( ⍺ → a ) APL FUNCTIONAL SYMBOL ALPHA → LATIN SMALL LETTER A# →α→
+    {9213, "l"},     // MA#* ( ⏽ → l ) POWER ON SYMBOL → LATIN SMALL LETTER L# →I→
+    {9290, "\\\\"},  // MA#* ( ⑊ → \\ ) OCR DOUBLE BACKSLASH → REVERSE SOLIDUS, REVERSE SOLIDUS#
+    {9332, "(l)"},   // MA#* ( ⑴ → (l) ) PARENTHESIZED DIGIT ONE → LEFT PARENTHESIS, LATIN SMALL LETTER L, RIGHT PARENTHESIS# →(1)→
+    {9333, "(2)"},   // MA#* ( ⑵ → (2) ) PARENTHESIZED DIGIT TWO → LEFT PARENTHESIS, DIGIT TWO, RIGHT PARENTHESIS#
+    {9334, "(3)"},   // MA#* ( ⑶ → (3) ) PARENTHESIZED DIGIT THREE → LEFT PARENTHESIS, DIGIT THREE, RIGHT PARENTHESIS#
+    {9335, "(4)"},   // MA#* ( ⑷ → (4) ) PARENTHESIZED DIGIT FOUR → LEFT PARENTHESIS, DIGIT FOUR, RIGHT PARENTHESIS#
+    {9336, "(5)"},   // MA#* ( ⑸ → (5) ) PARENTHESIZED DIGIT FIVE → LEFT PARENTHESIS, DIGIT FIVE, RIGHT PARENTHESIS#
+    {9337, "(6)"},   // MA#* ( ⑹ → (6) ) PARENTHESIZED DIGIT SIX → LEFT PARENTHESIS, DIGIT SIX, RIGHT PARENTHESIS#
+    {9338, "(7)"},   // MA#* ( ⑺ → (7) ) PARENTHESIZED DIGIT SEVEN → LEFT PARENTHESIS, DIGIT SEVEN, RIGHT PARENTHESIS#
+    {9339, "(8)"},   // MA#* ( ⑻ → (8) ) PARENTHESIZED DIGIT EIGHT → LEFT PARENTHESIS, DIGIT EIGHT, RIGHT PARENTHESIS#
+    {9340, "(9)"},   // MA#* ( ⑼ → (9) ) PARENTHESIZED DIGIT NINE → LEFT PARENTHESIS, DIGIT NINE, RIGHT PARENTHESIS#
+    {9341, "(lO)"},  // MA#* ( ⑽ → (lO) ) PARENTHESIZED NUMBER TEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, LATIN CAPITAL LETTER O, RIGHT PARENTHESIS# →(10)→
+    {9342, "(ll)"},  // MA#* ( ⑾ → (ll) ) PARENTHESIZED NUMBER ELEVEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, LATIN SMALL LETTER L, RIGHT PARENTHESIS# →(11)→
+    {9343, "(l2)"},  // MA#* ( ⑿ → (l2) ) PARENTHESIZED NUMBER TWELVE → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT TWO, RIGHT PARENTHESIS# →(12)→
+    {9344, "(l3)"},  // MA#* ( ⒀ → (l3) ) PARENTHESIZED NUMBER THIRTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT THREE, RIGHT PARENTHESIS# →(13)→
+    {9345, "(l4)"},  // MA#* ( ⒁ → (l4) ) PARENTHESIZED NUMBER FOURTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT FOUR, RIGHT PARENTHESIS# →(14)→
+    {9346, "(l5)"},  // MA#* ( ⒂ → (l5) ) PARENTHESIZED NUMBER FIFTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT FIVE, RIGHT PARENTHESIS# →(15)→
+    {9347, "(l6)"},  // MA#* ( ⒃ → (l6) ) PARENTHESIZED NUMBER SIXTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT SIX, RIGHT PARENTHESIS# →(16)→
+    {9348, "(l7)"},  // MA#* ( ⒄ → (l7) ) PARENTHESIZED NUMBER SEVENTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT SEVEN, RIGHT PARENTHESIS# →(17)→
+    {9349, "(l8)"},  // MA#* ( ⒅ → (l8) ) PARENTHESIZED NUMBER EIGHTEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT EIGHT, RIGHT PARENTHESIS# →(18)→
+    {9350, "(l9)"},  // MA#* ( ⒆ → (l9) ) PARENTHESIZED NUMBER NINETEEN → LEFT PARENTHESIS, LATIN SMALL LETTER L, DIGIT NINE, RIGHT PARENTHESIS# →(19)→
+    {9351, "(2O)"},  // MA#* ( ⒇ → (2O) ) PARENTHESIZED NUMBER TWENTY → LEFT PARENTHESIS, DIGIT TWO, LATIN CAPITAL LETTER O, RIGHT PARENTHESIS# →(20)→
+    {9352, "l."},    // MA#* ( ⒈ → l. ) DIGIT ONE FULL STOP → LATIN SMALL LETTER L, FULL STOP# →1.→
+    {9353, "2."},    // MA#* ( ⒉ → 2. ) DIGIT TWO FULL STOP → DIGIT TWO, FULL STOP#
+    {9354, "3."},    // MA#* ( ⒊ → 3. ) DIGIT THREE FULL STOP → DIGIT THREE, FULL STOP#
+    {9355, "4."},    // MA#* ( ⒋ → 4. ) DIGIT FOUR FULL STOP → DIGIT FOUR, FULL STOP#
+    {9356, "5."},    // MA#* ( ⒌ → 5. ) DIGIT FIVE FULL STOP → DIGIT FIVE, FULL STOP#
+    {9357, "6."},    // MA#* ( ⒍ → 6. ) DIGIT SIX FULL STOP → DIGIT SIX, FULL STOP#
+    {9358, "7."},    // MA#* ( ⒎ → 7. ) DIGIT SEVEN FULL STOP → DIGIT SEVEN, FULL STOP#
+    {9359, "8."},    // MA#* ( ⒏ → 8. ) DIGIT EIGHT FULL STOP → DIGIT EIGHT, FULL STOP#
+    {9360, "9."},    // MA#* ( ⒐ → 9. ) DIGIT NINE FULL STOP → DIGIT NINE, FULL STOP#
+    {9361, "lO."},   // MA#* ( ⒑ → lO. ) NUMBER TEN FULL STOP → LATIN SMALL LETTER L, LATIN CAPITAL LETTER O, FULL STOP# →10.→
+    {9362, "ll."},   // MA#* ( ⒒ → ll. ) NUMBER ELEVEN FULL STOP → LATIN SMALL LETTER L, LATIN SMALL LETTER L, FULL STOP# →11.→
+    {9363, "l2."},   // MA#* ( ⒓ → l2. ) NUMBER TWELVE FULL STOP → LATIN SMALL LETTER L, DIGIT TWO, FULL STOP# →12.→
+    {9364, "l3."},   // MA#* ( ⒔ → l3. ) NUMBER THIRTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT THREE, FULL STOP# →13.→
+    {9365, "l4."},   // MA#* ( ⒕ → l4. ) NUMBER FOURTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT FOUR, FULL STOP# →14.→
+    {9366, "l5."},   // MA#* ( ⒖ → l5. ) NUMBER FIFTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT FIVE, FULL STOP# →15.→
+    {9367, "l6."},   // MA#* ( ⒗ → l6. ) NUMBER SIXTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT SIX, FULL STOP# →16.→
+    {9368, "l7."},   // MA#* ( ⒘ → l7. ) NUMBER SEVENTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT SEVEN, FULL STOP# →17.→
+    {9369, "l8."},   // MA#* ( ⒙ → l8. ) NUMBER EIGHTEEN FULL STOP → LATIN SMALL LETTER L, DIGIT EIGHT, FULL STOP# →18.→
+    {9370, "l9."},   // MA#* ( ⒚ → l9. ) NUMBER NINETEEN FULL STOP → LATIN SMALL LETTER L, DIGIT NINE, FULL STOP# →19.→
+    {9371, "2O."},   // MA#* ( ⒛ → 2O. ) NUMBER TWENTY FULL STOP → DIGIT TWO, LATIN CAPITAL LETTER O, FULL STOP# →20.→
+    {9372, "(a)"},   // MA#* ( ⒜ → (a) ) PARENTHESIZED LATIN SMALL LETTER A → LEFT PARENTHESIS, LATIN SMALL LETTER A, RIGHT PARENTHESIS#
+    {9373, "(b)"},   // MA#* ( ⒝ → (b) ) PARENTHESIZED LATIN SMALL LETTER B → LEFT PARENTHESIS, LATIN SMALL LETTER B, RIGHT PARENTHESIS#
+    {9374, "(c)"},   // MA#* ( ⒞ → (c) ) PARENTHESIZED LATIN SMALL LETTER C → LEFT PARENTHESIS, LATIN SMALL LETTER C, RIGHT PARENTHESIS#
+    {9375, "(d)"},   // MA#* ( ⒟ → (d) ) PARENTHESIZED LATIN SMALL LETTER D → LEFT PARENTHESIS, LATIN SMALL LETTER D, RIGHT PARENTHESIS#
+    {9376, "(e)"},   // MA#* ( ⒠ → (e) ) PARENTHESIZED LATIN SMALL LETTER E → LEFT PARENTHESIS, LATIN SMALL LETTER E, RIGHT PARENTHESIS#
+    {9377, "(f)"},   // MA#* ( ⒡ → (f) ) PARENTHESIZED LATIN SMALL LETTER F → LEFT PARENTHESIS, LATIN SMALL LETTER F, RIGHT PARENTHESIS#
+    {9378, "(g)"},   // MA#* ( ⒢ → (g) ) PARENTHESIZED LATIN SMALL LETTER G → LEFT PARENTHESIS, LATIN SMALL LETTER G, RIGHT PARENTHESIS#
+    {9379, "(h)"},   // MA#* ( ⒣ → (h) ) PARENTHESIZED LATIN SMALL LETTER H → LEFT PARENTHESIS, LATIN SMALL LETTER H, RIGHT PARENTHESIS#
+    {9380, "(i)"},   // MA#* ( ⒤ → (i) ) PARENTHESIZED LATIN SMALL LETTER I → LEFT PARENTHESIS, LATIN SMALL LETTER I, RIGHT PARENTHESIS#
+    {9381, "(j)"},   // MA#* ( ⒥ → (j) ) PARENTHESIZED LATIN SMALL LETTER J → LEFT PARENTHESIS, LATIN SMALL LETTER J, RIGHT PARENTHESIS#
+    {9382, "(k)"},   // MA#* ( ⒦ → (k) ) PARENTHESIZED LATIN SMALL LETTER K → LEFT PARENTHESIS, LATIN SMALL LETTER K, RIGHT PARENTHESIS#
+    {9383, "(l)"},   // MA#* ( ⒧ → (l) ) PARENTHESIZED LATIN SMALL LETTER L → LEFT PARENTHESIS, LATIN SMALL LETTER L, RIGHT PARENTHESIS#
+    {9384, "(rn)"},  // MA#* ( ⒨ → (rn) ) PARENTHESIZED LATIN SMALL LETTER M → LEFT PARENTHESIS, LATIN SMALL LETTER R, LATIN SMALL LETTER N, RIGHT PARENTHESIS# →(m)→
+    {9385, "(n)"},   // MA#* ( ⒩ → (n) ) PARENTHESIZED LATIN SMALL LETTER N → LEFT PARENTHESIS, LATIN SMALL LETTER N, RIGHT PARENTHESIS#
+    {9386, "(o)"},   // MA#* ( ⒪ → (o) ) PARENTHESIZED LATIN SMALL LETTER O → LEFT PARENTHESIS, LATIN SMALL LETTER O, RIGHT PARENTHESIS#
+    {9387, "(p)"},   // MA#* ( ⒫ → (p) ) PARENTHESIZED LATIN SMALL LETTER P → LEFT PARENTHESIS, LATIN SMALL LETTER P, RIGHT PARENTHESIS#
+    {9388, "(q)"},   // MA#* ( ⒬ → (q) ) PARENTHESIZED LATIN SMALL LETTER Q → LEFT PARENTHESIS, LATIN SMALL LETTER Q, RIGHT PARENTHESIS#
+    {9389, "(r)"},   // MA#* ( ⒭ → (r) ) PARENTHESIZED LATIN SMALL LETTER R → LEFT PARENTHESIS, LATIN SMALL LETTER R, RIGHT PARENTHESIS#
+    {9390, "(s)"},   // MA#* ( ⒮ → (s) ) PARENTHESIZED LATIN SMALL LETTER S → LEFT PARENTHESIS, LATIN SMALL LETTER S, RIGHT PARENTHESIS#
+    {9391, "(t)"},   // MA#* ( ⒯ → (t) ) PARENTHESIZED LATIN SMALL LETTER T → LEFT PARENTHESIS, LATIN SMALL LETTER T, RIGHT PARENTHESIS#
+    {9392, "(u)"},   // MA#* ( ⒰ → (u) ) PARENTHESIZED LATIN SMALL LETTER U → LEFT PARENTHESIS, LATIN SMALL LETTER U, RIGHT PARENTHESIS#
+    {9393, "(v)"},   // MA#* ( ⒱ → (v) ) PARENTHESIZED LATIN SMALL LETTER V → LEFT PARENTHESIS, LATIN SMALL LETTER V, RIGHT PARENTHESIS#
+    {9394, "(w)"},   // MA#* ( ⒲ → (w) ) PARENTHESIZED LATIN SMALL LETTER W → LEFT PARENTHESIS, LATIN SMALL LETTER W, RIGHT PARENTHESIS#
+    {9395, "(x)"},   // MA#* ( ⒳ → (x) ) PARENTHESIZED LATIN SMALL LETTER X → LEFT PARENTHESIS, LATIN SMALL LETTER X, RIGHT PARENTHESIS#
+    {9396, "(y)"},   // MA#* ( ⒴ → (y) ) PARENTHESIZED LATIN SMALL LETTER Y → LEFT PARENTHESIS, LATIN SMALL LETTER Y, RIGHT PARENTHESIS#
+    {9397, "(z)"},   // MA#* ( ⒵ → (z) ) PARENTHESIZED LATIN SMALL LETTER Z → LEFT PARENTHESIS, LATIN SMALL LETTER Z, RIGHT PARENTHESIS#
+    {9585, "/"},     // MA#* ( ╱ → / ) BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT → SOLIDUS#
+    {9587, "X"},     // MA#* ( ╳ → X ) BOX DRAWINGS LIGHT DIAGONAL CROSS → LATIN CAPITAL LETTER X#
+    {10088, "("},    // MA#* ( ❨ → ( ) MEDIUM LEFT PARENTHESIS ORNAMENT → LEFT PARENTHESIS#
+    {10089, ")"},    // MA#* ( ❩ → ) ) MEDIUM RIGHT PARENTHESIS ORNAMENT → RIGHT PARENTHESIS#
+    {10094, "<"},    // MA#* ( ❮ → < ) HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT → LESS-THAN SIGN# →‹→
+    {10095, ">"},    // MA#* ( ❯ → > ) HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT → GREATER-THAN SIGN# →›→
+    {10098, "("},    // MA#* ( ❲ → ( ) LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT → LEFT PARENTHESIS# →〔→
+    {10099, ")"},    // MA#* ( ❳ → ) ) LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT → RIGHT PARENTHESIS# →〕→
+    {10100, "{"},    // MA#* ( ❴ → { ) MEDIUM LEFT CURLY BRACKET ORNAMENT → LEFT CURLY BRACKET#
+    {10101, "}"},    // MA#* ( ❵ → } ) MEDIUM RIGHT CURLY BRACKET ORNAMENT → RIGHT CURLY BRACKET#
+    {10133, "+"},    // MA#* ( ➕ → + ) HEAVY PLUS SIGN → PLUS SIGN#
+    {10134, "-"},    // MA#* ( ➖ → - ) HEAVY MINUS SIGN → HYPHEN-MINUS# →−→
+    {10187, "/"},    // MA#* ( ⟋ → / ) MATHEMATICAL RISING DIAGONAL → SOLIDUS#
+    {10189, "\\"},   // MA#* ( ⟍ → \ ) MATHEMATICAL FALLING DIAGONAL → REVERSE SOLIDUS#
+    {10201, "T"},    // MA#* ( ⟙ → T ) LARGE DOWN TACK → LATIN CAPITAL LETTER T#
+    {10539, "x"},    // MA#* ( ⤫ → x ) RISING DIAGONAL CROSSING FALLING DIAGONAL → LATIN SMALL LETTER X#
+    {10540, "x"},    // MA#* ( ⤬ → x ) FALLING DIAGONAL CROSSING RISING DIAGONAL → LATIN SMALL LETTER X#
+    {10741, "\\"},   // MA#* ( ⧵ → \ ) REVERSE SOLIDUS OPERATOR → REVERSE SOLIDUS#
+    {10744, "/"},    // MA#* ( ⧸ → / ) BIG SOLIDUS → SOLIDUS#
+    {10745, "\\"},   // MA#* ( ⧹ → \ ) BIG REVERSE SOLIDUS → REVERSE SOLIDUS#
+    {10784, ">>"},   // MA#* ( ⨠ → >> ) Z NOTATION SCHEMA PIPING → GREATER-THAN SIGN, GREATER-THAN SIGN# →≫→
+    {10799, "x"},    // MA#* ( ⨯ → x ) VECTOR OR CROSS PRODUCT → LATIN SMALL LETTER X# →×→
+    {10868, "::="},  // MA#* ( ⩴ → ::= ) DOUBLE COLON EQUAL → COLON, COLON, EQUALS SIGN#
+    {10869, "=="},   // MA#* ( ⩵ → == ) TWO CONSECUTIVE EQUALS SIGNS → EQUALS SIGN, EQUALS SIGN#
+    {10870, "==="},  // MA#* ( ⩶ → === ) THREE CONSECUTIVE EQUALS SIGNS → EQUALS SIGN, EQUALS SIGN, EQUALS SIGN#
+    {10917, "><"},   // MA#* ( ⪥ → >< ) GREATER-THAN BESIDE LESS-THAN → GREATER-THAN SIGN, LESS-THAN SIGN#
+    {11003, "///"},  // MA#* ( ⫻ → /// ) TRIPLE SOLIDUS BINARY RELATION → SOLIDUS, SOLIDUS, SOLIDUS#
+    {11005, "//"},   // MA#* ( ⫽ → // ) DOUBLE SOLIDUS OPERATOR → SOLIDUS, SOLIDUS#
+    {11397, "r"},    // MA# ( ⲅ → r ) COPTIC SMALL LETTER GAMMA → LATIN SMALL LETTER R# →г→
+    {11406, "H"},    // MA# ( Ⲏ → H ) COPTIC CAPITAL LETTER HATE → LATIN CAPITAL LETTER H# →Η→
+    {11410, "l"},    // MA# ( Ⲓ → l ) COPTIC CAPITAL LETTER IAUDA → LATIN SMALL LETTER L# →Ӏ→
+    {11412, "K"},    // MA# ( Ⲕ → K ) COPTIC CAPITAL LETTER KAPA → LATIN CAPITAL LETTER K# →Κ→
+    {11416, "M"},    // MA# ( Ⲙ → M ) COPTIC CAPITAL LETTER MI → LATIN CAPITAL LETTER M#
+    {11418, "N"},    // MA# ( Ⲛ → N ) COPTIC CAPITAL LETTER NI → LATIN CAPITAL LETTER N#
+    {11422, "O"},    // MA# ( Ⲟ → O ) COPTIC CAPITAL LETTER O → LATIN CAPITAL LETTER O#
+    {11423, "o"},    // MA# ( ⲟ → o ) COPTIC SMALL LETTER O → LATIN SMALL LETTER O#
+    {11426, "P"},    // MA# ( Ⲣ → P ) COPTIC CAPITAL LETTER RO → LATIN CAPITAL LETTER P#
+    {11427, "p"},    // MA# ( ⲣ → p ) COPTIC SMALL LETTER RO → LATIN SMALL LETTER P# →ρ→
+    {11428, "C"},    // MA# ( Ⲥ → C ) COPTIC CAPITAL LETTER SIMA → LATIN CAPITAL LETTER C# →Ϲ→
+    {11429, "c"},    // MA# ( ⲥ → c ) COPTIC SMALL LETTER SIMA → LATIN SMALL LETTER C# →ϲ→
+    {11430, "T"},    // MA# ( Ⲧ → T ) COPTIC CAPITAL LETTER TAU → LATIN CAPITAL LETTER T#
+    {11432, "Y"},    // MA# ( Ⲩ → Y ) COPTIC CAPITAL LETTER UA → LATIN CAPITAL LETTER Y#
+    {11436, "X"},    // MA# ( Ⲭ → X ) COPTIC CAPITAL LETTER KHI → LATIN CAPITAL LETTER X# →Х→
+    {11450, "-"},    // MA# ( Ⲻ → - ) COPTIC CAPITAL LETTER DIALECT-P NI → HYPHEN-MINUS# →‒→
+    {11462, "/"},    // MA# ( Ⳇ → / ) COPTIC CAPITAL LETTER OLD COPTIC ESH → SOLIDUS#
+    {11466, "9"},    // MA# ( Ⳋ → 9 ) COPTIC CAPITAL LETTER DIALECT-P HORI → DIGIT NINE#
+    {11468, "3"},    // MA# ( Ⳍ → 3 ) COPTIC CAPITAL LETTER OLD COPTIC HORI → DIGIT THREE# →Ȝ→→Ʒ→
+    {11472, "L"},    // MA# ( Ⳑ → L ) COPTIC CAPITAL LETTER L-SHAPED HA → LATIN CAPITAL LETTER L#
+    {11474, "6"},    // MA# ( Ⳓ → 6 ) COPTIC CAPITAL LETTER OLD COPTIC HEI → DIGIT SIX#
+    {11513, "\\\\"}, // MA#* ( ⳹ → \\ ) COPTIC OLD NUBIAN FULL STOP → REVERSE SOLIDUS, REVERSE SOLIDUS#
+    {11576, "V"},    // MA# ( ⴸ → V ) TIFINAGH LETTER YADH → LATIN CAPITAL LETTER V#
+    {11577, "E"},    // MA# ( ⴹ → E ) TIFINAGH LETTER YADD → LATIN CAPITAL LETTER E#
+    {11599, "l"},    // MA# ( ⵏ → l ) TIFINAGH LETTER YAN → LATIN SMALL LETTER L# →Ӏ→
+    {11601, "!"},    // MA# ( ⵑ → ! ) TIFINAGH LETTER TUAREG YANG → EXCLAMATION MARK#
+    {11604, "O"},    // MA# ( ⵔ → O ) TIFINAGH LETTER YAR → LATIN CAPITAL LETTER O#
+    {11605, "Q"},    // MA# ( ⵕ → Q ) TIFINAGH LETTER YARR → LATIN CAPITAL LETTER Q#
+    {11613, "X"},    // MA# ( ⵝ → X ) TIFINAGH LETTER YATH → LATIN CAPITAL LETTER X#
+    {11816, "(("},   // MA#* ( ⸨ → (( ) LEFT DOUBLE PARENTHESIS → LEFT PARENTHESIS, LEFT PARENTHESIS#
+    {11817, "))"},   // MA#* ( ⸩ → )) ) RIGHT DOUBLE PARENTHESIS → RIGHT PARENTHESIS, RIGHT PARENTHESIS#
+    {11840, "="},    // MA#* ( ⹀ → = ) DOUBLE HYPHEN → EQUALS SIGN#
+    {12034, "\\"},   // MA#* ( ⼂ → \ ) KANGXI RADICAL DOT → REVERSE SOLIDUS#
+    {12035, "/"},    // MA#* ( ⼃ → / ) KANGXI RADICAL SLASH → SOLIDUS#
+    {12291, "\""},   // MA#* ( 〃 → '' ) DITTO MARK → APOSTROPHE, APOSTROPHE# →″→→"→# Converted to a quote.
+    {12295, "O"},    // MA# ( 〇 → O ) IDEOGRAPHIC NUMBER ZERO → LATIN CAPITAL LETTER O#
+    {12308, "("},    // MA#* ( 〔 → ( ) LEFT TORTOISE SHELL BRACKET → LEFT PARENTHESIS#
+    {12309, ")"},    // MA#* ( 〕 → ) ) RIGHT TORTOISE SHELL BRACKET → RIGHT PARENTHESIS#
+    {12339, "/"},    // MA# ( 〳 → / ) VERTICAL KANA REPEAT MARK UPPER HALF → SOLIDUS#
+    {12448, "="},    // MA#* ( ゠ → = ) KATAKANA-HIRAGANA DOUBLE HYPHEN → EQUALS SIGN#
+    {12494, "/"},    // MA# ( ノ → / ) KATAKANA LETTER NO → SOLIDUS# →⼃→
+    {12755, "/"},    // MA#* ( ㇓ → / ) CJK STROKE SP → SOLIDUS# →⼃→
+    {12756, "\\"},   // MA#* ( ㇔ → \ ) CJK STROKE D → REVERSE SOLIDUS# →⼂→
+    {20022, "\\"},   // MA# ( 丶 → \ ) CJK UNIFIED IDEOGRAPH-4E36 → REVERSE SOLIDUS# →⼂→
+    {20031, "/"},    // MA# ( 丿 → / ) CJK UNIFIED IDEOGRAPH-4E3F → SOLIDUS# →⼃→
+    {42192, "B"},    // MA# ( ꓐ → B ) LISU LETTER BA → LATIN CAPITAL LETTER B#
+    {42193, "P"},    // MA# ( ꓑ → P ) LISU LETTER PA → LATIN CAPITAL LETTER P#
+    {42194, "d"},    // MA# ( ꓒ → d ) LISU LETTER PHA → LATIN SMALL LETTER D#
+    {42195, "D"},    // MA# ( ꓓ → D ) LISU LETTER DA → LATIN CAPITAL LETTER D#
+    {42196, "T"},    // MA# ( ꓔ → T ) LISU LETTER TA → LATIN CAPITAL LETTER T#
+    {42198, "G"},    // MA# ( ꓖ → G ) LISU LETTER GA → LATIN CAPITAL LETTER G#
+    {42199, "K"},    // MA# ( ꓗ → K ) LISU LETTER KA → LATIN CAPITAL LETTER K#
+    {42201, "J"},    // MA# ( ꓙ → J ) LISU LETTER JA → LATIN CAPITAL LETTER J#
+    {42202, "C"},    // MA# ( ꓚ → C ) LISU LETTER CA → LATIN CAPITAL LETTER C#
+    {42204, "Z"},    // MA# ( ꓜ → Z ) LISU LETTER DZA → LATIN CAPITAL LETTER Z#
+    {42205, "F"},    // MA# ( ꓝ → F ) LISU LETTER TSA → LATIN CAPITAL LETTER F#
+    {42207, "M"},    // MA# ( ꓟ → M ) LISU LETTER MA → LATIN CAPITAL LETTER M#
+    {42208, "N"},    // MA# ( ꓠ → N ) LISU LETTER NA → LATIN CAPITAL LETTER N#
+    {42209, "L"},    // MA# ( ꓡ → L ) LISU LETTER LA → LATIN CAPITAL LETTER L#
+    {42210, "S"},    // MA# ( ꓢ → S ) LISU LETTER SA → LATIN CAPITAL LETTER S#
+    {42211, "R"},    // MA# ( ꓣ → R ) LISU LETTER ZHA → LATIN CAPITAL LETTER R#
+    {42214, "V"},    // MA# ( ꓦ → V ) LISU LETTER HA → LATIN CAPITAL LETTER V#
+    {42215, "H"},    // MA# ( ꓧ → H ) LISU LETTER XA → LATIN CAPITAL LETTER H#
+    {42218, "W"},    // MA# ( ꓪ → W ) LISU LETTER WA → LATIN CAPITAL LETTER W#
+    {42219, "X"},    // MA# ( ꓫ → X ) LISU LETTER SHA → LATIN CAPITAL LETTER X#
+    {42220, "Y"},    // MA# ( ꓬ → Y ) LISU LETTER YA → LATIN CAPITAL LETTER Y#
+    {42222, "A"},    // MA# ( ꓮ → A ) LISU LETTER A → LATIN CAPITAL LETTER A#
+    {42224, "E"},    // MA# ( ꓰ → E ) LISU LETTER E → LATIN CAPITAL LETTER E#
+    {42226, "l"},    // MA# ( ꓲ → l ) LISU LETTER I → LATIN SMALL LETTER L# →I→
+    {42227, "O"},    // MA# ( ꓳ → O ) LISU LETTER O → LATIN CAPITAL LETTER O#
+    {42228, "U"},    // MA# ( ꓴ → U ) LISU LETTER U → LATIN CAPITAL LETTER U#
+    {42232, "."},    // MA# ( ꓸ → . ) LISU LETTER TONE MYA TI → FULL STOP#
+    {42233, ","},    // MA# ( ꓹ → , ) LISU LETTER TONE NA PO → COMMA#
+    {42234, ".."},   // MA# ( ꓺ → .. ) LISU LETTER TONE MYA CYA → FULL STOP, FULL STOP#
+    {42235, ".,"},   // MA# ( ꓻ → ., ) LISU LETTER TONE MYA BO → FULL STOP, COMMA#
+    {42237, ":"},    // MA# ( ꓽ → : ) LISU LETTER TONE MYA JEU → COLON#
+    {42238, "-."},   // MA#* ( ꓾ → -. ) LISU PUNCTUATION COMMA → HYPHEN-MINUS, FULL STOP#
+    {42239, "="},    // MA#* ( ꓿ → = ) LISU PUNCTUATION FULL STOP → EQUALS SIGN#
+    {42510, "."},    // MA#* ( ꘎ → . ) VAI FULL STOP → FULL STOP#
+    {42564, "2"},    // MA# ( Ꙅ → 2 ) CYRILLIC CAPITAL LETTER REVERSED DZE → DIGIT TWO# →Ƨ→
+    {42567, "i"},    // MA# ( ꙇ → i ) CYRILLIC SMALL LETTER IOTA → LATIN SMALL LETTER I# →ι→
+    {42648, "OO"},   // MA# ( Ꚙ → OO ) CYRILLIC CAPITAL LETTER DOUBLE O → LATIN CAPITAL LETTER O, LATIN CAPITAL LETTER O#
+    {42649, "oo"},   // MA# ( ꚙ → oo ) CYRILLIC SMALL LETTER DOUBLE O → LATIN SMALL LETTER O, LATIN SMALL LETTER O#
+    {42719, "V"},    // MA# ( ꛟ → V ) BAMUM LETTER KO → LATIN CAPITAL LETTER V#
+    {42731, "?"},    // MA# ( ꛫ → ? ) BAMUM LETTER NTUU → QUESTION MARK# →ʔ→
+    {42735, "2"},    // MA# ( ꛯ → 2 ) BAMUM LETTER KOGHOM → DIGIT TWO# →Ƨ→
+    {42792, "T3"},   // MA# ( Ꜩ → T3 ) LATIN CAPITAL LETTER TZ → LATIN CAPITAL LETTER T, DIGIT THREE# →TƷ→
+    {42801, "s"},    // MA# ( ꜱ → s ) LATIN LETTER SMALL CAPITAL S → LATIN SMALL LETTER S#
+    {42802, "AA"},   // MA# ( Ꜳ → AA ) LATIN CAPITAL LETTER AA → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER A#
+    {42803, "aa"},   // MA# ( ꜳ → aa ) LATIN SMALL LETTER AA → LATIN SMALL LETTER A, LATIN SMALL LETTER A#
+    {42804, "AO"},   // MA# ( Ꜵ → AO ) LATIN CAPITAL LETTER AO → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER O#
+    {42805, "ao"},   // MA# ( ꜵ → ao ) LATIN SMALL LETTER AO → LATIN SMALL LETTER A, LATIN SMALL LETTER O#
+    {42806, "AU"},   // MA# ( Ꜷ → AU ) LATIN CAPITAL LETTER AU → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER U#
+    {42807, "au"},   // MA# ( ꜷ → au ) LATIN SMALL LETTER AU → LATIN SMALL LETTER A, LATIN SMALL LETTER U#
+    {42808, "AV"},   // MA# ( Ꜹ → AV ) LATIN CAPITAL LETTER AV → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER V#
+    {42809, "av"},   // MA# ( ꜹ → av ) LATIN SMALL LETTER AV → LATIN SMALL LETTER A, LATIN SMALL LETTER V#
+    {42810, "AV"},   // MA# ( Ꜻ → AV ) LATIN CAPITAL LETTER AV WITH HORIZONTAL BAR → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER V#
+    {42811, "av"},   // MA# ( ꜻ → av ) LATIN SMALL LETTER AV WITH HORIZONTAL BAR → LATIN SMALL LETTER A, LATIN SMALL LETTER V#
+    {42812, "AY"},   // MA# ( Ꜽ → AY ) LATIN CAPITAL LETTER AY → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER Y#
+    {42813, "ay"},   // MA# ( ꜽ → ay ) LATIN SMALL LETTER AY → LATIN SMALL LETTER A, LATIN SMALL LETTER Y#
+    {42830, "OO"},   // MA# ( Ꝏ → OO ) LATIN CAPITAL LETTER OO → LATIN CAPITAL LETTER O, LATIN CAPITAL LETTER O#
+    {42831, "oo"},   // MA# ( ꝏ → oo ) LATIN SMALL LETTER OO → LATIN SMALL LETTER O, LATIN SMALL LETTER O#
+    {42842, "2"},    // MA# ( Ꝛ → 2 ) LATIN CAPITAL LETTER R ROTUNDA → DIGIT TWO#
+    {42858, "3"},    // MA# ( Ꝫ → 3 ) LATIN CAPITAL LETTER ET → DIGIT THREE#
+    {42862, "9"},    // MA# ( Ꝯ → 9 ) LATIN CAPITAL LETTER CON → DIGIT NINE#
+    {42871, "tf"},   // MA# ( ꝷ → tf ) LATIN SMALL LETTER TUM → LATIN SMALL LETTER T, LATIN SMALL LETTER F#
+    {42872, "&"},    // MA# ( ꝸ → & ) LATIN SMALL LETTER UM → AMPERSAND#
+    {42889, ":"},    // MA#* ( ꞉ → : ) MODIFIER LETTER COLON → COLON#
+    {42892, "'"},    // MA# ( ꞌ → ' ) LATIN SMALL LETTER SALTILLO → APOSTROPHE#
+    {42904, "F"},    // MA# ( Ꞙ → F ) LATIN CAPITAL LETTER F WITH STROKE → LATIN CAPITAL LETTER F#
+    {42905, "f"},    // MA# ( ꞙ → f ) LATIN SMALL LETTER F WITH STROKE → LATIN SMALL LETTER F#
+    {42911, "u"},    // MA# ( ꞟ → u ) LATIN SMALL LETTER VOLAPUK UE → LATIN SMALL LETTER U#
+    {42923, "3"},    // MA# ( Ɜ → 3 ) LATIN CAPITAL LETTER REVERSED OPEN E → DIGIT THREE#
+    {42930, "J"},    // MA# ( Ʝ → J ) LATIN CAPITAL LETTER J WITH CROSSED-TAIL → LATIN CAPITAL LETTER J#
+    {42931, "X"},    // MA# ( Ꭓ → X ) LATIN CAPITAL LETTER CHI → LATIN CAPITAL LETTER X#
+    {42932, "B"},    // MA# ( Ꞵ → B ) LATIN CAPITAL LETTER BETA → LATIN CAPITAL LETTER B#
+    {43826, "e"},    // MA# ( ꬲ → e ) LATIN SMALL LETTER BLACKLETTER E → LATIN SMALL LETTER E#
+    {43829, "f"},    // MA# ( ꬵ → f ) LATIN SMALL LETTER LENIS F → LATIN SMALL LETTER F#
+    {43837, "o"},    // MA# ( ꬽ → o ) LATIN SMALL LETTER BLACKLETTER O → LATIN SMALL LETTER O#
+    {43847, "r"},    // MA# ( ꭇ → r ) LATIN SMALL LETTER R WITHOUT HANDLE → LATIN SMALL LETTER R#
+    {43848, "r"},    // MA# ( ꭈ → r ) LATIN SMALL LETTER DOUBLE R → LATIN SMALL LETTER R#
+    {43854, "u"},    // MA# ( ꭎ → u ) LATIN SMALL LETTER U WITH SHORT RIGHT LEG → LATIN SMALL LETTER U#
+    {43858, "u"},    // MA# ( ꭒ → u ) LATIN SMALL LETTER U WITH LEFT HOOK → LATIN SMALL LETTER U#
+    {43866, "y"},    // MA# ( ꭚ → y ) LATIN SMALL LETTER Y WITH SHORT RIGHT LEG → LATIN SMALL LETTER Y#
+    {43875, "uo"},   // MA# ( ꭣ → uo ) LATIN SMALL LETTER UO → LATIN SMALL LETTER U, LATIN SMALL LETTER O#
+    {43893, "i"},    // MA# ( ꭵ → i ) CHEROKEE SMALL LETTER V → LATIN SMALL LETTER I#
+    {43905, "r"},    // MA# ( ꮁ → r ) CHEROKEE SMALL LETTER HU → LATIN SMALL LETTER R# →ᴦ→→г→
+    {43907, "w"},    // MA# ( ꮃ → w ) CHEROKEE SMALL LETTER LA → LATIN SMALL LETTER W# →ᴡ→
+    {43923, "z"},    // MA# ( ꮓ → z ) CHEROKEE SMALL LETTER NO → LATIN SMALL LETTER Z# →ᴢ→
+    {43945, "v"},    // MA# ( ꮩ → v ) CHEROKEE SMALL LETTER DO → LATIN SMALL LETTER V# →ᴠ→
+    {43946, "s"},    // MA# ( ꮪ → s ) CHEROKEE SMALL LETTER DU → LATIN SMALL LETTER S# →ꜱ→
+    {43951, "c"},    // MA# ( ꮯ → c ) CHEROKEE SMALL LETTER TLI → LATIN SMALL LETTER C# →ᴄ→
+    {64256, "ff"},   // MA# ( ﬀ → ff ) LATIN SMALL LIGATURE FF → LATIN SMALL LETTER F, LATIN SMALL LETTER F#
+    {64257, "fi"},   // MA# ( ﬁ → fi ) LATIN SMALL LIGATURE FI → LATIN SMALL LETTER F, LATIN SMALL LETTER I#
+    {64258, "fl"},   // MA# ( ﬂ → fl ) LATIN SMALL LIGATURE FL → LATIN SMALL LETTER F, LATIN SMALL LETTER L#
+    {64259, "ffi"},  // MA# ( ﬃ → ffi ) LATIN SMALL LIGATURE FFI → LATIN SMALL LETTER F, LATIN SMALL LETTER F, LATIN SMALL LETTER I#
+    {64260, "ffl"},  // MA# ( ﬄ → ffl ) LATIN SMALL LIGATURE FFL → LATIN SMALL LETTER F, LATIN SMALL LETTER F, LATIN SMALL LETTER L#
+    {64262, "st"},   // MA# ( ﬆ → st ) LATIN SMALL LIGATURE ST → LATIN SMALL LETTER S, LATIN SMALL LETTER T#
+    {64422, "o"},    // MA# ( ‎ﮦ‎ → o ) ARABIC LETTER HEH GOAL ISOLATED FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {64423, "o"},    // MA# ( ‎ﮧ‎ → o ) ARABIC LETTER HEH GOAL FINAL FORM → LATIN SMALL LETTER O# →‎ہ‎→→‎ه‎→
+    {64424, "o"},    // MA# ( ‎ﮨ‎ → o ) ARABIC LETTER HEH GOAL INITIAL FORM → LATIN SMALL LETTER O# →‎ہ‎→→‎ه‎→
+    {64425, "o"},    // MA# ( ‎ﮩ‎ → o ) ARABIC LETTER HEH GOAL MEDIAL FORM → LATIN SMALL LETTER O# →‎ہ‎→→‎ه‎→
+    {64426, "o"},    // MA# ( ‎ﮪ‎ → o ) ARABIC LETTER HEH DOACHASHMEE ISOLATED FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {64427, "o"},    // MA# ( ‎ﮫ‎ → o ) ARABIC LETTER HEH DOACHASHMEE FINAL FORM → LATIN SMALL LETTER O# →‎ﻪ‎→→‎ه‎→
+    {64428, "o"},    // MA# ( ‎ﮬ‎ → o ) ARABIC LETTER HEH DOACHASHMEE INITIAL FORM → LATIN SMALL LETTER O# →‎ﻫ‎→→‎ه‎→
+    {64429, "o"},    // MA# ( ‎ﮭ‎ → o ) ARABIC LETTER HEH DOACHASHMEE MEDIAL FORM → LATIN SMALL LETTER O# →‎ﻬ‎→→‎ه‎→
+    {64830, "("},    // MA#* ( ﴾ → ( ) ORNATE LEFT PARENTHESIS → LEFT PARENTHESIS#
+    {64831, ")"},    // MA#* ( ﴿ → ) ) ORNATE RIGHT PARENTHESIS → RIGHT PARENTHESIS#
+    {65072, ":"},    // MA#* ( ︰ → : ) PRESENTATION FORM FOR VERTICAL TWO DOT LEADER → COLON#
+    {65101, "_"},    // MA# ( ﹍ → _ ) DASHED LOW LINE → LOW LINE#
+    {65102, "_"},    // MA# ( ﹎ → _ ) CENTRELINE LOW LINE → LOW LINE#
+    {65103, "_"},    // MA# ( ﹏ → _ ) WAVY LOW LINE → LOW LINE#
+    {65112, "-"},    // MA#* ( ﹘ → - ) SMALL EM DASH → HYPHEN-MINUS#
+    {65128, "\\"},   // MA#* ( ﹨ → \ ) SMALL REVERSE SOLIDUS → REVERSE SOLIDUS# →∖→
+    {65165, "l"},    // MA# ( ‎ﺍ‎ → l ) ARABIC LETTER ALEF ISOLATED FORM → LATIN SMALL LETTER L# →‎ا‎→→1→
+    {65166, "l"},    // MA# ( ‎ﺎ‎ → l ) ARABIC LETTER ALEF FINAL FORM → LATIN SMALL LETTER L# →‎ا‎→→1→
+    {65257, "o"},    // MA# ( ‎ﻩ‎ → o ) ARABIC LETTER HEH ISOLATED FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {65258, "o"},    // MA# ( ‎ﻪ‎ → o ) ARABIC LETTER HEH FINAL FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {65259, "o"},    // MA# ( ‎ﻫ‎ → o ) ARABIC LETTER HEH INITIAL FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {65260, "o"},    // MA# ( ‎ﻬ‎ → o ) ARABIC LETTER HEH MEDIAL FORM → LATIN SMALL LETTER O# →‎ه‎→
+    {65281, "!"},    // MA#* ( ！ → ! ) FULLWIDTH EXCLAMATION MARK → EXCLAMATION MARK# →ǃ→
+    {65282, "\""},   // MA#* ( ＂ → '' ) FULLWIDTH QUOTATION MARK → APOSTROPHE, APOSTROPHE# →”→→"→# Converted to a quote.
+    {65287, "'"},    // MA#* ( ＇ → ' ) FULLWIDTH APOSTROPHE → APOSTROPHE# →’→
+    {65306, ":"},    // MA#* ( ： → : ) FULLWIDTH COLON → COLON# →︰→
+    {65313, "A"},    // MA# ( Ａ → A ) FULLWIDTH LATIN CAPITAL LETTER A → LATIN CAPITAL LETTER A# →А→
+    {65314, "B"},    // MA# ( Ｂ → B ) FULLWIDTH LATIN CAPITAL LETTER B → LATIN CAPITAL LETTER B# →Β→
+    {65315, "C"},    // MA# ( Ｃ → C ) FULLWIDTH LATIN CAPITAL LETTER C → LATIN CAPITAL LETTER C# →С→
+    {65317, "E"},    // MA# ( Ｅ → E ) FULLWIDTH LATIN CAPITAL LETTER E → LATIN CAPITAL LETTER E# →Ε→
+    {65320, "H"},    // MA# ( Ｈ → H ) FULLWIDTH LATIN CAPITAL LETTER H → LATIN CAPITAL LETTER H# →Η→
+    {65321, "l"},    // MA# ( Ｉ → l ) FULLWIDTH LATIN CAPITAL LETTER I → LATIN SMALL LETTER L# →Ӏ→
+    {65322, "J"},    // MA# ( Ｊ → J ) FULLWIDTH LATIN CAPITAL LETTER J → LATIN CAPITAL LETTER J# →Ј→
+    {65323, "K"},    // MA# ( Ｋ → K ) FULLWIDTH LATIN CAPITAL LETTER K → LATIN CAPITAL LETTER K# →Κ→
+    {65325, "M"},    // MA# ( Ｍ → M ) FULLWIDTH LATIN CAPITAL LETTER M → LATIN CAPITAL LETTER M# →Μ→
+    {65326, "N"},    // MA# ( Ｎ → N ) FULLWIDTH LATIN CAPITAL LETTER N → LATIN CAPITAL LETTER N# →Ν→
+    {65327, "O"},    // MA# ( Ｏ → O ) FULLWIDTH LATIN CAPITAL LETTER O → LATIN CAPITAL LETTER O# →О→
+    {65328, "P"},    // MA# ( Ｐ → P ) FULLWIDTH LATIN CAPITAL LETTER P → LATIN CAPITAL LETTER P# →Р→
+    {65331, "S"},    // MA# ( Ｓ → S ) FULLWIDTH LATIN CAPITAL LETTER S → LATIN CAPITAL LETTER S# →Ѕ→
+    {65332, "T"},    // MA# ( Ｔ → T ) FULLWIDTH LATIN CAPITAL LETTER T → LATIN CAPITAL LETTER T# →Т→
+    {65336, "X"},    // MA# ( Ｘ → X ) FULLWIDTH LATIN CAPITAL LETTER X → LATIN CAPITAL LETTER X# →Х→
+    {65337, "Y"},    // MA# ( Ｙ → Y ) FULLWIDTH LATIN CAPITAL LETTER Y → LATIN CAPITAL LETTER Y# →Υ→
+    {65338, "Z"},    // MA# ( Ｚ → Z ) FULLWIDTH LATIN CAPITAL LETTER Z → LATIN CAPITAL LETTER Z# →Ζ→
+    {65339, "("},    // MA#* ( ［ → ( ) FULLWIDTH LEFT SQUARE BRACKET → LEFT PARENTHESIS# →〔→
+    {65340, "\\"},   // MA#* ( ＼ → \ ) FULLWIDTH REVERSE SOLIDUS → REVERSE SOLIDUS# →∖→
+    {65341, ")"},    // MA#* ( ］ → ) ) FULLWIDTH RIGHT SQUARE BRACKET → RIGHT PARENTHESIS# →〕→
+    {65344, "'"},    // MA#* ( ｀ → ' ) FULLWIDTH GRAVE ACCENT → APOSTROPHE# →‘→
+    {65345, "a"},    // MA# ( ａ → a ) FULLWIDTH LATIN SMALL LETTER A → LATIN SMALL LETTER A# →а→
+    {65347, "c"},    // MA# ( ｃ → c ) FULLWIDTH LATIN SMALL LETTER C → LATIN SMALL LETTER C# →с→
+    {65349, "e"},    // MA# ( ｅ → e ) FULLWIDTH LATIN SMALL LETTER E → LATIN SMALL LETTER E# →е→
+    {65351, "g"},    // MA# ( ｇ → g ) FULLWIDTH LATIN SMALL LETTER G → LATIN SMALL LETTER G# →ɡ→
+    {65352, "h"},    // MA# ( ｈ → h ) FULLWIDTH LATIN SMALL LETTER H → LATIN SMALL LETTER H# →һ→
+    {65353, "i"},    // MA# ( ｉ → i ) FULLWIDTH LATIN SMALL LETTER I → LATIN SMALL LETTER I# →і→
+    {65354, "j"},    // MA# ( ｊ → j ) FULLWIDTH LATIN SMALL LETTER J → LATIN SMALL LETTER J# →ϳ→
+    {65356, "l"},    // MA# ( ｌ → l ) FULLWIDTH LATIN SMALL LETTER L → LATIN SMALL LETTER L# →Ⅰ→→Ӏ→
+    {65359, "o"},    // MA# ( ｏ → o ) FULLWIDTH LATIN SMALL LETTER O → LATIN SMALL LETTER O# →о→
+    {65360, "p"},    // MA# ( ｐ → p ) FULLWIDTH LATIN SMALL LETTER P → LATIN SMALL LETTER P# →р→
+    {65363, "s"},    // MA# ( ｓ → s ) FULLWIDTH LATIN SMALL LETTER S → LATIN SMALL LETTER S# →ѕ→
+    {65366, "v"},    // MA# ( ｖ → v ) FULLWIDTH LATIN SMALL LETTER V → LATIN SMALL LETTER V# →ν→
+    {65368, "x"},    // MA# ( ｘ → x ) FULLWIDTH LATIN SMALL LETTER X → LATIN SMALL LETTER X# →х→
+    {65369, "y"},    // MA# ( ｙ → y ) FULLWIDTH LATIN SMALL LETTER Y → LATIN SMALL LETTER Y# →у→
+    {65512, "l"},    // MA#* ( ￨ → l ) HALFWIDTH FORMS LIGHT VERTICAL → LATIN SMALL LETTER L# →|→
+    {66178, "B"},    // MA# ( 𐊂 → B ) LYCIAN LETTER B → LATIN CAPITAL LETTER B#
+    {66182, "E"},    // MA# ( 𐊆 → E ) LYCIAN LETTER I → LATIN CAPITAL LETTER E#
+    {66183, "F"},    // MA# ( 𐊇 → F ) LYCIAN LETTER W → LATIN CAPITAL LETTER F#
+    {66186, "l"},    // MA# ( 𐊊 → l ) LYCIAN LETTER J → LATIN SMALL LETTER L# →I→
+    {66192, "X"},    // MA# ( 𐊐 → X ) LYCIAN LETTER MM → LATIN CAPITAL LETTER X#
+    {66194, "O"},    // MA# ( 𐊒 → O ) LYCIAN LETTER U → LATIN CAPITAL LETTER O#
+    {66197, "P"},    // MA# ( 𐊕 → P ) LYCIAN LETTER R → LATIN CAPITAL LETTER P#
+    {66198, "S"},    // MA# ( 𐊖 → S ) LYCIAN LETTER S → LATIN CAPITAL LETTER S#
+    {66199, "T"},    // MA# ( 𐊗 → T ) LYCIAN LETTER T → LATIN CAPITAL LETTER T#
+    {66203, "+"},    // MA# ( 𐊛 → + ) LYCIAN LETTER H → PLUS SIGN#
+    {66208, "A"},    // MA# ( 𐊠 → A ) CARIAN LETTER A → LATIN CAPITAL LETTER A#
+    {66209, "B"},    // MA# ( 𐊡 → B ) CARIAN LETTER P2 → LATIN CAPITAL LETTER B#
+    {66210, "C"},    // MA# ( 𐊢 → C ) CARIAN LETTER D → LATIN CAPITAL LETTER C#
+    {66213, "F"},    // MA# ( 𐊥 → F ) CARIAN LETTER R → LATIN CAPITAL LETTER F#
+    {66219, "O"},    // MA# ( 𐊫 → O ) CARIAN LETTER O → LATIN CAPITAL LETTER O#
+    {66224, "M"},    // MA# ( 𐊰 → M ) CARIAN LETTER S → LATIN CAPITAL LETTER M#
+    {66225, "T"},    // MA# ( 𐊱 → T ) CARIAN LETTER C-18 → LATIN CAPITAL LETTER T#
+    {66226, "Y"},    // MA# ( 𐊲 → Y ) CARIAN LETTER U → LATIN CAPITAL LETTER Y#
+    {66228, "X"},    // MA# ( 𐊴 → X ) CARIAN LETTER X → LATIN CAPITAL LETTER X#
+    {66255, "H"},    // MA# ( 𐋏 → H ) CARIAN LETTER E2 → LATIN CAPITAL LETTER H#
+    {66293, "Z"},    // MA#* ( 𐋵 → Z ) COPTIC EPACT NUMBER THREE HUNDRED → LATIN CAPITAL LETTER Z#
+    {66305, "B"},    // MA# ( 𐌁 → B ) OLD ITALIC LETTER BE → LATIN CAPITAL LETTER B#
+    {66306, "C"},    // MA# ( 𐌂 → C ) OLD ITALIC LETTER KE → LATIN CAPITAL LETTER C#
+    {66313, "l"},    // MA# ( 𐌉 → l ) OLD ITALIC LETTER I → LATIN SMALL LETTER L# →I→
+    {66321, "M"},    // MA# ( 𐌑 → M ) OLD ITALIC LETTER SHE → LATIN CAPITAL LETTER M#
+    {66325, "T"},    // MA# ( 𐌕 → T ) OLD ITALIC LETTER TE → LATIN CAPITAL LETTER T#
+    {66327, "X"},    // MA# ( 𐌗 → X ) OLD ITALIC LETTER EKS → LATIN CAPITAL LETTER X#
+    {66330, "8"},    // MA# ( 𐌚 → 8 ) OLD ITALIC LETTER EF → DIGIT EIGHT#
+    {66335, "*"},    // MA# ( 𐌟 → * ) OLD ITALIC LETTER ESS → ASTERISK#
+    {66336, "l"},    // MA#* ( 𐌠 → l ) OLD ITALIC NUMERAL ONE → LATIN SMALL LETTER L# →𐌉→→I→
+    {66338, "X"},    // MA#* ( 𐌢 → X ) OLD ITALIC NUMERAL TEN → LATIN CAPITAL LETTER X# →𐌗→
+    {66564, "O"},    // MA# ( 𐐄 → O ) DESERET CAPITAL LETTER LONG O → LATIN CAPITAL LETTER O#
+    {66581, "C"},    // MA# ( 𐐕 → C ) DESERET CAPITAL LETTER CHEE → LATIN CAPITAL LETTER C#
+    {66587, "L"},    // MA# ( 𐐛 → L ) DESERET CAPITAL LETTER ETH → LATIN CAPITAL LETTER L#
+    {66592, "S"},    // MA# ( 𐐠 → S ) DESERET CAPITAL LETTER ZHEE → LATIN CAPITAL LETTER S#
+    {66604, "o"},    // MA# ( 𐐬 → o ) DESERET SMALL LETTER LONG O → LATIN SMALL LETTER O#
+    {66621, "c"},    // MA# ( 𐐽 → c ) DESERET SMALL LETTER CHEE → LATIN SMALL LETTER C#
+    {66632, "s"},    // MA# ( 𐑈 → s ) DESERET SMALL LETTER ZHEE → LATIN SMALL LETTER S#
+    {66740, "R"},    // MA# ( 𐒴 → R ) OSAGE CAPITAL LETTER BRA → LATIN CAPITAL LETTER R# →Ʀ→
+    {66754, "O"},    // MA# ( 𐓂 → O ) OSAGE CAPITAL LETTER O → LATIN CAPITAL LETTER O#
+    {66766, "U"},    // MA# ( 𐓎 → U ) OSAGE CAPITAL LETTER U → LATIN CAPITAL LETTER U#
+    {66770, "7"},    // MA# ( 𐓒 → 7 ) OSAGE CAPITAL LETTER ZA → DIGIT SEVEN#
+    {66794, "o"},    // MA# ( 𐓪 → o ) OSAGE SMALL LETTER O → LATIN SMALL LETTER O#
+    {66806, "u"},    // MA# ( 𐓶 → u ) OSAGE SMALL LETTER U → LATIN SMALL LETTER U# →ᴜ→
+    {66835, "N"},    // MA# ( 𐔓 → N ) ELBASAN LETTER NE → LATIN CAPITAL LETTER N#
+    {66838, "O"},    // MA# ( 𐔖 → O ) ELBASAN LETTER O → LATIN CAPITAL LETTER O#
+    {66840, "K"},    // MA# ( 𐔘 → K ) ELBASAN LETTER QE → LATIN CAPITAL LETTER K#
+    {66844, "C"},    // MA# ( 𐔜 → C ) ELBASAN LETTER SHE → LATIN CAPITAL LETTER C#
+    {66845, "V"},    // MA# ( 𐔝 → V ) ELBASAN LETTER TE → LATIN CAPITAL LETTER V#
+    {66853, "F"},    // MA# ( 𐔥 → F ) ELBASAN LETTER GHE → LATIN CAPITAL LETTER F#
+    {66854, "L"},    // MA# ( 𐔦 → L ) ELBASAN LETTER GHAMMA → LATIN CAPITAL LETTER L#
+    {66855, "X"},    // MA# ( 𐔧 → X ) ELBASAN LETTER KHE → LATIN CAPITAL LETTER X#
+    {68176, "."},    // MA#* ( ‎𐩐‎ → . ) KHAROSHTHI PUNCTUATION DOT → FULL STOP#
+    {70864, "O"},    // MA# ( 𑓐 → O ) TIRHUTA DIGIT ZERO → LATIN CAPITAL LETTER O# →০→→0→
+    {71424, "rn"},   // MA# ( 𑜀 → rn ) AHOM LETTER KA → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {71430, "v"},    // MA# ( 𑜆 → v ) AHOM LETTER PA → LATIN SMALL LETTER V#
+    {71434, "w"},    // MA# ( 𑜊 → w ) AHOM LETTER JA → LATIN SMALL LETTER W#
+    {71438, "w"},    // MA# ( 𑜎 → w ) AHOM LETTER LA → LATIN SMALL LETTER W#
+    {71439, "w"},    // MA# ( 𑜏 → w ) AHOM LETTER SA → LATIN SMALL LETTER W#
+    {71840, "V"},    // MA# ( 𑢠 → V ) WARANG CITI CAPITAL LETTER NGAA → LATIN CAPITAL LETTER V#
+    {71842, "F"},    // MA# ( 𑢢 → F ) WARANG CITI CAPITAL LETTER WI → LATIN CAPITAL LETTER F#
+    {71843, "L"},    // MA# ( 𑢣 → L ) WARANG CITI CAPITAL LETTER YU → LATIN CAPITAL LETTER L#
+    {71844, "Y"},    // MA# ( 𑢤 → Y ) WARANG CITI CAPITAL LETTER YA → LATIN CAPITAL LETTER Y#
+    {71846, "E"},    // MA# ( 𑢦 → E ) WARANG CITI CAPITAL LETTER II → LATIN CAPITAL LETTER E#
+    {71849, "Z"},    // MA# ( 𑢩 → Z ) WARANG CITI CAPITAL LETTER O → LATIN CAPITAL LETTER Z#
+    {71852, "9"},    // MA# ( 𑢬 → 9 ) WARANG CITI CAPITAL LETTER KO → DIGIT NINE#
+    {71854, "E"},    // MA# ( 𑢮 → E ) WARANG CITI CAPITAL LETTER YUJ → LATIN CAPITAL LETTER E#
+    {71855, "4"},    // MA# ( 𑢯 → 4 ) WARANG CITI CAPITAL LETTER UC → DIGIT FOUR#
+    {71858, "L"},    // MA# ( 𑢲 → L ) WARANG CITI CAPITAL LETTER TTE → LATIN CAPITAL LETTER L#
+    {71861, "O"},    // MA# ( 𑢵 → O ) WARANG CITI CAPITAL LETTER AT → LATIN CAPITAL LETTER O#
+    {71864, "U"},    // MA# ( 𑢸 → U ) WARANG CITI CAPITAL LETTER PU → LATIN CAPITAL LETTER U#
+    {71867, "5"},    // MA# ( 𑢻 → 5 ) WARANG CITI CAPITAL LETTER HORR → DIGIT FIVE#
+    {71868, "T"},    // MA# ( 𑢼 → T ) WARANG CITI CAPITAL LETTER HAR → LATIN CAPITAL LETTER T#
+    {71872, "v"},    // MA# ( 𑣀 → v ) WARANG CITI SMALL LETTER NGAA → LATIN SMALL LETTER V#
+    {71873, "s"},    // MA# ( 𑣁 → s ) WARANG CITI SMALL LETTER A → LATIN SMALL LETTER S#
+    {71874, "F"},    // MA# ( 𑣂 → F ) WARANG CITI SMALL LETTER WI → LATIN CAPITAL LETTER F#
+    {71875, "i"},    // MA# ( 𑣃 → i ) WARANG CITI SMALL LETTER YU → LATIN SMALL LETTER I# →ι→
+    {71876, "z"},    // MA# ( 𑣄 → z ) WARANG CITI SMALL LETTER YA → LATIN SMALL LETTER Z#
+    {71878, "7"},    // MA# ( 𑣆 → 7 ) WARANG CITI SMALL LETTER II → DIGIT SEVEN#
+    {71880, "o"},    // MA# ( 𑣈 → o ) WARANG CITI SMALL LETTER E → LATIN SMALL LETTER O#
+    {71882, "3"},    // MA# ( 𑣊 → 3 ) WARANG CITI SMALL LETTER ANG → DIGIT THREE#
+    {71884, "9"},    // MA# ( 𑣌 → 9 ) WARANG CITI SMALL LETTER KO → DIGIT NINE#
+    {71893, "6"},    // MA# ( 𑣕 → 6 ) WARANG CITI SMALL LETTER AT → DIGIT SIX#
+    {71894, "9"},    // MA# ( 𑣖 → 9 ) WARANG CITI SMALL LETTER AM → DIGIT NINE#
+    {71895, "o"},    // MA# ( 𑣗 → o ) WARANG CITI SMALL LETTER BU → LATIN SMALL LETTER O#
+    {71896, "u"},    // MA# ( 𑣘 → u ) WARANG CITI SMALL LETTER PU → LATIN SMALL LETTER U# →υ→→ʋ→
+    {71900, "y"},    // MA# ( 𑣜 → y ) WARANG CITI SMALL LETTER HAR → LATIN SMALL LETTER Y# →ɣ→→γ→
+    {71904, "O"},    // MA# ( 𑣠 → O ) WARANG CITI DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {71907, "rn"},   // MA# ( 𑣣 → rn ) WARANG CITI DIGIT THREE → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {71909, "Z"},    // MA# ( 𑣥 → Z ) WARANG CITI DIGIT FIVE → LATIN CAPITAL LETTER Z#
+    {71910, "W"},    // MA# ( 𑣦 → W ) WARANG CITI DIGIT SIX → LATIN CAPITAL LETTER W#
+    {71913, "C"},    // MA# ( 𑣩 → C ) WARANG CITI DIGIT NINE → LATIN CAPITAL LETTER C#
+    {71916, "X"},    // MA#* ( 𑣬 → X ) WARANG CITI NUMBER THIRTY → LATIN CAPITAL LETTER X#
+    {71919, "W"},    // MA#* ( 𑣯 → W ) WARANG CITI NUMBER SIXTY → LATIN CAPITAL LETTER W#
+    {71922, "C"},    // MA#* ( 𑣲 → C ) WARANG CITI NUMBER NINETY → LATIN CAPITAL LETTER C#
+    {93960, "V"},    // MA# ( 𖼈 → V ) MIAO LETTER VA → LATIN CAPITAL LETTER V#
+    {93962, "T"},    // MA# ( 𖼊 → T ) MIAO LETTER TA → LATIN CAPITAL LETTER T#
+    {93974, "L"},    // MA# ( 𖼖 → L ) MIAO LETTER LA → LATIN CAPITAL LETTER L#
+    {93992, "l"},    // MA# ( 𖼨 → l ) MIAO LETTER GHA → LATIN SMALL LETTER L# →I→
+    {94005, "R"},    // MA# ( 𖼵 → R ) MIAO LETTER ZHA → LATIN CAPITAL LETTER R#
+    {94010, "S"},    // MA# ( 𖼺 → S ) MIAO LETTER SA → LATIN CAPITAL LETTER S#
+    {94011, "3"},    // MA# ( 𖼻 → 3 ) MIAO LETTER ZA → DIGIT THREE# →Ʒ→
+    {94015, ">"},    // MA# ( 𖼿 → > ) MIAO LETTER ARCHAIC ZZA → GREATER-THAN SIGN#
+    {94016, "A"},    // MA# ( 𖽀 → A ) MIAO LETTER ZZYA → LATIN CAPITAL LETTER A#
+    {94018, "U"},    // MA# ( 𖽂 → U ) MIAO LETTER WA → LATIN CAPITAL LETTER U#
+    {94019, "Y"},    // MA# ( 𖽃 → Y ) MIAO LETTER AH → LATIN CAPITAL LETTER Y#
+    {94033, "'"},    // MA# ( 𖽑 → ' ) MIAO SIGN ASPIRATION → APOSTROPHE# →ʼ→→′→
+    {94034, "'"},    // MA# ( 𖽒 → ' ) MIAO SIGN REFORMED VOICING → APOSTROPHE# →ʻ→→‘→
+    {119060, "{"},   // MA#* ( 𝄔 → { ) MUSICAL SYMBOL BRACE → LEFT CURLY BRACKET#
+    {119149, "."},   // MA# ( 𝅭 → . ) MUSICAL SYMBOL COMBINING AUGMENTATION DOT → FULL STOP#
+    {119302, "3"},   // MA#* ( 𝈆 → 3 ) GREEK VOCAL NOTATION SYMBOL-7 → DIGIT THREE#
+    {119309, "V"},   // MA#* ( 𝈍 → V ) GREEK VOCAL NOTATION SYMBOL-14 → LATIN CAPITAL LETTER V#
+    {119311, "\\"},  // MA#* ( 𝈏 → \ ) GREEK VOCAL NOTATION SYMBOL-16 → REVERSE SOLIDUS#
+    {119314, "7"},   // MA#* ( 𝈒 → 7 ) GREEK VOCAL NOTATION SYMBOL-19 → DIGIT SEVEN#
+    {119315, "F"},   // MA#* ( 𝈓 → F ) GREEK VOCAL NOTATION SYMBOL-20 → LATIN CAPITAL LETTER F# →Ϝ→
+    {119318, "R"},   // MA#* ( 𝈖 → R ) GREEK VOCAL NOTATION SYMBOL-23 → LATIN CAPITAL LETTER R#
+    {119338, "L"},   // MA#* ( 𝈪 → L ) GREEK INSTRUMENTAL NOTATION SYMBOL-23 → LATIN CAPITAL LETTER L#
+    {119350, "<"},   // MA#* ( 𝈶 → < ) GREEK INSTRUMENTAL NOTATION SYMBOL-40 → LESS-THAN SIGN#
+    {119351, ">"},   // MA#* ( 𝈷 → > ) GREEK INSTRUMENTAL NOTATION SYMBOL-42 → GREATER-THAN SIGN#
+    {119354, "/"},   // MA#* ( 𝈺 → / ) GREEK INSTRUMENTAL NOTATION SYMBOL-47 → SOLIDUS#
+    {119355, "\\"},  // MA#* ( 𝈻 → \ ) GREEK INSTRUMENTAL NOTATION SYMBOL-48 → REVERSE SOLIDUS# →𝈏→
+    {119808, "A"},   // MA# ( 𝐀 → A ) MATHEMATICAL BOLD CAPITAL A → LATIN CAPITAL LETTER A#
+    {119809, "B"},   // MA# ( 𝐁 → B ) MATHEMATICAL BOLD CAPITAL B → LATIN CAPITAL LETTER B#
+    {119810, "C"},   // MA# ( 𝐂 → C ) MATHEMATICAL BOLD CAPITAL C → LATIN CAPITAL LETTER C#
+    {119811, "D"},   // MA# ( 𝐃 → D ) MATHEMATICAL BOLD CAPITAL D → LATIN CAPITAL LETTER D#
+    {119812, "E"},   // MA# ( 𝐄 → E ) MATHEMATICAL BOLD CAPITAL E → LATIN CAPITAL LETTER E#
+    {119813, "F"},   // MA# ( 𝐅 → F ) MATHEMATICAL BOLD CAPITAL F → LATIN CAPITAL LETTER F#
+    {119814, "G"},   // MA# ( 𝐆 → G ) MATHEMATICAL BOLD CAPITAL G → LATIN CAPITAL LETTER G#
+    {119815, "H"},   // MA# ( 𝐇 → H ) MATHEMATICAL BOLD CAPITAL H → LATIN CAPITAL LETTER H#
+    {119816, "l"},   // MA# ( 𝐈 → l ) MATHEMATICAL BOLD CAPITAL I → LATIN SMALL LETTER L# →I→
+    {119817, "J"},   // MA# ( 𝐉 → J ) MATHEMATICAL BOLD CAPITAL J → LATIN CAPITAL LETTER J#
+    {119818, "K"},   // MA# ( 𝐊 → K ) MATHEMATICAL BOLD CAPITAL K → LATIN CAPITAL LETTER K#
+    {119819, "L"},   // MA# ( 𝐋 → L ) MATHEMATICAL BOLD CAPITAL L → LATIN CAPITAL LETTER L#
+    {119820, "M"},   // MA# ( 𝐌 → M ) MATHEMATICAL BOLD CAPITAL M → LATIN CAPITAL LETTER M#
+    {119821, "N"},   // MA# ( 𝐍 → N ) MATHEMATICAL BOLD CAPITAL N → LATIN CAPITAL LETTER N#
+    {119822, "O"},   // MA# ( 𝐎 → O ) MATHEMATICAL BOLD CAPITAL O → LATIN CAPITAL LETTER O#
+    {119823, "P"},   // MA# ( 𝐏 → P ) MATHEMATICAL BOLD CAPITAL P → LATIN CAPITAL LETTER P#
+    {119824, "Q"},   // MA# ( 𝐐 → Q ) MATHEMATICAL BOLD CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {119825, "R"},   // MA# ( 𝐑 → R ) MATHEMATICAL BOLD CAPITAL R → LATIN CAPITAL LETTER R#
+    {119826, "S"},   // MA# ( 𝐒 → S ) MATHEMATICAL BOLD CAPITAL S → LATIN CAPITAL LETTER S#
+    {119827, "T"},   // MA# ( 𝐓 → T ) MATHEMATICAL BOLD CAPITAL T → LATIN CAPITAL LETTER T#
+    {119828, "U"},   // MA# ( 𝐔 → U ) MATHEMATICAL BOLD CAPITAL U → LATIN CAPITAL LETTER U#
+    {119829, "V"},   // MA# ( 𝐕 → V ) MATHEMATICAL BOLD CAPITAL V → LATIN CAPITAL LETTER V#
+    {119830, "W"},   // MA# ( 𝐖 → W ) MATHEMATICAL BOLD CAPITAL W → LATIN CAPITAL LETTER W#
+    {119831, "X"},   // MA# ( 𝐗 → X ) MATHEMATICAL BOLD CAPITAL X → LATIN CAPITAL LETTER X#
+    {119832, "Y"},   // MA# ( 𝐘 → Y ) MATHEMATICAL BOLD CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {119833, "Z"},   // MA# ( 𝐙 → Z ) MATHEMATICAL BOLD CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {119834, "a"},   // MA# ( 𝐚 → a ) MATHEMATICAL BOLD SMALL A → LATIN SMALL LETTER A#
+    {119835, "b"},   // MA# ( 𝐛 → b ) MATHEMATICAL BOLD SMALL B → LATIN SMALL LETTER B#
+    {119836, "c"},   // MA# ( 𝐜 → c ) MATHEMATICAL BOLD SMALL C → LATIN SMALL LETTER C#
+    {119837, "d"},   // MA# ( 𝐝 → d ) MATHEMATICAL BOLD SMALL D → LATIN SMALL LETTER D#
+    {119838, "e"},   // MA# ( 𝐞 → e ) MATHEMATICAL BOLD SMALL E → LATIN SMALL LETTER E#
+    {119839, "f"},   // MA# ( 𝐟 → f ) MATHEMATICAL BOLD SMALL F → LATIN SMALL LETTER F#
+    {119840, "g"},   // MA# ( 𝐠 → g ) MATHEMATICAL BOLD SMALL G → LATIN SMALL LETTER G#
+    {119841, "h"},   // MA# ( 𝐡 → h ) MATHEMATICAL BOLD SMALL H → LATIN SMALL LETTER H#
+    {119842, "i"},   // MA# ( 𝐢 → i ) MATHEMATICAL BOLD SMALL I → LATIN SMALL LETTER I#
+    {119843, "j"},   // MA# ( 𝐣 → j ) MATHEMATICAL BOLD SMALL J → LATIN SMALL LETTER J#
+    {119844, "k"},   // MA# ( 𝐤 → k ) MATHEMATICAL BOLD SMALL K → LATIN SMALL LETTER K#
+    {119845, "l"},   // MA# ( 𝐥 → l ) MATHEMATICAL BOLD SMALL L → LATIN SMALL LETTER L#
+    {119846, "rn"},  // MA# ( 𝐦 → rn ) MATHEMATICAL BOLD SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {119847, "n"},   // MA# ( 𝐧 → n ) MATHEMATICAL BOLD SMALL N → LATIN SMALL LETTER N#
+    {119848, "o"},   // MA# ( 𝐨 → o ) MATHEMATICAL BOLD SMALL O → LATIN SMALL LETTER O#
+    {119849, "p"},   // MA# ( 𝐩 → p ) MATHEMATICAL BOLD SMALL P → LATIN SMALL LETTER P#
+    {119850, "q"},   // MA# ( 𝐪 → q ) MATHEMATICAL BOLD SMALL Q → LATIN SMALL LETTER Q#
+    {119851, "r"},   // MA# ( 𝐫 → r ) MATHEMATICAL BOLD SMALL R → LATIN SMALL LETTER R#
+    {119852, "s"},   // MA# ( 𝐬 → s ) MATHEMATICAL BOLD SMALL S → LATIN SMALL LETTER S#
+    {119853, "t"},   // MA# ( 𝐭 → t ) MATHEMATICAL BOLD SMALL T → LATIN SMALL LETTER T#
+    {119854, "u"},   // MA# ( 𝐮 → u ) MATHEMATICAL BOLD SMALL U → LATIN SMALL LETTER U#
+    {119855, "v"},   // MA# ( 𝐯 → v ) MATHEMATICAL BOLD SMALL V → LATIN SMALL LETTER V#
+    {119856, "w"},   // MA# ( 𝐰 → w ) MATHEMATICAL BOLD SMALL W → LATIN SMALL LETTER W#
+    {119857, "x"},   // MA# ( 𝐱 → x ) MATHEMATICAL BOLD SMALL X → LATIN SMALL LETTER X#
+    {119858, "y"},   // MA# ( 𝐲 → y ) MATHEMATICAL BOLD SMALL Y → LATIN SMALL LETTER Y#
+    {119859, "z"},   // MA# ( 𝐳 → z ) MATHEMATICAL BOLD SMALL Z → LATIN SMALL LETTER Z#
+    {119860, "A"},   // MA# ( 𝐴 → A ) MATHEMATICAL ITALIC CAPITAL A → LATIN CAPITAL LETTER A#
+    {119861, "B"},   // MA# ( 𝐵 → B ) MATHEMATICAL ITALIC CAPITAL B → LATIN CAPITAL LETTER B#
+    {119862, "C"},   // MA# ( 𝐶 → C ) MATHEMATICAL ITALIC CAPITAL C → LATIN CAPITAL LETTER C#
+    {119863, "D"},   // MA# ( 𝐷 → D ) MATHEMATICAL ITALIC CAPITAL D → LATIN CAPITAL LETTER D#
+    {119864, "E"},   // MA# ( 𝐸 → E ) MATHEMATICAL ITALIC CAPITAL E → LATIN CAPITAL LETTER E#
+    {119865, "F"},   // MA# ( 𝐹 → F ) MATHEMATICAL ITALIC CAPITAL F → LATIN CAPITAL LETTER F#
+    {119866, "G"},   // MA# ( 𝐺 → G ) MATHEMATICAL ITALIC CAPITAL G → LATIN CAPITAL LETTER G#
+    {119867, "H"},   // MA# ( 𝐻 → H ) MATHEMATICAL ITALIC CAPITAL H → LATIN CAPITAL LETTER H#
+    {119868, "l"},   // MA# ( 𝐼 → l ) MATHEMATICAL ITALIC CAPITAL I → LATIN SMALL LETTER L# →I→
+    {119869, "J"},   // MA# ( 𝐽 → J ) MATHEMATICAL ITALIC CAPITAL J → LATIN CAPITAL LETTER J#
+    {119870, "K"},   // MA# ( 𝐾 → K ) MATHEMATICAL ITALIC CAPITAL K → LATIN CAPITAL LETTER K#
+    {119871, "L"},   // MA# ( 𝐿 → L ) MATHEMATICAL ITALIC CAPITAL L → LATIN CAPITAL LETTER L#
+    {119872, "M"},   // MA# ( 𝑀 → M ) MATHEMATICAL ITALIC CAPITAL M → LATIN CAPITAL LETTER M#
+    {119873, "N"},   // MA# ( 𝑁 → N ) MATHEMATICAL ITALIC CAPITAL N → LATIN CAPITAL LETTER N#
+    {119874, "O"},   // MA# ( 𝑂 → O ) MATHEMATICAL ITALIC CAPITAL O → LATIN CAPITAL LETTER O#
+    {119875, "P"},   // MA# ( 𝑃 → P ) MATHEMATICAL ITALIC CAPITAL P → LATIN CAPITAL LETTER P#
+    {119876, "Q"},   // MA# ( 𝑄 → Q ) MATHEMATICAL ITALIC CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {119877, "R"},   // MA# ( 𝑅 → R ) MATHEMATICAL ITALIC CAPITAL R → LATIN CAPITAL LETTER R#
+    {119878, "S"},   // MA# ( 𝑆 → S ) MATHEMATICAL ITALIC CAPITAL S → LATIN CAPITAL LETTER S#
+    {119879, "T"},   // MA# ( 𝑇 → T ) MATHEMATICAL ITALIC CAPITAL T → LATIN CAPITAL LETTER T#
+    {119880, "U"},   // MA# ( 𝑈 → U ) MATHEMATICAL ITALIC CAPITAL U → LATIN CAPITAL LETTER U#
+    {119881, "V"},   // MA# ( 𝑉 → V ) MATHEMATICAL ITALIC CAPITAL V → LATIN CAPITAL LETTER V#
+    {119882, "W"},   // MA# ( 𝑊 → W ) MATHEMATICAL ITALIC CAPITAL W → LATIN CAPITAL LETTER W#
+    {119883, "X"},   // MA# ( 𝑋 → X ) MATHEMATICAL ITALIC CAPITAL X → LATIN CAPITAL LETTER X#
+    {119884, "Y"},   // MA# ( 𝑌 → Y ) MATHEMATICAL ITALIC CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {119885, "Z"},   // MA# ( 𝑍 → Z ) MATHEMATICAL ITALIC CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {119886, "a"},   // MA# ( 𝑎 → a ) MATHEMATICAL ITALIC SMALL A → LATIN SMALL LETTER A#
+    {119887, "b"},   // MA# ( 𝑏 → b ) MATHEMATICAL ITALIC SMALL B → LATIN SMALL LETTER B#
+    {119888, "c"},   // MA# ( 𝑐 → c ) MATHEMATICAL ITALIC SMALL C → LATIN SMALL LETTER C#
+    {119889, "d"},   // MA# ( 𝑑 → d ) MATHEMATICAL ITALIC SMALL D → LATIN SMALL LETTER D#
+    {119890, "e"},   // MA# ( 𝑒 → e ) MATHEMATICAL ITALIC SMALL E → LATIN SMALL LETTER E#
+    {119891, "f"},   // MA# ( 𝑓 → f ) MATHEMATICAL ITALIC SMALL F → LATIN SMALL LETTER F#
+    {119892, "g"},   // MA# ( 𝑔 → g ) MATHEMATICAL ITALIC SMALL G → LATIN SMALL LETTER G#
+    {119894, "i"},   // MA# ( 𝑖 → i ) MATHEMATICAL ITALIC SMALL I → LATIN SMALL LETTER I#
+    {119895, "j"},   // MA# ( 𝑗 → j ) MATHEMATICAL ITALIC SMALL J → LATIN SMALL LETTER J#
+    {119896, "k"},   // MA# ( 𝑘 → k ) MATHEMATICAL ITALIC SMALL K → LATIN SMALL LETTER K#
+    {119897, "l"},   // MA# ( 𝑙 → l ) MATHEMATICAL ITALIC SMALL L → LATIN SMALL LETTER L#
+    {119898, "rn"},  // MA# ( 𝑚 → rn ) MATHEMATICAL ITALIC SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {119899, "n"},   // MA# ( 𝑛 → n ) MATHEMATICAL ITALIC SMALL N → LATIN SMALL LETTER N#
+    {119900, "o"},   // MA# ( 𝑜 → o ) MATHEMATICAL ITALIC SMALL O → LATIN SMALL LETTER O#
+    {119901, "p"},   // MA# ( 𝑝 → p ) MATHEMATICAL ITALIC SMALL P → LATIN SMALL LETTER P#
+    {119902, "q"},   // MA# ( 𝑞 → q ) MATHEMATICAL ITALIC SMALL Q → LATIN SMALL LETTER Q#
+    {119903, "r"},   // MA# ( 𝑟 → r ) MATHEMATICAL ITALIC SMALL R → LATIN SMALL LETTER R#
+    {119904, "s"},   // MA# ( 𝑠 → s ) MATHEMATICAL ITALIC SMALL S → LATIN SMALL LETTER S#
+    {119905, "t"},   // MA# ( 𝑡 → t ) MATHEMATICAL ITALIC SMALL T → LATIN SMALL LETTER T#
+    {119906, "u"},   // MA# ( 𝑢 → u ) MATHEMATICAL ITALIC SMALL U → LATIN SMALL LETTER U#
+    {119907, "v"},   // MA# ( 𝑣 → v ) MATHEMATICAL ITALIC SMALL V → LATIN SMALL LETTER V#
+    {119908, "w"},   // MA# ( 𝑤 → w ) MATHEMATICAL ITALIC SMALL W → LATIN SMALL LETTER W#
+    {119909, "x"},   // MA# ( 𝑥 → x ) MATHEMATICAL ITALIC SMALL X → LATIN SMALL LETTER X#
+    {119910, "y"},   // MA# ( 𝑦 → y ) MATHEMATICAL ITALIC SMALL Y → LATIN SMALL LETTER Y#
+    {119911, "z"},   // MA# ( 𝑧 → z ) MATHEMATICAL ITALIC SMALL Z → LATIN SMALL LETTER Z#
+    {119912, "A"},   // MA# ( 𝑨 → A ) MATHEMATICAL BOLD ITALIC CAPITAL A → LATIN CAPITAL LETTER A#
+    {119913, "B"},   // MA# ( 𝑩 → B ) MATHEMATICAL BOLD ITALIC CAPITAL B → LATIN CAPITAL LETTER B#
+    {119914, "C"},   // MA# ( 𝑪 → C ) MATHEMATICAL BOLD ITALIC CAPITAL C → LATIN CAPITAL LETTER C#
+    {119915, "D"},   // MA# ( 𝑫 → D ) MATHEMATICAL BOLD ITALIC CAPITAL D → LATIN CAPITAL LETTER D#
+    {119916, "E"},   // MA# ( 𝑬 → E ) MATHEMATICAL BOLD ITALIC CAPITAL E → LATIN CAPITAL LETTER E#
+    {119917, "F"},   // MA# ( 𝑭 → F ) MATHEMATICAL BOLD ITALIC CAPITAL F → LATIN CAPITAL LETTER F#
+    {119918, "G"},   // MA# ( 𝑮 → G ) MATHEMATICAL BOLD ITALIC CAPITAL G → LATIN CAPITAL LETTER G#
+    {119919, "H"},   // MA# ( 𝑯 → H ) MATHEMATICAL BOLD ITALIC CAPITAL H → LATIN CAPITAL LETTER H#
+    {119920, "l"},   // MA# ( 𝑰 → l ) MATHEMATICAL BOLD ITALIC CAPITAL I → LATIN SMALL LETTER L# →I→
+    {119921, "J"},   // MA# ( 𝑱 → J ) MATHEMATICAL BOLD ITALIC CAPITAL J → LATIN CAPITAL LETTER J#
+    {119922, "K"},   // MA# ( 𝑲 → K ) MATHEMATICAL BOLD ITALIC CAPITAL K → LATIN CAPITAL LETTER K#
+    {119923, "L"},   // MA# ( 𝑳 → L ) MATHEMATICAL BOLD ITALIC CAPITAL L → LATIN CAPITAL LETTER L#
+    {119924, "M"},   // MA# ( 𝑴 → M ) MATHEMATICAL BOLD ITALIC CAPITAL M → LATIN CAPITAL LETTER M#
+    {119925, "N"},   // MA# ( 𝑵 → N ) MATHEMATICAL BOLD ITALIC CAPITAL N → LATIN CAPITAL LETTER N#
+    {119926, "O"},   // MA# ( 𝑶 → O ) MATHEMATICAL BOLD ITALIC CAPITAL O → LATIN CAPITAL LETTER O#
+    {119927, "P"},   // MA# ( 𝑷 → P ) MATHEMATICAL BOLD ITALIC CAPITAL P → LATIN CAPITAL LETTER P#
+    {119928, "Q"},   // MA# ( 𝑸 → Q ) MATHEMATICAL BOLD ITALIC CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {119929, "R"},   // MA# ( 𝑹 → R ) MATHEMATICAL BOLD ITALIC CAPITAL R → LATIN CAPITAL LETTER R#
+    {119930, "S"},   // MA# ( 𝑺 → S ) MATHEMATICAL BOLD ITALIC CAPITAL S → LATIN CAPITAL LETTER S#
+    {119931, "T"},   // MA# ( 𝑻 → T ) MATHEMATICAL BOLD ITALIC CAPITAL T → LATIN CAPITAL LETTER T#
+    {119932, "U"},   // MA# ( 𝑼 → U ) MATHEMATICAL BOLD ITALIC CAPITAL U → LATIN CAPITAL LETTER U#
+    {119933, "V"},   // MA# ( 𝑽 → V ) MATHEMATICAL BOLD ITALIC CAPITAL V → LATIN CAPITAL LETTER V#
+    {119934, "W"},   // MA# ( 𝑾 → W ) MATHEMATICAL BOLD ITALIC CAPITAL W → LATIN CAPITAL LETTER W#
+    {119935, "X"},   // MA# ( 𝑿 → X ) MATHEMATICAL BOLD ITALIC CAPITAL X → LATIN CAPITAL LETTER X#
+    {119936, "Y"},   // MA# ( 𝒀 → Y ) MATHEMATICAL BOLD ITALIC CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {119937, "Z"},   // MA# ( 𝒁 → Z ) MATHEMATICAL BOLD ITALIC CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {119938, "a"},   // MA# ( 𝒂 → a ) MATHEMATICAL BOLD ITALIC SMALL A → LATIN SMALL LETTER A#
+    {119939, "b"},   // MA# ( 𝒃 → b ) MATHEMATICAL BOLD ITALIC SMALL B → LATIN SMALL LETTER B#
+    {119940, "c"},   // MA# ( 𝒄 → c ) MATHEMATICAL BOLD ITALIC SMALL C → LATIN SMALL LETTER C#
+    {119941, "d"},   // MA# ( 𝒅 → d ) MATHEMATICAL BOLD ITALIC SMALL D → LATIN SMALL LETTER D#
+    {119942, "e"},   // MA# ( 𝒆 → e ) MATHEMATICAL BOLD ITALIC SMALL E → LATIN SMALL LETTER E#
+    {119943, "f"},   // MA# ( 𝒇 → f ) MATHEMATICAL BOLD ITALIC SMALL F → LATIN SMALL LETTER F#
+    {119944, "g"},   // MA# ( 𝒈 → g ) MATHEMATICAL BOLD ITALIC SMALL G → LATIN SMALL LETTER G#
+    {119945, "h"},   // MA# ( 𝒉 → h ) MATHEMATICAL BOLD ITALIC SMALL H → LATIN SMALL LETTER H#
+    {119946, "i"},   // MA# ( 𝒊 → i ) MATHEMATICAL BOLD ITALIC SMALL I → LATIN SMALL LETTER I#
+    {119947, "j"},   // MA# ( 𝒋 → j ) MATHEMATICAL BOLD ITALIC SMALL J → LATIN SMALL LETTER J#
+    {119948, "k"},   // MA# ( 𝒌 → k ) MATHEMATICAL BOLD ITALIC SMALL K → LATIN SMALL LETTER K#
+    {119949, "l"},   // MA# ( 𝒍 → l ) MATHEMATICAL BOLD ITALIC SMALL L → LATIN SMALL LETTER L#
+    {119950, "rn"},  // MA# ( 𝒎 → rn ) MATHEMATICAL BOLD ITALIC SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {119951, "n"},   // MA# ( 𝒏 → n ) MATHEMATICAL BOLD ITALIC SMALL N → LATIN SMALL LETTER N#
+    {119952, "o"},   // MA# ( 𝒐 → o ) MATHEMATICAL BOLD ITALIC SMALL O → LATIN SMALL LETTER O#
+    {119953, "p"},   // MA# ( 𝒑 → p ) MATHEMATICAL BOLD ITALIC SMALL P → LATIN SMALL LETTER P#
+    {119954, "q"},   // MA# ( 𝒒 → q ) MATHEMATICAL BOLD ITALIC SMALL Q → LATIN SMALL LETTER Q#
+    {119955, "r"},   // MA# ( 𝒓 → r ) MATHEMATICAL BOLD ITALIC SMALL R → LATIN SMALL LETTER R#
+    {119956, "s"},   // MA# ( 𝒔 → s ) MATHEMATICAL BOLD ITALIC SMALL S → LATIN SMALL LETTER S#
+    {119957, "t"},   // MA# ( 𝒕 → t ) MATHEMATICAL BOLD ITALIC SMALL T → LATIN SMALL LETTER T#
+    {119958, "u"},   // MA# ( 𝒖 → u ) MATHEMATICAL BOLD ITALIC SMALL U → LATIN SMALL LETTER U#
+    {119959, "v"},   // MA# ( 𝒗 → v ) MATHEMATICAL BOLD ITALIC SMALL V → LATIN SMALL LETTER V#
+    {119960, "w"},   // MA# ( 𝒘 → w ) MATHEMATICAL BOLD ITALIC SMALL W → LATIN SMALL LETTER W#
+    {119961, "x"},   // MA# ( 𝒙 → x ) MATHEMATICAL BOLD ITALIC SMALL X → LATIN SMALL LETTER X#
+    {119962, "y"},   // MA# ( 𝒚 → y ) MATHEMATICAL BOLD ITALIC SMALL Y → LATIN SMALL LETTER Y#
+    {119963, "z"},   // MA# ( 𝒛 → z ) MATHEMATICAL BOLD ITALIC SMALL Z → LATIN SMALL LETTER Z#
+    {119964, "A"},   // MA# ( 𝒜 → A ) MATHEMATICAL SCRIPT CAPITAL A → LATIN CAPITAL LETTER A#
+    {119966, "C"},   // MA# ( 𝒞 → C ) MATHEMATICAL SCRIPT CAPITAL C → LATIN CAPITAL LETTER C#
+    {119967, "D"},   // MA# ( 𝒟 → D ) MATHEMATICAL SCRIPT CAPITAL D → LATIN CAPITAL LETTER D#
+    {119970, "G"},   // MA# ( 𝒢 → G ) MATHEMATICAL SCRIPT CAPITAL G → LATIN CAPITAL LETTER G#
+    {119973, "J"},   // MA# ( 𝒥 → J ) MATHEMATICAL SCRIPT CAPITAL J → LATIN CAPITAL LETTER J#
+    {119974, "K"},   // MA# ( 𝒦 → K ) MATHEMATICAL SCRIPT CAPITAL K → LATIN CAPITAL LETTER K#
+    {119977, "N"},   // MA# ( 𝒩 → N ) MATHEMATICAL SCRIPT CAPITAL N → LATIN CAPITAL LETTER N#
+    {119978, "O"},   // MA# ( 𝒪 → O ) MATHEMATICAL SCRIPT CAPITAL O → LATIN CAPITAL LETTER O#
+    {119979, "P"},   // MA# ( 𝒫 → P ) MATHEMATICAL SCRIPT CAPITAL P → LATIN CAPITAL LETTER P#
+    {119980, "Q"},   // MA# ( 𝒬 → Q ) MATHEMATICAL SCRIPT CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {119982, "S"},   // MA# ( 𝒮 → S ) MATHEMATICAL SCRIPT CAPITAL S → LATIN CAPITAL LETTER S#
+    {119983, "T"},   // MA# ( 𝒯 → T ) MATHEMATICAL SCRIPT CAPITAL T → LATIN CAPITAL LETTER T#
+    {119984, "U"},   // MA# ( 𝒰 → U ) MATHEMATICAL SCRIPT CAPITAL U → LATIN CAPITAL LETTER U#
+    {119985, "V"},   // MA# ( 𝒱 → V ) MATHEMATICAL SCRIPT CAPITAL V → LATIN CAPITAL LETTER V#
+    {119986, "W"},   // MA# ( 𝒲 → W ) MATHEMATICAL SCRIPT CAPITAL W → LATIN CAPITAL LETTER W#
+    {119987, "X"},   // MA# ( 𝒳 → X ) MATHEMATICAL SCRIPT CAPITAL X → LATIN CAPITAL LETTER X#
+    {119988, "Y"},   // MA# ( 𝒴 → Y ) MATHEMATICAL SCRIPT CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {119989, "Z"},   // MA# ( 𝒵 → Z ) MATHEMATICAL SCRIPT CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {119990, "a"},   // MA# ( 𝒶 → a ) MATHEMATICAL SCRIPT SMALL A → LATIN SMALL LETTER A#
+    {119991, "b"},   // MA# ( 𝒷 → b ) MATHEMATICAL SCRIPT SMALL B → LATIN SMALL LETTER B#
+    {119992, "c"},   // MA# ( 𝒸 → c ) MATHEMATICAL SCRIPT SMALL C → LATIN SMALL LETTER C#
+    {119993, "d"},   // MA# ( 𝒹 → d ) MATHEMATICAL SCRIPT SMALL D → LATIN SMALL LETTER D#
+    {119995, "f"},   // MA# ( 𝒻 → f ) MATHEMATICAL SCRIPT SMALL F → LATIN SMALL LETTER F#
+    {119997, "h"},   // MA# ( 𝒽 → h ) MATHEMATICAL SCRIPT SMALL H → LATIN SMALL LETTER H#
+    {119998, "i"},   // MA# ( 𝒾 → i ) MATHEMATICAL SCRIPT SMALL I → LATIN SMALL LETTER I#
+    {119999, "j"},   // MA# ( 𝒿 → j ) MATHEMATICAL SCRIPT SMALL J → LATIN SMALL LETTER J#
+    {120000, "k"},   // MA# ( 𝓀 → k ) MATHEMATICAL SCRIPT SMALL K → LATIN SMALL LETTER K#
+    {120001, "l"},   // MA# ( 𝓁 → l ) MATHEMATICAL SCRIPT SMALL L → LATIN SMALL LETTER L#
+    {120002, "rn"},  // MA# ( 𝓂 → rn ) MATHEMATICAL SCRIPT SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120003, "n"},   // MA# ( 𝓃 → n ) MATHEMATICAL SCRIPT SMALL N → LATIN SMALL LETTER N#
+    {120005, "p"},   // MA# ( 𝓅 → p ) MATHEMATICAL SCRIPT SMALL P → LATIN SMALL LETTER P#
+    {120006, "q"},   // MA# ( 𝓆 → q ) MATHEMATICAL SCRIPT SMALL Q → LATIN SMALL LETTER Q#
+    {120007, "r"},   // MA# ( 𝓇 → r ) MATHEMATICAL SCRIPT SMALL R → LATIN SMALL LETTER R#
+    {120008, "s"},   // MA# ( 𝓈 → s ) MATHEMATICAL SCRIPT SMALL S → LATIN SMALL LETTER S#
+    {120009, "t"},   // MA# ( 𝓉 → t ) MATHEMATICAL SCRIPT SMALL T → LATIN SMALL LETTER T#
+    {120010, "u"},   // MA# ( 𝓊 → u ) MATHEMATICAL SCRIPT SMALL U → LATIN SMALL LETTER U#
+    {120011, "v"},   // MA# ( 𝓋 → v ) MATHEMATICAL SCRIPT SMALL V → LATIN SMALL LETTER V#
+    {120012, "w"},   // MA# ( 𝓌 → w ) MATHEMATICAL SCRIPT SMALL W → LATIN SMALL LETTER W#
+    {120013, "x"},   // MA# ( 𝓍 → x ) MATHEMATICAL SCRIPT SMALL X → LATIN SMALL LETTER X#
+    {120014, "y"},   // MA# ( 𝓎 → y ) MATHEMATICAL SCRIPT SMALL Y → LATIN SMALL LETTER Y#
+    {120015, "z"},   // MA# ( 𝓏 → z ) MATHEMATICAL SCRIPT SMALL Z → LATIN SMALL LETTER Z#
+    {120016, "A"},   // MA# ( 𝓐 → A ) MATHEMATICAL BOLD SCRIPT CAPITAL A → LATIN CAPITAL LETTER A#
+    {120017, "B"},   // MA# ( 𝓑 → B ) MATHEMATICAL BOLD SCRIPT CAPITAL B → LATIN CAPITAL LETTER B#
+    {120018, "C"},   // MA# ( 𝓒 → C ) MATHEMATICAL BOLD SCRIPT CAPITAL C → LATIN CAPITAL LETTER C#
+    {120019, "D"},   // MA# ( 𝓓 → D ) MATHEMATICAL BOLD SCRIPT CAPITAL D → LATIN CAPITAL LETTER D#
+    {120020, "E"},   // MA# ( 𝓔 → E ) MATHEMATICAL BOLD SCRIPT CAPITAL E → LATIN CAPITAL LETTER E#
+    {120021, "F"},   // MA# ( 𝓕 → F ) MATHEMATICAL BOLD SCRIPT CAPITAL F → LATIN CAPITAL LETTER F#
+    {120022, "G"},   // MA# ( 𝓖 → G ) MATHEMATICAL BOLD SCRIPT CAPITAL G → LATIN CAPITAL LETTER G#
+    {120023, "H"},   // MA# ( 𝓗 → H ) MATHEMATICAL BOLD SCRIPT CAPITAL H → LATIN CAPITAL LETTER H#
+    {120024, "l"},   // MA# ( 𝓘 → l ) MATHEMATICAL BOLD SCRIPT CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120025, "J"},   // MA# ( 𝓙 → J ) MATHEMATICAL BOLD SCRIPT CAPITAL J → LATIN CAPITAL LETTER J#
+    {120026, "K"},   // MA# ( 𝓚 → K ) MATHEMATICAL BOLD SCRIPT CAPITAL K → LATIN CAPITAL LETTER K#
+    {120027, "L"},   // MA# ( 𝓛 → L ) MATHEMATICAL BOLD SCRIPT CAPITAL L → LATIN CAPITAL LETTER L#
+    {120028, "M"},   // MA# ( 𝓜 → M ) MATHEMATICAL BOLD SCRIPT CAPITAL M → LATIN CAPITAL LETTER M#
+    {120029, "N"},   // MA# ( 𝓝 → N ) MATHEMATICAL BOLD SCRIPT CAPITAL N → LATIN CAPITAL LETTER N#
+    {120030, "O"},   // MA# ( 𝓞 → O ) MATHEMATICAL BOLD SCRIPT CAPITAL O → LATIN CAPITAL LETTER O#
+    {120031, "P"},   // MA# ( 𝓟 → P ) MATHEMATICAL BOLD SCRIPT CAPITAL P → LATIN CAPITAL LETTER P#
+    {120032, "Q"},   // MA# ( 𝓠 → Q ) MATHEMATICAL BOLD SCRIPT CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120033, "R"},   // MA# ( 𝓡 → R ) MATHEMATICAL BOLD SCRIPT CAPITAL R → LATIN CAPITAL LETTER R#
+    {120034, "S"},   // MA# ( 𝓢 → S ) MATHEMATICAL BOLD SCRIPT CAPITAL S → LATIN CAPITAL LETTER S#
+    {120035, "T"},   // MA# ( 𝓣 → T ) MATHEMATICAL BOLD SCRIPT CAPITAL T → LATIN CAPITAL LETTER T#
+    {120036, "U"},   // MA# ( 𝓤 → U ) MATHEMATICAL BOLD SCRIPT CAPITAL U → LATIN CAPITAL LETTER U#
+    {120037, "V"},   // MA# ( 𝓥 → V ) MATHEMATICAL BOLD SCRIPT CAPITAL V → LATIN CAPITAL LETTER V#
+    {120038, "W"},   // MA# ( 𝓦 → W ) MATHEMATICAL BOLD SCRIPT CAPITAL W → LATIN CAPITAL LETTER W#
+    {120039, "X"},   // MA# ( 𝓧 → X ) MATHEMATICAL BOLD SCRIPT CAPITAL X → LATIN CAPITAL LETTER X#
+    {120040, "Y"},   // MA# ( 𝓨 → Y ) MATHEMATICAL BOLD SCRIPT CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120041, "Z"},   // MA# ( 𝓩 → Z ) MATHEMATICAL BOLD SCRIPT CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120042, "a"},   // MA# ( 𝓪 → a ) MATHEMATICAL BOLD SCRIPT SMALL A → LATIN SMALL LETTER A#
+    {120043, "b"},   // MA# ( 𝓫 → b ) MATHEMATICAL BOLD SCRIPT SMALL B → LATIN SMALL LETTER B#
+    {120044, "c"},   // MA# ( 𝓬 → c ) MATHEMATICAL BOLD SCRIPT SMALL C → LATIN SMALL LETTER C#
+    {120045, "d"},   // MA# ( 𝓭 → d ) MATHEMATICAL BOLD SCRIPT SMALL D → LATIN SMALL LETTER D#
+    {120046, "e"},   // MA# ( 𝓮 → e ) MATHEMATICAL BOLD SCRIPT SMALL E → LATIN SMALL LETTER E#
+    {120047, "f"},   // MA# ( 𝓯 → f ) MATHEMATICAL BOLD SCRIPT SMALL F → LATIN SMALL LETTER F#
+    {120048, "g"},   // MA# ( 𝓰 → g ) MATHEMATICAL BOLD SCRIPT SMALL G → LATIN SMALL LETTER G#
+    {120049, "h"},   // MA# ( 𝓱 → h ) MATHEMATICAL BOLD SCRIPT SMALL H → LATIN SMALL LETTER H#
+    {120050, "i"},   // MA# ( 𝓲 → i ) MATHEMATICAL BOLD SCRIPT SMALL I → LATIN SMALL LETTER I#
+    {120051, "j"},   // MA# ( 𝓳 → j ) MATHEMATICAL BOLD SCRIPT SMALL J → LATIN SMALL LETTER J#
+    {120052, "k"},   // MA# ( 𝓴 → k ) MATHEMATICAL BOLD SCRIPT SMALL K → LATIN SMALL LETTER K#
+    {120053, "l"},   // MA# ( 𝓵 → l ) MATHEMATICAL BOLD SCRIPT SMALL L → LATIN SMALL LETTER L#
+    {120054, "rn"},  // MA# ( 𝓶 → rn ) MATHEMATICAL BOLD SCRIPT SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120055, "n"},   // MA# ( 𝓷 → n ) MATHEMATICAL BOLD SCRIPT SMALL N → LATIN SMALL LETTER N#
+    {120056, "o"},   // MA# ( 𝓸 → o ) MATHEMATICAL BOLD SCRIPT SMALL O → LATIN SMALL LETTER O#
+    {120057, "p"},   // MA# ( 𝓹 → p ) MATHEMATICAL BOLD SCRIPT SMALL P → LATIN SMALL LETTER P#
+    {120058, "q"},   // MA# ( 𝓺 → q ) MATHEMATICAL BOLD SCRIPT SMALL Q → LATIN SMALL LETTER Q#
+    {120059, "r"},   // MA# ( 𝓻 → r ) MATHEMATICAL BOLD SCRIPT SMALL R → LATIN SMALL LETTER R#
+    {120060, "s"},   // MA# ( 𝓼 → s ) MATHEMATICAL BOLD SCRIPT SMALL S → LATIN SMALL LETTER S#
+    {120061, "t"},   // MA# ( 𝓽 → t ) MATHEMATICAL BOLD SCRIPT SMALL T → LATIN SMALL LETTER T#
+    {120062, "u"},   // MA# ( 𝓾 → u ) MATHEMATICAL BOLD SCRIPT SMALL U → LATIN SMALL LETTER U#
+    {120063, "v"},   // MA# ( 𝓿 → v ) MATHEMATICAL BOLD SCRIPT SMALL V → LATIN SMALL LETTER V#
+    {120064, "w"},   // MA# ( 𝔀 → w ) MATHEMATICAL BOLD SCRIPT SMALL W → LATIN SMALL LETTER W#
+    {120065, "x"},   // MA# ( 𝔁 → x ) MATHEMATICAL BOLD SCRIPT SMALL X → LATIN SMALL LETTER X#
+    {120066, "y"},   // MA# ( 𝔂 → y ) MATHEMATICAL BOLD SCRIPT SMALL Y → LATIN SMALL LETTER Y#
+    {120067, "z"},   // MA# ( 𝔃 → z ) MATHEMATICAL BOLD SCRIPT SMALL Z → LATIN SMALL LETTER Z#
+    {120068, "A"},   // MA# ( 𝔄 → A ) MATHEMATICAL FRAKTUR CAPITAL A → LATIN CAPITAL LETTER A#
+    {120069, "B"},   // MA# ( 𝔅 → B ) MATHEMATICAL FRAKTUR CAPITAL B → LATIN CAPITAL LETTER B#
+    {120071, "D"},   // MA# ( 𝔇 → D ) MATHEMATICAL FRAKTUR CAPITAL D → LATIN CAPITAL LETTER D#
+    {120072, "E"},   // MA# ( 𝔈 → E ) MATHEMATICAL FRAKTUR CAPITAL E → LATIN CAPITAL LETTER E#
+    {120073, "F"},   // MA# ( 𝔉 → F ) MATHEMATICAL FRAKTUR CAPITAL F → LATIN CAPITAL LETTER F#
+    {120074, "G"},   // MA# ( 𝔊 → G ) MATHEMATICAL FRAKTUR CAPITAL G → LATIN CAPITAL LETTER G#
+    {120077, "J"},   // MA# ( 𝔍 → J ) MATHEMATICAL FRAKTUR CAPITAL J → LATIN CAPITAL LETTER J#
+    {120078, "K"},   // MA# ( 𝔎 → K ) MATHEMATICAL FRAKTUR CAPITAL K → LATIN CAPITAL LETTER K#
+    {120079, "L"},   // MA# ( 𝔏 → L ) MATHEMATICAL FRAKTUR CAPITAL L → LATIN CAPITAL LETTER L#
+    {120080, "M"},   // MA# ( 𝔐 → M ) MATHEMATICAL FRAKTUR CAPITAL M → LATIN CAPITAL LETTER M#
+    {120081, "N"},   // MA# ( 𝔑 → N ) MATHEMATICAL FRAKTUR CAPITAL N → LATIN CAPITAL LETTER N#
+    {120082, "O"},   // MA# ( 𝔒 → O ) MATHEMATICAL FRAKTUR CAPITAL O → LATIN CAPITAL LETTER O#
+    {120083, "P"},   // MA# ( 𝔓 → P ) MATHEMATICAL FRAKTUR CAPITAL P → LATIN CAPITAL LETTER P#
+    {120084, "Q"},   // MA# ( 𝔔 → Q ) MATHEMATICAL FRAKTUR CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120086, "S"},   // MA# ( 𝔖 → S ) MATHEMATICAL FRAKTUR CAPITAL S → LATIN CAPITAL LETTER S#
+    {120087, "T"},   // MA# ( 𝔗 → T ) MATHEMATICAL FRAKTUR CAPITAL T → LATIN CAPITAL LETTER T#
+    {120088, "U"},   // MA# ( 𝔘 → U ) MATHEMATICAL FRAKTUR CAPITAL U → LATIN CAPITAL LETTER U#
+    {120089, "V"},   // MA# ( 𝔙 → V ) MATHEMATICAL FRAKTUR CAPITAL V → LATIN CAPITAL LETTER V#
+    {120090, "W"},   // MA# ( 𝔚 → W ) MATHEMATICAL FRAKTUR CAPITAL W → LATIN CAPITAL LETTER W#
+    {120091, "X"},   // MA# ( 𝔛 → X ) MATHEMATICAL FRAKTUR CAPITAL X → LATIN CAPITAL LETTER X#
+    {120092, "Y"},   // MA# ( 𝔜 → Y ) MATHEMATICAL FRAKTUR CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120094, "a"},   // MA# ( 𝔞 → a ) MATHEMATICAL FRAKTUR SMALL A → LATIN SMALL LETTER A#
+    {120095, "b"},   // MA# ( 𝔟 → b ) MATHEMATICAL FRAKTUR SMALL B → LATIN SMALL LETTER B#
+    {120096, "c"},   // MA# ( 𝔠 → c ) MATHEMATICAL FRAKTUR SMALL C → LATIN SMALL LETTER C#
+    {120097, "d"},   // MA# ( 𝔡 → d ) MATHEMATICAL FRAKTUR SMALL D → LATIN SMALL LETTER D#
+    {120098, "e"},   // MA# ( 𝔢 → e ) MATHEMATICAL FRAKTUR SMALL E → LATIN SMALL LETTER E#
+    {120099, "f"},   // MA# ( 𝔣 → f ) MATHEMATICAL FRAKTUR SMALL F → LATIN SMALL LETTER F#
+    {120100, "g"},   // MA# ( 𝔤 → g ) MATHEMATICAL FRAKTUR SMALL G → LATIN SMALL LETTER G#
+    {120101, "h"},   // MA# ( 𝔥 → h ) MATHEMATICAL FRAKTUR SMALL H → LATIN SMALL LETTER H#
+    {120102, "i"},   // MA# ( 𝔦 → i ) MATHEMATICAL FRAKTUR SMALL I → LATIN SMALL LETTER I#
+    {120103, "j"},   // MA# ( 𝔧 → j ) MATHEMATICAL FRAKTUR SMALL J → LATIN SMALL LETTER J#
+    {120104, "k"},   // MA# ( 𝔨 → k ) MATHEMATICAL FRAKTUR SMALL K → LATIN SMALL LETTER K#
+    {120105, "l"},   // MA# ( 𝔩 → l ) MATHEMATICAL FRAKTUR SMALL L → LATIN SMALL LETTER L#
+    {120106, "rn"},  // MA# ( 𝔪 → rn ) MATHEMATICAL FRAKTUR SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120107, "n"},   // MA# ( 𝔫 → n ) MATHEMATICAL FRAKTUR SMALL N → LATIN SMALL LETTER N#
+    {120108, "o"},   // MA# ( 𝔬 → o ) MATHEMATICAL FRAKTUR SMALL O → LATIN SMALL LETTER O#
+    {120109, "p"},   // MA# ( 𝔭 → p ) MATHEMATICAL FRAKTUR SMALL P → LATIN SMALL LETTER P#
+    {120110, "q"},   // MA# ( 𝔮 → q ) MATHEMATICAL FRAKTUR SMALL Q → LATIN SMALL LETTER Q#
+    {120111, "r"},   // MA# ( 𝔯 → r ) MATHEMATICAL FRAKTUR SMALL R → LATIN SMALL LETTER R#
+    {120112, "s"},   // MA# ( 𝔰 → s ) MATHEMATICAL FRAKTUR SMALL S → LATIN SMALL LETTER S#
+    {120113, "t"},   // MA# ( 𝔱 → t ) MATHEMATICAL FRAKTUR SMALL T → LATIN SMALL LETTER T#
+    {120114, "u"},   // MA# ( 𝔲 → u ) MATHEMATICAL FRAKTUR SMALL U → LATIN SMALL LETTER U#
+    {120115, "v"},   // MA# ( 𝔳 → v ) MATHEMATICAL FRAKTUR SMALL V → LATIN SMALL LETTER V#
+    {120116, "w"},   // MA# ( 𝔴 → w ) MATHEMATICAL FRAKTUR SMALL W → LATIN SMALL LETTER W#
+    {120117, "x"},   // MA# ( 𝔵 → x ) MATHEMATICAL FRAKTUR SMALL X → LATIN SMALL LETTER X#
+    {120118, "y"},   // MA# ( 𝔶 → y ) MATHEMATICAL FRAKTUR SMALL Y → LATIN SMALL LETTER Y#
+    {120119, "z"},   // MA# ( 𝔷 → z ) MATHEMATICAL FRAKTUR SMALL Z → LATIN SMALL LETTER Z#
+    {120120, "A"},   // MA# ( 𝔸 → A ) MATHEMATICAL DOUBLE-STRUCK CAPITAL A → LATIN CAPITAL LETTER A#
+    {120121, "B"},   // MA# ( 𝔹 → B ) MATHEMATICAL DOUBLE-STRUCK CAPITAL B → LATIN CAPITAL LETTER B#
+    {120123, "D"},   // MA# ( 𝔻 → D ) MATHEMATICAL DOUBLE-STRUCK CAPITAL D → LATIN CAPITAL LETTER D#
+    {120124, "E"},   // MA# ( 𝔼 → E ) MATHEMATICAL DOUBLE-STRUCK CAPITAL E → LATIN CAPITAL LETTER E#
+    {120125, "F"},   // MA# ( 𝔽 → F ) MATHEMATICAL DOUBLE-STRUCK CAPITAL F → LATIN CAPITAL LETTER F#
+    {120126, "G"},   // MA# ( 𝔾 → G ) MATHEMATICAL DOUBLE-STRUCK CAPITAL G → LATIN CAPITAL LETTER G#
+    {120128, "l"},   // MA# ( 𝕀 → l ) MATHEMATICAL DOUBLE-STRUCK CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120129, "J"},   // MA# ( 𝕁 → J ) MATHEMATICAL DOUBLE-STRUCK CAPITAL J → LATIN CAPITAL LETTER J#
+    {120130, "K"},   // MA# ( 𝕂 → K ) MATHEMATICAL DOUBLE-STRUCK CAPITAL K → LATIN CAPITAL LETTER K#
+    {120131, "L"},   // MA# ( 𝕃 → L ) MATHEMATICAL DOUBLE-STRUCK CAPITAL L → LATIN CAPITAL LETTER L#
+    {120132, "M"},   // MA# ( 𝕄 → M ) MATHEMATICAL DOUBLE-STRUCK CAPITAL M → LATIN CAPITAL LETTER M#
+    {120134, "O"},   // MA# ( 𝕆 → O ) MATHEMATICAL DOUBLE-STRUCK CAPITAL O → LATIN CAPITAL LETTER O#
+    {120138, "S"},   // MA# ( 𝕊 → S ) MATHEMATICAL DOUBLE-STRUCK CAPITAL S → LATIN CAPITAL LETTER S#
+    {120139, "T"},   // MA# ( 𝕋 → T ) MATHEMATICAL DOUBLE-STRUCK CAPITAL T → LATIN CAPITAL LETTER T#
+    {120140, "U"},   // MA# ( 𝕌 → U ) MATHEMATICAL DOUBLE-STRUCK CAPITAL U → LATIN CAPITAL LETTER U#
+    {120141, "V"},   // MA# ( 𝕍 → V ) MATHEMATICAL DOUBLE-STRUCK CAPITAL V → LATIN CAPITAL LETTER V#
+    {120142, "W"},   // MA# ( 𝕎 → W ) MATHEMATICAL DOUBLE-STRUCK CAPITAL W → LATIN CAPITAL LETTER W#
+    {120143, "X"},   // MA# ( 𝕏 → X ) MATHEMATICAL DOUBLE-STRUCK CAPITAL X → LATIN CAPITAL LETTER X#
+    {120144, "Y"},   // MA# ( 𝕐 → Y ) MATHEMATICAL DOUBLE-STRUCK CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120146, "a"},   // MA# ( 𝕒 → a ) MATHEMATICAL DOUBLE-STRUCK SMALL A → LATIN SMALL LETTER A#
+    {120147, "b"},   // MA# ( 𝕓 → b ) MATHEMATICAL DOUBLE-STRUCK SMALL B → LATIN SMALL LETTER B#
+    {120148, "c"},   // MA# ( 𝕔 → c ) MATHEMATICAL DOUBLE-STRUCK SMALL C → LATIN SMALL LETTER C#
+    {120149, "d"},   // MA# ( 𝕕 → d ) MATHEMATICAL DOUBLE-STRUCK SMALL D → LATIN SMALL LETTER D#
+    {120150, "e"},   // MA# ( 𝕖 → e ) MATHEMATICAL DOUBLE-STRUCK SMALL E → LATIN SMALL LETTER E#
+    {120151, "f"},   // MA# ( 𝕗 → f ) MATHEMATICAL DOUBLE-STRUCK SMALL F → LATIN SMALL LETTER F#
+    {120152, "g"},   // MA# ( 𝕘 → g ) MATHEMATICAL DOUBLE-STRUCK SMALL G → LATIN SMALL LETTER G#
+    {120153, "h"},   // MA# ( 𝕙 → h ) MATHEMATICAL DOUBLE-STRUCK SMALL H → LATIN SMALL LETTER H#
+    {120154, "i"},   // MA# ( 𝕚 → i ) MATHEMATICAL DOUBLE-STRUCK SMALL I → LATIN SMALL LETTER I#
+    {120155, "j"},   // MA# ( 𝕛 → j ) MATHEMATICAL DOUBLE-STRUCK SMALL J → LATIN SMALL LETTER J#
+    {120156, "k"},   // MA# ( 𝕜 → k ) MATHEMATICAL DOUBLE-STRUCK SMALL K → LATIN SMALL LETTER K#
+    {120157, "l"},   // MA# ( 𝕝 → l ) MATHEMATICAL DOUBLE-STRUCK SMALL L → LATIN SMALL LETTER L#
+    {120158, "rn"},  // MA# ( 𝕞 → rn ) MATHEMATICAL DOUBLE-STRUCK SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120159, "n"},   // MA# ( 𝕟 → n ) MATHEMATICAL DOUBLE-STRUCK SMALL N → LATIN SMALL LETTER N#
+    {120160, "o"},   // MA# ( 𝕠 → o ) MATHEMATICAL DOUBLE-STRUCK SMALL O → LATIN SMALL LETTER O#
+    {120161, "p"},   // MA# ( 𝕡 → p ) MATHEMATICAL DOUBLE-STRUCK SMALL P → LATIN SMALL LETTER P#
+    {120162, "q"},   // MA# ( 𝕢 → q ) MATHEMATICAL DOUBLE-STRUCK SMALL Q → LATIN SMALL LETTER Q#
+    {120163, "r"},   // MA# ( 𝕣 → r ) MATHEMATICAL DOUBLE-STRUCK SMALL R → LATIN SMALL LETTER R#
+    {120164, "s"},   // MA# ( 𝕤 → s ) MATHEMATICAL DOUBLE-STRUCK SMALL S → LATIN SMALL LETTER S#
+    {120165, "t"},   // MA# ( 𝕥 → t ) MATHEMATICAL DOUBLE-STRUCK SMALL T → LATIN SMALL LETTER T#
+    {120166, "u"},   // MA# ( 𝕦 → u ) MATHEMATICAL DOUBLE-STRUCK SMALL U → LATIN SMALL LETTER U#
+    {120167, "v"},   // MA# ( 𝕧 → v ) MATHEMATICAL DOUBLE-STRUCK SMALL V → LATIN SMALL LETTER V#
+    {120168, "w"},   // MA# ( 𝕨 → w ) MATHEMATICAL DOUBLE-STRUCK SMALL W → LATIN SMALL LETTER W#
+    {120169, "x"},   // MA# ( 𝕩 → x ) MATHEMATICAL DOUBLE-STRUCK SMALL X → LATIN SMALL LETTER X#
+    {120170, "y"},   // MA# ( 𝕪 → y ) MATHEMATICAL DOUBLE-STRUCK SMALL Y → LATIN SMALL LETTER Y#
+    {120171, "z"},   // MA# ( 𝕫 → z ) MATHEMATICAL DOUBLE-STRUCK SMALL Z → LATIN SMALL LETTER Z#
+    {120172, "A"},   // MA# ( 𝕬 → A ) MATHEMATICAL BOLD FRAKTUR CAPITAL A → LATIN CAPITAL LETTER A#
+    {120173, "B"},   // MA# ( 𝕭 → B ) MATHEMATICAL BOLD FRAKTUR CAPITAL B → LATIN CAPITAL LETTER B#
+    {120174, "C"},   // MA# ( 𝕮 → C ) MATHEMATICAL BOLD FRAKTUR CAPITAL C → LATIN CAPITAL LETTER C#
+    {120175, "D"},   // MA# ( 𝕯 → D ) MATHEMATICAL BOLD FRAKTUR CAPITAL D → LATIN CAPITAL LETTER D#
+    {120176, "E"},   // MA# ( 𝕰 → E ) MATHEMATICAL BOLD FRAKTUR CAPITAL E → LATIN CAPITAL LETTER E#
+    {120177, "F"},   // MA# ( 𝕱 → F ) MATHEMATICAL BOLD FRAKTUR CAPITAL F → LATIN CAPITAL LETTER F#
+    {120178, "G"},   // MA# ( 𝕲 → G ) MATHEMATICAL BOLD FRAKTUR CAPITAL G → LATIN CAPITAL LETTER G#
+    {120179, "H"},   // MA# ( 𝕳 → H ) MATHEMATICAL BOLD FRAKTUR CAPITAL H → LATIN CAPITAL LETTER H#
+    {120180, "l"},   // MA# ( 𝕴 → l ) MATHEMATICAL BOLD FRAKTUR CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120181, "J"},   // MA# ( 𝕵 → J ) MATHEMATICAL BOLD FRAKTUR CAPITAL J → LATIN CAPITAL LETTER J#
+    {120182, "K"},   // MA# ( 𝕶 → K ) MATHEMATICAL BOLD FRAKTUR CAPITAL K → LATIN CAPITAL LETTER K#
+    {120183, "L"},   // MA# ( 𝕷 → L ) MATHEMATICAL BOLD FRAKTUR CAPITAL L → LATIN CAPITAL LETTER L#
+    {120184, "M"},   // MA# ( 𝕸 → M ) MATHEMATICAL BOLD FRAKTUR CAPITAL M → LATIN CAPITAL LETTER M#
+    {120185, "N"},   // MA# ( 𝕹 → N ) MATHEMATICAL BOLD FRAKTUR CAPITAL N → LATIN CAPITAL LETTER N#
+    {120186, "O"},   // MA# ( 𝕺 → O ) MATHEMATICAL BOLD FRAKTUR CAPITAL O → LATIN CAPITAL LETTER O#
+    {120187, "P"},   // MA# ( 𝕻 → P ) MATHEMATICAL BOLD FRAKTUR CAPITAL P → LATIN CAPITAL LETTER P#
+    {120188, "Q"},   // MA# ( 𝕼 → Q ) MATHEMATICAL BOLD FRAKTUR CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120189, "R"},   // MA# ( 𝕽 → R ) MATHEMATICAL BOLD FRAKTUR CAPITAL R → LATIN CAPITAL LETTER R#
+    {120190, "S"},   // MA# ( 𝕾 → S ) MATHEMATICAL BOLD FRAKTUR CAPITAL S → LATIN CAPITAL LETTER S#
+    {120191, "T"},   // MA# ( 𝕿 → T ) MATHEMATICAL BOLD FRAKTUR CAPITAL T → LATIN CAPITAL LETTER T#
+    {120192, "U"},   // MA# ( 𝖀 → U ) MATHEMATICAL BOLD FRAKTUR CAPITAL U → LATIN CAPITAL LETTER U#
+    {120193, "V"},   // MA# ( 𝖁 → V ) MATHEMATICAL BOLD FRAKTUR CAPITAL V → LATIN CAPITAL LETTER V#
+    {120194, "W"},   // MA# ( 𝖂 → W ) MATHEMATICAL BOLD FRAKTUR CAPITAL W → LATIN CAPITAL LETTER W#
+    {120195, "X"},   // MA# ( 𝖃 → X ) MATHEMATICAL BOLD FRAKTUR CAPITAL X → LATIN CAPITAL LETTER X#
+    {120196, "Y"},   // MA# ( 𝖄 → Y ) MATHEMATICAL BOLD FRAKTUR CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120197, "Z"},   // MA# ( 𝖅 → Z ) MATHEMATICAL BOLD FRAKTUR CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120198, "a"},   // MA# ( 𝖆 → a ) MATHEMATICAL BOLD FRAKTUR SMALL A → LATIN SMALL LETTER A#
+    {120199, "b"},   // MA# ( 𝖇 → b ) MATHEMATICAL BOLD FRAKTUR SMALL B → LATIN SMALL LETTER B#
+    {120200, "c"},   // MA# ( 𝖈 → c ) MATHEMATICAL BOLD FRAKTUR SMALL C → LATIN SMALL LETTER C#
+    {120201, "d"},   // MA# ( 𝖉 → d ) MATHEMATICAL BOLD FRAKTUR SMALL D → LATIN SMALL LETTER D#
+    {120202, "e"},   // MA# ( 𝖊 → e ) MATHEMATICAL BOLD FRAKTUR SMALL E → LATIN SMALL LETTER E#
+    {120203, "f"},   // MA# ( 𝖋 → f ) MATHEMATICAL BOLD FRAKTUR SMALL F → LATIN SMALL LETTER F#
+    {120204, "g"},   // MA# ( 𝖌 → g ) MATHEMATICAL BOLD FRAKTUR SMALL G → LATIN SMALL LETTER G#
+    {120205, "h"},   // MA# ( 𝖍 → h ) MATHEMATICAL BOLD FRAKTUR SMALL H → LATIN SMALL LETTER H#
+    {120206, "i"},   // MA# ( 𝖎 → i ) MATHEMATICAL BOLD FRAKTUR SMALL I → LATIN SMALL LETTER I#
+    {120207, "j"},   // MA# ( 𝖏 → j ) MATHEMATICAL BOLD FRAKTUR SMALL J → LATIN SMALL LETTER J#
+    {120208, "k"},   // MA# ( 𝖐 → k ) MATHEMATICAL BOLD FRAKTUR SMALL K → LATIN SMALL LETTER K#
+    {120209, "l"},   // MA# ( 𝖑 → l ) MATHEMATICAL BOLD FRAKTUR SMALL L → LATIN SMALL LETTER L#
+    {120210, "rn"},  // MA# ( 𝖒 → rn ) MATHEMATICAL BOLD FRAKTUR SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120211, "n"},   // MA# ( 𝖓 → n ) MATHEMATICAL BOLD FRAKTUR SMALL N → LATIN SMALL LETTER N#
+    {120212, "o"},   // MA# ( 𝖔 → o ) MATHEMATICAL BOLD FRAKTUR SMALL O → LATIN SMALL LETTER O#
+    {120213, "p"},   // MA# ( 𝖕 → p ) MATHEMATICAL BOLD FRAKTUR SMALL P → LATIN SMALL LETTER P#
+    {120214, "q"},   // MA# ( 𝖖 → q ) MATHEMATICAL BOLD FRAKTUR SMALL Q → LATIN SMALL LETTER Q#
+    {120215, "r"},   // MA# ( 𝖗 → r ) MATHEMATICAL BOLD FRAKTUR SMALL R → LATIN SMALL LETTER R#
+    {120216, "s"},   // MA# ( 𝖘 → s ) MATHEMATICAL BOLD FRAKTUR SMALL S → LATIN SMALL LETTER S#
+    {120217, "t"},   // MA# ( 𝖙 → t ) MATHEMATICAL BOLD FRAKTUR SMALL T → LATIN SMALL LETTER T#
+    {120218, "u"},   // MA# ( 𝖚 → u ) MATHEMATICAL BOLD FRAKTUR SMALL U → LATIN SMALL LETTER U#
+    {120219, "v"},   // MA# ( 𝖛 → v ) MATHEMATICAL BOLD FRAKTUR SMALL V → LATIN SMALL LETTER V#
+    {120220, "w"},   // MA# ( 𝖜 → w ) MATHEMATICAL BOLD FRAKTUR SMALL W → LATIN SMALL LETTER W#
+    {120221, "x"},   // MA# ( 𝖝 → x ) MATHEMATICAL BOLD FRAKTUR SMALL X → LATIN SMALL LETTER X#
+    {120222, "y"},   // MA# ( 𝖞 → y ) MATHEMATICAL BOLD FRAKTUR SMALL Y → LATIN SMALL LETTER Y#
+    {120223, "z"},   // MA# ( 𝖟 → z ) MATHEMATICAL BOLD FRAKTUR SMALL Z → LATIN SMALL LETTER Z#
+    {120224, "A"},   // MA# ( 𝖠 → A ) MATHEMATICAL SANS-SERIF CAPITAL A → LATIN CAPITAL LETTER A#
+    {120225, "B"},   // MA# ( 𝖡 → B ) MATHEMATICAL SANS-SERIF CAPITAL B → LATIN CAPITAL LETTER B#
+    {120226, "C"},   // MA# ( 𝖢 → C ) MATHEMATICAL SANS-SERIF CAPITAL C → LATIN CAPITAL LETTER C#
+    {120227, "D"},   // MA# ( 𝖣 → D ) MATHEMATICAL SANS-SERIF CAPITAL D → LATIN CAPITAL LETTER D#
+    {120228, "E"},   // MA# ( 𝖤 → E ) MATHEMATICAL SANS-SERIF CAPITAL E → LATIN CAPITAL LETTER E#
+    {120229, "F"},   // MA# ( 𝖥 → F ) MATHEMATICAL SANS-SERIF CAPITAL F → LATIN CAPITAL LETTER F#
+    {120230, "G"},   // MA# ( 𝖦 → G ) MATHEMATICAL SANS-SERIF CAPITAL G → LATIN CAPITAL LETTER G#
+    {120231, "H"},   // MA# ( 𝖧 → H ) MATHEMATICAL SANS-SERIF CAPITAL H → LATIN CAPITAL LETTER H#
+    {120232, "l"},   // MA# ( 𝖨 → l ) MATHEMATICAL SANS-SERIF CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120233, "J"},   // MA# ( 𝖩 → J ) MATHEMATICAL SANS-SERIF CAPITAL J → LATIN CAPITAL LETTER J#
+    {120234, "K"},   // MA# ( 𝖪 → K ) MATHEMATICAL SANS-SERIF CAPITAL K → LATIN CAPITAL LETTER K#
+    {120235, "L"},   // MA# ( 𝖫 → L ) MATHEMATICAL SANS-SERIF CAPITAL L → LATIN CAPITAL LETTER L#
+    {120236, "M"},   // MA# ( 𝖬 → M ) MATHEMATICAL SANS-SERIF CAPITAL M → LATIN CAPITAL LETTER M#
+    {120237, "N"},   // MA# ( 𝖭 → N ) MATHEMATICAL SANS-SERIF CAPITAL N → LATIN CAPITAL LETTER N#
+    {120238, "O"},   // MA# ( 𝖮 → O ) MATHEMATICAL SANS-SERIF CAPITAL O → LATIN CAPITAL LETTER O#
+    {120239, "P"},   // MA# ( 𝖯 → P ) MATHEMATICAL SANS-SERIF CAPITAL P → LATIN CAPITAL LETTER P#
+    {120240, "Q"},   // MA# ( 𝖰 → Q ) MATHEMATICAL SANS-SERIF CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120241, "R"},   // MA# ( 𝖱 → R ) MATHEMATICAL SANS-SERIF CAPITAL R → LATIN CAPITAL LETTER R#
+    {120242, "S"},   // MA# ( 𝖲 → S ) MATHEMATICAL SANS-SERIF CAPITAL S → LATIN CAPITAL LETTER S#
+    {120243, "T"},   // MA# ( 𝖳 → T ) MATHEMATICAL SANS-SERIF CAPITAL T → LATIN CAPITAL LETTER T#
+    {120244, "U"},   // MA# ( 𝖴 → U ) MATHEMATICAL SANS-SERIF CAPITAL U → LATIN CAPITAL LETTER U#
+    {120245, "V"},   // MA# ( 𝖵 → V ) MATHEMATICAL SANS-SERIF CAPITAL V → LATIN CAPITAL LETTER V#
+    {120246, "W"},   // MA# ( 𝖶 → W ) MATHEMATICAL SANS-SERIF CAPITAL W → LATIN CAPITAL LETTER W#
+    {120247, "X"},   // MA# ( 𝖷 → X ) MATHEMATICAL SANS-SERIF CAPITAL X → LATIN CAPITAL LETTER X#
+    {120248, "Y"},   // MA# ( 𝖸 → Y ) MATHEMATICAL SANS-SERIF CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120249, "Z"},   // MA# ( 𝖹 → Z ) MATHEMATICAL SANS-SERIF CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120250, "a"},   // MA# ( 𝖺 → a ) MATHEMATICAL SANS-SERIF SMALL A → LATIN SMALL LETTER A#
+    {120251, "b"},   // MA# ( 𝖻 → b ) MATHEMATICAL SANS-SERIF SMALL B → LATIN SMALL LETTER B#
+    {120252, "c"},   // MA# ( 𝖼 → c ) MATHEMATICAL SANS-SERIF SMALL C → LATIN SMALL LETTER C#
+    {120253, "d"},   // MA# ( 𝖽 → d ) MATHEMATICAL SANS-SERIF SMALL D → LATIN SMALL LETTER D#
+    {120254, "e"},   // MA# ( 𝖾 → e ) MATHEMATICAL SANS-SERIF SMALL E → LATIN SMALL LETTER E#
+    {120255, "f"},   // MA# ( 𝖿 → f ) MATHEMATICAL SANS-SERIF SMALL F → LATIN SMALL LETTER F#
+    {120256, "g"},   // MA# ( 𝗀 → g ) MATHEMATICAL SANS-SERIF SMALL G → LATIN SMALL LETTER G#
+    {120257, "h"},   // MA# ( 𝗁 → h ) MATHEMATICAL SANS-SERIF SMALL H → LATIN SMALL LETTER H#
+    {120258, "i"},   // MA# ( 𝗂 → i ) MATHEMATICAL SANS-SERIF SMALL I → LATIN SMALL LETTER I#
+    {120259, "j"},   // MA# ( 𝗃 → j ) MATHEMATICAL SANS-SERIF SMALL J → LATIN SMALL LETTER J#
+    {120260, "k"},   // MA# ( 𝗄 → k ) MATHEMATICAL SANS-SERIF SMALL K → LATIN SMALL LETTER K#
+    {120261, "l"},   // MA# ( 𝗅 → l ) MATHEMATICAL SANS-SERIF SMALL L → LATIN SMALL LETTER L#
+    {120262, "rn"},  // MA# ( 𝗆 → rn ) MATHEMATICAL SANS-SERIF SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120263, "n"},   // MA# ( 𝗇 → n ) MATHEMATICAL SANS-SERIF SMALL N → LATIN SMALL LETTER N#
+    {120264, "o"},   // MA# ( 𝗈 → o ) MATHEMATICAL SANS-SERIF SMALL O → LATIN SMALL LETTER O#
+    {120265, "p"},   // MA# ( 𝗉 → p ) MATHEMATICAL SANS-SERIF SMALL P → LATIN SMALL LETTER P#
+    {120266, "q"},   // MA# ( 𝗊 → q ) MATHEMATICAL SANS-SERIF SMALL Q → LATIN SMALL LETTER Q#
+    {120267, "r"},   // MA# ( 𝗋 → r ) MATHEMATICAL SANS-SERIF SMALL R → LATIN SMALL LETTER R#
+    {120268, "s"},   // MA# ( 𝗌 → s ) MATHEMATICAL SANS-SERIF SMALL S → LATIN SMALL LETTER S#
+    {120269, "t"},   // MA# ( 𝗍 → t ) MATHEMATICAL SANS-SERIF SMALL T → LATIN SMALL LETTER T#
+    {120270, "u"},   // MA# ( 𝗎 → u ) MATHEMATICAL SANS-SERIF SMALL U → LATIN SMALL LETTER U#
+    {120271, "v"},   // MA# ( 𝗏 → v ) MATHEMATICAL SANS-SERIF SMALL V → LATIN SMALL LETTER V#
+    {120272, "w"},   // MA# ( 𝗐 → w ) MATHEMATICAL SANS-SERIF SMALL W → LATIN SMALL LETTER W#
+    {120273, "x"},   // MA# ( 𝗑 → x ) MATHEMATICAL SANS-SERIF SMALL X → LATIN SMALL LETTER X#
+    {120274, "y"},   // MA# ( 𝗒 → y ) MATHEMATICAL SANS-SERIF SMALL Y → LATIN SMALL LETTER Y#
+    {120275, "z"},   // MA# ( 𝗓 → z ) MATHEMATICAL SANS-SERIF SMALL Z → LATIN SMALL LETTER Z#
+    {120276, "A"},   // MA# ( 𝗔 → A ) MATHEMATICAL SANS-SERIF BOLD CAPITAL A → LATIN CAPITAL LETTER A#
+    {120277, "B"},   // MA# ( 𝗕 → B ) MATHEMATICAL SANS-SERIF BOLD CAPITAL B → LATIN CAPITAL LETTER B#
+    {120278, "C"},   // MA# ( 𝗖 → C ) MATHEMATICAL SANS-SERIF BOLD CAPITAL C → LATIN CAPITAL LETTER C#
+    {120279, "D"},   // MA# ( 𝗗 → D ) MATHEMATICAL SANS-SERIF BOLD CAPITAL D → LATIN CAPITAL LETTER D#
+    {120280, "E"},   // MA# ( 𝗘 → E ) MATHEMATICAL SANS-SERIF BOLD CAPITAL E → LATIN CAPITAL LETTER E#
+    {120281, "F"},   // MA# ( 𝗙 → F ) MATHEMATICAL SANS-SERIF BOLD CAPITAL F → LATIN CAPITAL LETTER F#
+    {120282, "G"},   // MA# ( 𝗚 → G ) MATHEMATICAL SANS-SERIF BOLD CAPITAL G → LATIN CAPITAL LETTER G#
+    {120283, "H"},   // MA# ( 𝗛 → H ) MATHEMATICAL SANS-SERIF BOLD CAPITAL H → LATIN CAPITAL LETTER H#
+    {120284, "l"},   // MA# ( 𝗜 → l ) MATHEMATICAL SANS-SERIF BOLD CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120285, "J"},   // MA# ( 𝗝 → J ) MATHEMATICAL SANS-SERIF BOLD CAPITAL J → LATIN CAPITAL LETTER J#
+    {120286, "K"},   // MA# ( 𝗞 → K ) MATHEMATICAL SANS-SERIF BOLD CAPITAL K → LATIN CAPITAL LETTER K#
+    {120287, "L"},   // MA# ( 𝗟 → L ) MATHEMATICAL SANS-SERIF BOLD CAPITAL L → LATIN CAPITAL LETTER L#
+    {120288, "M"},   // MA# ( 𝗠 → M ) MATHEMATICAL SANS-SERIF BOLD CAPITAL M → LATIN CAPITAL LETTER M#
+    {120289, "N"},   // MA# ( 𝗡 → N ) MATHEMATICAL SANS-SERIF BOLD CAPITAL N → LATIN CAPITAL LETTER N#
+    {120290, "O"},   // MA# ( 𝗢 → O ) MATHEMATICAL SANS-SERIF BOLD CAPITAL O → LATIN CAPITAL LETTER O#
+    {120291, "P"},   // MA# ( 𝗣 → P ) MATHEMATICAL SANS-SERIF BOLD CAPITAL P → LATIN CAPITAL LETTER P#
+    {120292, "Q"},   // MA# ( 𝗤 → Q ) MATHEMATICAL SANS-SERIF BOLD CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120293, "R"},   // MA# ( 𝗥 → R ) MATHEMATICAL SANS-SERIF BOLD CAPITAL R → LATIN CAPITAL LETTER R#
+    {120294, "S"},   // MA# ( 𝗦 → S ) MATHEMATICAL SANS-SERIF BOLD CAPITAL S → LATIN CAPITAL LETTER S#
+    {120295, "T"},   // MA# ( 𝗧 → T ) MATHEMATICAL SANS-SERIF BOLD CAPITAL T → LATIN CAPITAL LETTER T#
+    {120296, "U"},   // MA# ( 𝗨 → U ) MATHEMATICAL SANS-SERIF BOLD CAPITAL U → LATIN CAPITAL LETTER U#
+    {120297, "V"},   // MA# ( 𝗩 → V ) MATHEMATICAL SANS-SERIF BOLD CAPITAL V → LATIN CAPITAL LETTER V#
+    {120298, "W"},   // MA# ( 𝗪 → W ) MATHEMATICAL SANS-SERIF BOLD CAPITAL W → LATIN CAPITAL LETTER W#
+    {120299, "X"},   // MA# ( 𝗫 → X ) MATHEMATICAL SANS-SERIF BOLD CAPITAL X → LATIN CAPITAL LETTER X#
+    {120300, "Y"},   // MA# ( 𝗬 → Y ) MATHEMATICAL SANS-SERIF BOLD CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120301, "Z"},   // MA# ( 𝗭 → Z ) MATHEMATICAL SANS-SERIF BOLD CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120302, "a"},   // MA# ( 𝗮 → a ) MATHEMATICAL SANS-SERIF BOLD SMALL A → LATIN SMALL LETTER A#
+    {120303, "b"},   // MA# ( 𝗯 → b ) MATHEMATICAL SANS-SERIF BOLD SMALL B → LATIN SMALL LETTER B#
+    {120304, "c"},   // MA# ( 𝗰 → c ) MATHEMATICAL SANS-SERIF BOLD SMALL C → LATIN SMALL LETTER C#
+    {120305, "d"},   // MA# ( 𝗱 → d ) MATHEMATICAL SANS-SERIF BOLD SMALL D → LATIN SMALL LETTER D#
+    {120306, "e"},   // MA# ( 𝗲 → e ) MATHEMATICAL SANS-SERIF BOLD SMALL E → LATIN SMALL LETTER E#
+    {120307, "f"},   // MA# ( 𝗳 → f ) MATHEMATICAL SANS-SERIF BOLD SMALL F → LATIN SMALL LETTER F#
+    {120308, "g"},   // MA# ( 𝗴 → g ) MATHEMATICAL SANS-SERIF BOLD SMALL G → LATIN SMALL LETTER G#
+    {120309, "h"},   // MA# ( 𝗵 → h ) MATHEMATICAL SANS-SERIF BOLD SMALL H → LATIN SMALL LETTER H#
+    {120310, "i"},   // MA# ( 𝗶 → i ) MATHEMATICAL SANS-SERIF BOLD SMALL I → LATIN SMALL LETTER I#
+    {120311, "j"},   // MA# ( 𝗷 → j ) MATHEMATICAL SANS-SERIF BOLD SMALL J → LATIN SMALL LETTER J#
+    {120312, "k"},   // MA# ( 𝗸 → k ) MATHEMATICAL SANS-SERIF BOLD SMALL K → LATIN SMALL LETTER K#
+    {120313, "l"},   // MA# ( 𝗹 → l ) MATHEMATICAL SANS-SERIF BOLD SMALL L → LATIN SMALL LETTER L#
+    {120314, "rn"},  // MA# ( 𝗺 → rn ) MATHEMATICAL SANS-SERIF BOLD SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120315, "n"},   // MA# ( 𝗻 → n ) MATHEMATICAL SANS-SERIF BOLD SMALL N → LATIN SMALL LETTER N#
+    {120316, "o"},   // MA# ( 𝗼 → o ) MATHEMATICAL SANS-SERIF BOLD SMALL O → LATIN SMALL LETTER O#
+    {120317, "p"},   // MA# ( 𝗽 → p ) MATHEMATICAL SANS-SERIF BOLD SMALL P → LATIN SMALL LETTER P#
+    {120318, "q"},   // MA# ( 𝗾 → q ) MATHEMATICAL SANS-SERIF BOLD SMALL Q → LATIN SMALL LETTER Q#
+    {120319, "r"},   // MA# ( 𝗿 → r ) MATHEMATICAL SANS-SERIF BOLD SMALL R → LATIN SMALL LETTER R#
+    {120320, "s"},   // MA# ( 𝘀 → s ) MATHEMATICAL SANS-SERIF BOLD SMALL S → LATIN SMALL LETTER S#
+    {120321, "t"},   // MA# ( 𝘁 → t ) MATHEMATICAL SANS-SERIF BOLD SMALL T → LATIN SMALL LETTER T#
+    {120322, "u"},   // MA# ( 𝘂 → u ) MATHEMATICAL SANS-SERIF BOLD SMALL U → LATIN SMALL LETTER U#
+    {120323, "v"},   // MA# ( 𝘃 → v ) MATHEMATICAL SANS-SERIF BOLD SMALL V → LATIN SMALL LETTER V#
+    {120324, "w"},   // MA# ( 𝘄 → w ) MATHEMATICAL SANS-SERIF BOLD SMALL W → LATIN SMALL LETTER W#
+    {120325, "x"},   // MA# ( 𝘅 → x ) MATHEMATICAL SANS-SERIF BOLD SMALL X → LATIN SMALL LETTER X#
+    {120326, "y"},   // MA# ( 𝘆 → y ) MATHEMATICAL SANS-SERIF BOLD SMALL Y → LATIN SMALL LETTER Y#
+    {120327, "z"},   // MA# ( 𝘇 → z ) MATHEMATICAL SANS-SERIF BOLD SMALL Z → LATIN SMALL LETTER Z#
+    {120328, "A"},   // MA# ( 𝘈 → A ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL A → LATIN CAPITAL LETTER A#
+    {120329, "B"},   // MA# ( 𝘉 → B ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL B → LATIN CAPITAL LETTER B#
+    {120330, "C"},   // MA# ( 𝘊 → C ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL C → LATIN CAPITAL LETTER C#
+    {120331, "D"},   // MA# ( 𝘋 → D ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL D → LATIN CAPITAL LETTER D#
+    {120332, "E"},   // MA# ( 𝘌 → E ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL E → LATIN CAPITAL LETTER E#
+    {120333, "F"},   // MA# ( 𝘍 → F ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL F → LATIN CAPITAL LETTER F#
+    {120334, "G"},   // MA# ( 𝘎 → G ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL G → LATIN CAPITAL LETTER G#
+    {120335, "H"},   // MA# ( 𝘏 → H ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL H → LATIN CAPITAL LETTER H#
+    {120336, "l"},   // MA# ( 𝘐 → l ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120337, "J"},   // MA# ( 𝘑 → J ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL J → LATIN CAPITAL LETTER J#
+    {120338, "K"},   // MA# ( 𝘒 → K ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL K → LATIN CAPITAL LETTER K#
+    {120339, "L"},   // MA# ( 𝘓 → L ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL L → LATIN CAPITAL LETTER L#
+    {120340, "M"},   // MA# ( 𝘔 → M ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL M → LATIN CAPITAL LETTER M#
+    {120341, "N"},   // MA# ( 𝘕 → N ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL N → LATIN CAPITAL LETTER N#
+    {120342, "O"},   // MA# ( 𝘖 → O ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL O → LATIN CAPITAL LETTER O#
+    {120343, "P"},   // MA# ( 𝘗 → P ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL P → LATIN CAPITAL LETTER P#
+    {120344, "Q"},   // MA# ( 𝘘 → Q ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120345, "R"},   // MA# ( 𝘙 → R ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL R → LATIN CAPITAL LETTER R#
+    {120346, "S"},   // MA# ( 𝘚 → S ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL S → LATIN CAPITAL LETTER S#
+    {120347, "T"},   // MA# ( 𝘛 → T ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL T → LATIN CAPITAL LETTER T#
+    {120348, "U"},   // MA# ( 𝘜 → U ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL U → LATIN CAPITAL LETTER U#
+    {120349, "V"},   // MA# ( 𝘝 → V ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL V → LATIN CAPITAL LETTER V#
+    {120350, "W"},   // MA# ( 𝘞 → W ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL W → LATIN CAPITAL LETTER W#
+    {120351, "X"},   // MA# ( 𝘟 → X ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL X → LATIN CAPITAL LETTER X#
+    {120352, "Y"},   // MA# ( 𝘠 → Y ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120353, "Z"},   // MA# ( 𝘡 → Z ) MATHEMATICAL SANS-SERIF ITALIC CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120354, "a"},   // MA# ( 𝘢 → a ) MATHEMATICAL SANS-SERIF ITALIC SMALL A → LATIN SMALL LETTER A#
+    {120355, "b"},   // MA# ( 𝘣 → b ) MATHEMATICAL SANS-SERIF ITALIC SMALL B → LATIN SMALL LETTER B#
+    {120356, "c"},   // MA# ( 𝘤 → c ) MATHEMATICAL SANS-SERIF ITALIC SMALL C → LATIN SMALL LETTER C#
+    {120357, "d"},   // MA# ( 𝘥 → d ) MATHEMATICAL SANS-SERIF ITALIC SMALL D → LATIN SMALL LETTER D#
+    {120358, "e"},   // MA# ( 𝘦 → e ) MATHEMATICAL SANS-SERIF ITALIC SMALL E → LATIN SMALL LETTER E#
+    {120359, "f"},   // MA# ( 𝘧 → f ) MATHEMATICAL SANS-SERIF ITALIC SMALL F → LATIN SMALL LETTER F#
+    {120360, "g"},   // MA# ( 𝘨 → g ) MATHEMATICAL SANS-SERIF ITALIC SMALL G → LATIN SMALL LETTER G#
+    {120361, "h"},   // MA# ( 𝘩 → h ) MATHEMATICAL SANS-SERIF ITALIC SMALL H → LATIN SMALL LETTER H#
+    {120362, "i"},   // MA# ( 𝘪 → i ) MATHEMATICAL SANS-SERIF ITALIC SMALL I → LATIN SMALL LETTER I#
+    {120363, "j"},   // MA# ( 𝘫 → j ) MATHEMATICAL SANS-SERIF ITALIC SMALL J → LATIN SMALL LETTER J#
+    {120364, "k"},   // MA# ( 𝘬 → k ) MATHEMATICAL SANS-SERIF ITALIC SMALL K → LATIN SMALL LETTER K#
+    {120365, "l"},   // MA# ( 𝘭 → l ) MATHEMATICAL SANS-SERIF ITALIC SMALL L → LATIN SMALL LETTER L#
+    {120366, "rn"},  // MA# ( 𝘮 → rn ) MATHEMATICAL SANS-SERIF ITALIC SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120367, "n"},   // MA# ( 𝘯 → n ) MATHEMATICAL SANS-SERIF ITALIC SMALL N → LATIN SMALL LETTER N#
+    {120368, "o"},   // MA# ( 𝘰 → o ) MATHEMATICAL SANS-SERIF ITALIC SMALL O → LATIN SMALL LETTER O#
+    {120369, "p"},   // MA# ( 𝘱 → p ) MATHEMATICAL SANS-SERIF ITALIC SMALL P → LATIN SMALL LETTER P#
+    {120370, "q"},   // MA# ( 𝘲 → q ) MATHEMATICAL SANS-SERIF ITALIC SMALL Q → LATIN SMALL LETTER Q#
+    {120371, "r"},   // MA# ( 𝘳 → r ) MATHEMATICAL SANS-SERIF ITALIC SMALL R → LATIN SMALL LETTER R#
+    {120372, "s"},   // MA# ( 𝘴 → s ) MATHEMATICAL SANS-SERIF ITALIC SMALL S → LATIN SMALL LETTER S#
+    {120373, "t"},   // MA# ( 𝘵 → t ) MATHEMATICAL SANS-SERIF ITALIC SMALL T → LATIN SMALL LETTER T#
+    {120374, "u"},   // MA# ( 𝘶 → u ) MATHEMATICAL SANS-SERIF ITALIC SMALL U → LATIN SMALL LETTER U#
+    {120375, "v"},   // MA# ( 𝘷 → v ) MATHEMATICAL SANS-SERIF ITALIC SMALL V → LATIN SMALL LETTER V#
+    {120376, "w"},   // MA# ( 𝘸 → w ) MATHEMATICAL SANS-SERIF ITALIC SMALL W → LATIN SMALL LETTER W#
+    {120377, "x"},   // MA# ( 𝘹 → x ) MATHEMATICAL SANS-SERIF ITALIC SMALL X → LATIN SMALL LETTER X#
+    {120378, "y"},   // MA# ( 𝘺 → y ) MATHEMATICAL SANS-SERIF ITALIC SMALL Y → LATIN SMALL LETTER Y#
+    {120379, "z"},   // MA# ( 𝘻 → z ) MATHEMATICAL SANS-SERIF ITALIC SMALL Z → LATIN SMALL LETTER Z#
+    {120380, "A"},   // MA# ( 𝘼 → A ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL A → LATIN CAPITAL LETTER A#
+    {120381, "B"},   // MA# ( 𝘽 → B ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL B → LATIN CAPITAL LETTER B#
+    {120382, "C"},   // MA# ( 𝘾 → C ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL C → LATIN CAPITAL LETTER C#
+    {120383, "D"},   // MA# ( 𝘿 → D ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL D → LATIN CAPITAL LETTER D#
+    {120384, "E"},   // MA# ( 𝙀 → E ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL E → LATIN CAPITAL LETTER E#
+    {120385, "F"},   // MA# ( 𝙁 → F ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL F → LATIN CAPITAL LETTER F#
+    {120386, "G"},   // MA# ( 𝙂 → G ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL G → LATIN CAPITAL LETTER G#
+    {120387, "H"},   // MA# ( 𝙃 → H ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL H → LATIN CAPITAL LETTER H#
+    {120388, "l"},   // MA# ( 𝙄 → l ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120389, "J"},   // MA# ( 𝙅 → J ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL J → LATIN CAPITAL LETTER J#
+    {120390, "K"},   // MA# ( 𝙆 → K ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL K → LATIN CAPITAL LETTER K#
+    {120391, "L"},   // MA# ( 𝙇 → L ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL L → LATIN CAPITAL LETTER L#
+    {120392, "M"},   // MA# ( 𝙈 → M ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL M → LATIN CAPITAL LETTER M#
+    {120393, "N"},   // MA# ( 𝙉 → N ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL N → LATIN CAPITAL LETTER N#
+    {120394, "O"},   // MA# ( 𝙊 → O ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL O → LATIN CAPITAL LETTER O#
+    {120395, "P"},   // MA# ( 𝙋 → P ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL P → LATIN CAPITAL LETTER P#
+    {120396, "Q"},   // MA# ( 𝙌 → Q ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120397, "R"},   // MA# ( 𝙍 → R ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL R → LATIN CAPITAL LETTER R#
+    {120398, "S"},   // MA# ( 𝙎 → S ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL S → LATIN CAPITAL LETTER S#
+    {120399, "T"},   // MA# ( 𝙏 → T ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL T → LATIN CAPITAL LETTER T#
+    {120400, "U"},   // MA# ( 𝙐 → U ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL U → LATIN CAPITAL LETTER U#
+    {120401, "V"},   // MA# ( 𝙑 → V ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL V → LATIN CAPITAL LETTER V#
+    {120402, "W"},   // MA# ( 𝙒 → W ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL W → LATIN CAPITAL LETTER W#
+    {120403, "X"},   // MA# ( 𝙓 → X ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL X → LATIN CAPITAL LETTER X#
+    {120404, "Y"},   // MA# ( 𝙔 → Y ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120405, "Z"},   // MA# ( 𝙕 → Z ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120406, "a"},   // MA# ( 𝙖 → a ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL A → LATIN SMALL LETTER A#
+    {120407, "b"},   // MA# ( 𝙗 → b ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL B → LATIN SMALL LETTER B#
+    {120408, "c"},   // MA# ( 𝙘 → c ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL C → LATIN SMALL LETTER C#
+    {120409, "d"},   // MA# ( 𝙙 → d ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL D → LATIN SMALL LETTER D#
+    {120410, "e"},   // MA# ( 𝙚 → e ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL E → LATIN SMALL LETTER E#
+    {120411, "f"},   // MA# ( 𝙛 → f ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL F → LATIN SMALL LETTER F#
+    {120412, "g"},   // MA# ( 𝙜 → g ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL G → LATIN SMALL LETTER G#
+    {120413, "h"},   // MA# ( 𝙝 → h ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL H → LATIN SMALL LETTER H#
+    {120414, "i"},   // MA# ( 𝙞 → i ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I → LATIN SMALL LETTER I#
+    {120415, "j"},   // MA# ( 𝙟 → j ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J → LATIN SMALL LETTER J#
+    {120416, "k"},   // MA# ( 𝙠 → k ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL K → LATIN SMALL LETTER K#
+    {120417, "l"},   // MA# ( 𝙡 → l ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL L → LATIN SMALL LETTER L#
+    {120418, "rn"},  // MA# ( 𝙢 → rn ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120419, "n"},   // MA# ( 𝙣 → n ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL N → LATIN SMALL LETTER N#
+    {120420, "o"},   // MA# ( 𝙤 → o ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL O → LATIN SMALL LETTER O#
+    {120421, "p"},   // MA# ( 𝙥 → p ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL P → LATIN SMALL LETTER P#
+    {120422, "q"},   // MA# ( 𝙦 → q ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Q → LATIN SMALL LETTER Q#
+    {120423, "r"},   // MA# ( 𝙧 → r ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL R → LATIN SMALL LETTER R#
+    {120424, "s"},   // MA# ( 𝙨 → s ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL S → LATIN SMALL LETTER S#
+    {120425, "t"},   // MA# ( 𝙩 → t ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL T → LATIN SMALL LETTER T#
+    {120426, "u"},   // MA# ( 𝙪 → u ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL U → LATIN SMALL LETTER U#
+    {120427, "v"},   // MA# ( 𝙫 → v ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL V → LATIN SMALL LETTER V#
+    {120428, "w"},   // MA# ( 𝙬 → w ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL W → LATIN SMALL LETTER W#
+    {120429, "x"},   // MA# ( 𝙭 → x ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL X → LATIN SMALL LETTER X#
+    {120430, "y"},   // MA# ( 𝙮 → y ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Y → LATIN SMALL LETTER Y#
+    {120431, "z"},   // MA# ( 𝙯 → z ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Z → LATIN SMALL LETTER Z#
+    {120432, "A"},   // MA# ( 𝙰 → A ) MATHEMATICAL MONOSPACE CAPITAL A → LATIN CAPITAL LETTER A#
+    {120433, "B"},   // MA# ( 𝙱 → B ) MATHEMATICAL MONOSPACE CAPITAL B → LATIN CAPITAL LETTER B#
+    {120434, "C"},   // MA# ( 𝙲 → C ) MATHEMATICAL MONOSPACE CAPITAL C → LATIN CAPITAL LETTER C#
+    {120435, "D"},   // MA# ( 𝙳 → D ) MATHEMATICAL MONOSPACE CAPITAL D → LATIN CAPITAL LETTER D#
+    {120436, "E"},   // MA# ( 𝙴 → E ) MATHEMATICAL MONOSPACE CAPITAL E → LATIN CAPITAL LETTER E#
+    {120437, "F"},   // MA# ( 𝙵 → F ) MATHEMATICAL MONOSPACE CAPITAL F → LATIN CAPITAL LETTER F#
+    {120438, "G"},   // MA# ( 𝙶 → G ) MATHEMATICAL MONOSPACE CAPITAL G → LATIN CAPITAL LETTER G#
+    {120439, "H"},   // MA# ( 𝙷 → H ) MATHEMATICAL MONOSPACE CAPITAL H → LATIN CAPITAL LETTER H#
+    {120440, "l"},   // MA# ( 𝙸 → l ) MATHEMATICAL MONOSPACE CAPITAL I → LATIN SMALL LETTER L# →I→
+    {120441, "J"},   // MA# ( 𝙹 → J ) MATHEMATICAL MONOSPACE CAPITAL J → LATIN CAPITAL LETTER J#
+    {120442, "K"},   // MA# ( 𝙺 → K ) MATHEMATICAL MONOSPACE CAPITAL K → LATIN CAPITAL LETTER K#
+    {120443, "L"},   // MA# ( 𝙻 → L ) MATHEMATICAL MONOSPACE CAPITAL L → LATIN CAPITAL LETTER L#
+    {120444, "M"},   // MA# ( 𝙼 → M ) MATHEMATICAL MONOSPACE CAPITAL M → LATIN CAPITAL LETTER M#
+    {120445, "N"},   // MA# ( 𝙽 → N ) MATHEMATICAL MONOSPACE CAPITAL N → LATIN CAPITAL LETTER N#
+    {120446, "O"},   // MA# ( 𝙾 → O ) MATHEMATICAL MONOSPACE CAPITAL O → LATIN CAPITAL LETTER O#
+    {120447, "P"},   // MA# ( 𝙿 → P ) MATHEMATICAL MONOSPACE CAPITAL P → LATIN CAPITAL LETTER P#
+    {120448, "Q"},   // MA# ( 𝚀 → Q ) MATHEMATICAL MONOSPACE CAPITAL Q → LATIN CAPITAL LETTER Q#
+    {120449, "R"},   // MA# ( 𝚁 → R ) MATHEMATICAL MONOSPACE CAPITAL R → LATIN CAPITAL LETTER R#
+    {120450, "S"},   // MA# ( 𝚂 → S ) MATHEMATICAL MONOSPACE CAPITAL S → LATIN CAPITAL LETTER S#
+    {120451, "T"},   // MA# ( 𝚃 → T ) MATHEMATICAL MONOSPACE CAPITAL T → LATIN CAPITAL LETTER T#
+    {120452, "U"},   // MA# ( 𝚄 → U ) MATHEMATICAL MONOSPACE CAPITAL U → LATIN CAPITAL LETTER U#
+    {120453, "V"},   // MA# ( 𝚅 → V ) MATHEMATICAL MONOSPACE CAPITAL V → LATIN CAPITAL LETTER V#
+    {120454, "W"},   // MA# ( 𝚆 → W ) MATHEMATICAL MONOSPACE CAPITAL W → LATIN CAPITAL LETTER W#
+    {120455, "X"},   // MA# ( 𝚇 → X ) MATHEMATICAL MONOSPACE CAPITAL X → LATIN CAPITAL LETTER X#
+    {120456, "Y"},   // MA# ( 𝚈 → Y ) MATHEMATICAL MONOSPACE CAPITAL Y → LATIN CAPITAL LETTER Y#
+    {120457, "Z"},   // MA# ( 𝚉 → Z ) MATHEMATICAL MONOSPACE CAPITAL Z → LATIN CAPITAL LETTER Z#
+    {120458, "a"},   // MA# ( 𝚊 → a ) MATHEMATICAL MONOSPACE SMALL A → LATIN SMALL LETTER A#
+    {120459, "b"},   // MA# ( 𝚋 → b ) MATHEMATICAL MONOSPACE SMALL B → LATIN SMALL LETTER B#
+    {120460, "c"},   // MA# ( 𝚌 → c ) MATHEMATICAL MONOSPACE SMALL C → LATIN SMALL LETTER C#
+    {120461, "d"},   // MA# ( 𝚍 → d ) MATHEMATICAL MONOSPACE SMALL D → LATIN SMALL LETTER D#
+    {120462, "e"},   // MA# ( 𝚎 → e ) MATHEMATICAL MONOSPACE SMALL E → LATIN SMALL LETTER E#
+    {120463, "f"},   // MA# ( 𝚏 → f ) MATHEMATICAL MONOSPACE SMALL F → LATIN SMALL LETTER F#
+    {120464, "g"},   // MA# ( 𝚐 → g ) MATHEMATICAL MONOSPACE SMALL G → LATIN SMALL LETTER G#
+    {120465, "h"},   // MA# ( 𝚑 → h ) MATHEMATICAL MONOSPACE SMALL H → LATIN SMALL LETTER H#
+    {120466, "i"},   // MA# ( 𝚒 → i ) MATHEMATICAL MONOSPACE SMALL I → LATIN SMALL LETTER I#
+    {120467, "j"},   // MA# ( 𝚓 → j ) MATHEMATICAL MONOSPACE SMALL J → LATIN SMALL LETTER J#
+    {120468, "k"},   // MA# ( 𝚔 → k ) MATHEMATICAL MONOSPACE SMALL K → LATIN SMALL LETTER K#
+    {120469, "l"},   // MA# ( 𝚕 → l ) MATHEMATICAL MONOSPACE SMALL L → LATIN SMALL LETTER L#
+    {120470, "rn"},  // MA# ( 𝚖 → rn ) MATHEMATICAL MONOSPACE SMALL M → LATIN SMALL LETTER R, LATIN SMALL LETTER N# →m→
+    {120471, "n"},   // MA# ( 𝚗 → n ) MATHEMATICAL MONOSPACE SMALL N → LATIN SMALL LETTER N#
+    {120472, "o"},   // MA# ( 𝚘 → o ) MATHEMATICAL MONOSPACE SMALL O → LATIN SMALL LETTER O#
+    {120473, "p"},   // MA# ( 𝚙 → p ) MATHEMATICAL MONOSPACE SMALL P → LATIN SMALL LETTER P#
+    {120474, "q"},   // MA# ( 𝚚 → q ) MATHEMATICAL MONOSPACE SMALL Q → LATIN SMALL LETTER Q#
+    {120475, "r"},   // MA# ( 𝚛 → r ) MATHEMATICAL MONOSPACE SMALL R → LATIN SMALL LETTER R#
+    {120476, "s"},   // MA# ( 𝚜 → s ) MATHEMATICAL MONOSPACE SMALL S → LATIN SMALL LETTER S#
+    {120477, "t"},   // MA# ( 𝚝 → t ) MATHEMATICAL MONOSPACE SMALL T → LATIN SMALL LETTER T#
+    {120478, "u"},   // MA# ( 𝚞 → u ) MATHEMATICAL MONOSPACE SMALL U → LATIN SMALL LETTER U#
+    {120479, "v"},   // MA# ( 𝚟 → v ) MATHEMATICAL MONOSPACE SMALL V → LATIN SMALL LETTER V#
+    {120480, "w"},   // MA# ( 𝚠 → w ) MATHEMATICAL MONOSPACE SMALL W → LATIN SMALL LETTER W#
+    {120481, "x"},   // MA# ( 𝚡 → x ) MATHEMATICAL MONOSPACE SMALL X → LATIN SMALL LETTER X#
+    {120482, "y"},   // MA# ( 𝚢 → y ) MATHEMATICAL MONOSPACE SMALL Y → LATIN SMALL LETTER Y#
+    {120483, "z"},   // MA# ( 𝚣 → z ) MATHEMATICAL MONOSPACE SMALL Z → LATIN SMALL LETTER Z#
+    {120484, "i"},   // MA# ( 𝚤 → i ) MATHEMATICAL ITALIC SMALL DOTLESS I → LATIN SMALL LETTER I# →ı→
+    {120488, "A"},   // MA# ( 𝚨 → A ) MATHEMATICAL BOLD CAPITAL ALPHA → LATIN CAPITAL LETTER A# →𝐀→
+    {120489, "B"},   // MA# ( 𝚩 → B ) MATHEMATICAL BOLD CAPITAL BETA → LATIN CAPITAL LETTER B# →Β→
+    {120492, "E"},   // MA# ( 𝚬 → E ) MATHEMATICAL BOLD CAPITAL EPSILON → LATIN CAPITAL LETTER E# →𝐄→
+    {120493, "Z"},   // MA# ( 𝚭 → Z ) MATHEMATICAL BOLD CAPITAL ZETA → LATIN CAPITAL LETTER Z# →Ζ→
+    {120494, "H"},   // MA# ( 𝚮 → H ) MATHEMATICAL BOLD CAPITAL ETA → LATIN CAPITAL LETTER H# →Η→
+    {120496, "l"},   // MA# ( 𝚰 → l ) MATHEMATICAL BOLD CAPITAL IOTA → LATIN SMALL LETTER L# →Ι→
+    {120497, "K"},   // MA# ( 𝚱 → K ) MATHEMATICAL BOLD CAPITAL KAPPA → LATIN CAPITAL LETTER K# →Κ→
+    {120499, "M"},   // MA# ( 𝚳 → M ) MATHEMATICAL BOLD CAPITAL MU → LATIN CAPITAL LETTER M# →𝐌→
+    {120500, "N"},   // MA# ( 𝚴 → N ) MATHEMATICAL BOLD CAPITAL NU → LATIN CAPITAL LETTER N# →𝐍→
+    {120502, "O"},   // MA# ( 𝚶 → O ) MATHEMATICAL BOLD CAPITAL OMICRON → LATIN CAPITAL LETTER O# →𝐎→
+    {120504, "P"},   // MA# ( 𝚸 → P ) MATHEMATICAL BOLD CAPITAL RHO → LATIN CAPITAL LETTER P# →𝐏→
+    {120507, "T"},   // MA# ( 𝚻 → T ) MATHEMATICAL BOLD CAPITAL TAU → LATIN CAPITAL LETTER T# →Τ→
+    {120508, "Y"},   // MA# ( 𝚼 → Y ) MATHEMATICAL BOLD CAPITAL UPSILON → LATIN CAPITAL LETTER Y# →Υ→
+    {120510, "X"},   // MA# ( 𝚾 → X ) MATHEMATICAL BOLD CAPITAL CHI → LATIN CAPITAL LETTER X# →Χ→
+    {120514, "a"},   // MA# ( 𝛂 → a ) MATHEMATICAL BOLD SMALL ALPHA → LATIN SMALL LETTER A# →α→
+    {120516, "y"},   // MA# ( 𝛄 → y ) MATHEMATICAL BOLD SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {120522, "i"},   // MA# ( 𝛊 → i ) MATHEMATICAL BOLD SMALL IOTA → LATIN SMALL LETTER I# →ι→
+    {120526, "v"},   // MA# ( 𝛎 → v ) MATHEMATICAL BOLD SMALL NU → LATIN SMALL LETTER V# →ν→
+    {120528, "o"},   // MA# ( 𝛐 → o ) MATHEMATICAL BOLD SMALL OMICRON → LATIN SMALL LETTER O# →𝐨→
+    {120530, "p"},   // MA# ( 𝛒 → p ) MATHEMATICAL BOLD SMALL RHO → LATIN SMALL LETTER P# →ρ→
+    {120532, "o"},   // MA# ( 𝛔 → o ) MATHEMATICAL BOLD SMALL SIGMA → LATIN SMALL LETTER O# →σ→
+    {120534, "u"},   // MA# ( 𝛖 → u ) MATHEMATICAL BOLD SMALL UPSILON → LATIN SMALL LETTER U# →υ→→ʋ→
+    {120544, "p"},   // MA# ( 𝛠 → p ) MATHEMATICAL BOLD RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {120546, "A"},   // MA# ( 𝛢 → A ) MATHEMATICAL ITALIC CAPITAL ALPHA → LATIN CAPITAL LETTER A# →Α→
+    {120547, "B"},   // MA# ( 𝛣 → B ) MATHEMATICAL ITALIC CAPITAL BETA → LATIN CAPITAL LETTER B# →Β→
+    {120550, "E"},   // MA# ( 𝛦 → E ) MATHEMATICAL ITALIC CAPITAL EPSILON → LATIN CAPITAL LETTER E# →Ε→
+    {120551, "Z"},   // MA# ( 𝛧 → Z ) MATHEMATICAL ITALIC CAPITAL ZETA → LATIN CAPITAL LETTER Z# →𝑍→
+    {120552, "H"},   // MA# ( 𝛨 → H ) MATHEMATICAL ITALIC CAPITAL ETA → LATIN CAPITAL LETTER H# →Η→
+    {120554, "l"},   // MA# ( 𝛪 → l ) MATHEMATICAL ITALIC CAPITAL IOTA → LATIN SMALL LETTER L# →Ι→
+    {120555, "K"},   // MA# ( 𝛫 → K ) MATHEMATICAL ITALIC CAPITAL KAPPA → LATIN CAPITAL LETTER K# →𝐾→
+    {120557, "M"},   // MA# ( 𝛭 → M ) MATHEMATICAL ITALIC CAPITAL MU → LATIN CAPITAL LETTER M# →𝑀→
+    {120558, "N"},   // MA# ( 𝛮 → N ) MATHEMATICAL ITALIC CAPITAL NU → LATIN CAPITAL LETTER N# →𝑁→
+    {120560, "O"},   // MA# ( 𝛰 → O ) MATHEMATICAL ITALIC CAPITAL OMICRON → LATIN CAPITAL LETTER O# →𝑂→
+    {120562, "P"},   // MA# ( 𝛲 → P ) MATHEMATICAL ITALIC CAPITAL RHO → LATIN CAPITAL LETTER P# →Ρ→
+    {120565, "T"},   // MA# ( 𝛵 → T ) MATHEMATICAL ITALIC CAPITAL TAU → LATIN CAPITAL LETTER T# →Τ→
+    {120566, "Y"},   // MA# ( 𝛶 → Y ) MATHEMATICAL ITALIC CAPITAL UPSILON → LATIN CAPITAL LETTER Y# →Υ→
+    {120568, "X"},   // MA# ( 𝛸 → X ) MATHEMATICAL ITALIC CAPITAL CHI → LATIN CAPITAL LETTER X# →Χ→
+    {120572, "a"},   // MA# ( 𝛼 → a ) MATHEMATICAL ITALIC SMALL ALPHA → LATIN SMALL LETTER A# →α→
+    {120574, "y"},   // MA# ( 𝛾 → y ) MATHEMATICAL ITALIC SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {120580, "i"},   // MA# ( 𝜄 → i ) MATHEMATICAL ITALIC SMALL IOTA → LATIN SMALL LETTER I# →ι→
+    {120584, "v"},   // MA# ( 𝜈 → v ) MATHEMATICAL ITALIC SMALL NU → LATIN SMALL LETTER V# →ν→
+    {120586, "o"},   // MA# ( 𝜊 → o ) MATHEMATICAL ITALIC SMALL OMICRON → LATIN SMALL LETTER O# →𝑜→
+    {120588, "p"},   // MA# ( 𝜌 → p ) MATHEMATICAL ITALIC SMALL RHO → LATIN SMALL LETTER P# →ρ→
+    {120590, "o"},   // MA# ( 𝜎 → o ) MATHEMATICAL ITALIC SMALL SIGMA → LATIN SMALL LETTER O# →σ→
+    {120592, "u"},   // MA# ( 𝜐 → u ) MATHEMATICAL ITALIC SMALL UPSILON → LATIN SMALL LETTER U# →υ→→ʋ→
+    {120602, "p"},   // MA# ( 𝜚 → p ) MATHEMATICAL ITALIC RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {120604, "A"},   // MA# ( 𝜜 → A ) MATHEMATICAL BOLD ITALIC CAPITAL ALPHA → LATIN CAPITAL LETTER A# →Α→
+    {120605, "B"},   // MA# ( 𝜝 → B ) MATHEMATICAL BOLD ITALIC CAPITAL BETA → LATIN CAPITAL LETTER B# →Β→
+    {120608, "E"},   // MA# ( 𝜠 → E ) MATHEMATICAL BOLD ITALIC CAPITAL EPSILON → LATIN CAPITAL LETTER E# →Ε→
+    {120609, "Z"},   // MA# ( 𝜡 → Z ) MATHEMATICAL BOLD ITALIC CAPITAL ZETA → LATIN CAPITAL LETTER Z# →Ζ→
+    {120610, "H"},   // MA# ( 𝜢 → H ) MATHEMATICAL BOLD ITALIC CAPITAL ETA → LATIN CAPITAL LETTER H# →𝑯→
+    {120612, "l"},   // MA# ( 𝜤 → l ) MATHEMATICAL BOLD ITALIC CAPITAL IOTA → LATIN SMALL LETTER L# →Ι→
+    {120613, "K"},   // MA# ( 𝜥 → K ) MATHEMATICAL BOLD ITALIC CAPITAL KAPPA → LATIN CAPITAL LETTER K# →𝑲→
+    {120615, "M"},   // MA# ( 𝜧 → M ) MATHEMATICAL BOLD ITALIC CAPITAL MU → LATIN CAPITAL LETTER M# →𝑴→
+    {120616, "N"},   // MA# ( 𝜨 → N ) MATHEMATICAL BOLD ITALIC CAPITAL NU → LATIN CAPITAL LETTER N# →𝑵→
+    {120618, "O"},   // MA# ( 𝜪 → O ) MATHEMATICAL BOLD ITALIC CAPITAL OMICRON → LATIN CAPITAL LETTER O# →𝑶→
+    {120620, "P"},   // MA# ( 𝜬 → P ) MATHEMATICAL BOLD ITALIC CAPITAL RHO → LATIN CAPITAL LETTER P# →Ρ→
+    {120623, "T"},   // MA# ( 𝜯 → T ) MATHEMATICAL BOLD ITALIC CAPITAL TAU → LATIN CAPITAL LETTER T# →Τ→
+    {120624, "Y"},   // MA# ( 𝜰 → Y ) MATHEMATICAL BOLD ITALIC CAPITAL UPSILON → LATIN CAPITAL LETTER Y# →Υ→
+    {120626, "X"},   // MA# ( 𝜲 → X ) MATHEMATICAL BOLD ITALIC CAPITAL CHI → LATIN CAPITAL LETTER X# →𝑿→
+    {120630, "a"},   // MA# ( 𝜶 → a ) MATHEMATICAL BOLD ITALIC SMALL ALPHA → LATIN SMALL LETTER A# →α→
+    {120632, "y"},   // MA# ( 𝜸 → y ) MATHEMATICAL BOLD ITALIC SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {120638, "i"},   // MA# ( 𝜾 → i ) MATHEMATICAL BOLD ITALIC SMALL IOTA → LATIN SMALL LETTER I# →ι→
+    {120642, "v"},   // MA# ( 𝝂 → v ) MATHEMATICAL BOLD ITALIC SMALL NU → LATIN SMALL LETTER V# →ν→
+    {120644, "o"},   // MA# ( 𝝄 → o ) MATHEMATICAL BOLD ITALIC SMALL OMICRON → LATIN SMALL LETTER O# →𝒐→
+    {120646, "p"},   // MA# ( 𝝆 → p ) MATHEMATICAL BOLD ITALIC SMALL RHO → LATIN SMALL LETTER P# →ρ→
+    {120648, "o"},   // MA# ( 𝝈 → o ) MATHEMATICAL BOLD ITALIC SMALL SIGMA → LATIN SMALL LETTER O# →σ→
+    {120650, "u"},   // MA# ( 𝝊 → u ) MATHEMATICAL BOLD ITALIC SMALL UPSILON → LATIN SMALL LETTER U# →υ→→ʋ→
+    {120660, "p"},   // MA# ( 𝝔 → p ) MATHEMATICAL BOLD ITALIC RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {120662, "A"},   // MA# ( 𝝖 → A ) MATHEMATICAL SANS-SERIF BOLD CAPITAL ALPHA → LATIN CAPITAL LETTER A# →Α→
+    {120663, "B"},   // MA# ( 𝝗 → B ) MATHEMATICAL SANS-SERIF BOLD CAPITAL BETA → LATIN CAPITAL LETTER B# →Β→
+    {120666, "E"},   // MA# ( 𝝚 → E ) MATHEMATICAL SANS-SERIF BOLD CAPITAL EPSILON → LATIN CAPITAL LETTER E# →Ε→
+    {120667, "Z"},   // MA# ( 𝝛 → Z ) MATHEMATICAL SANS-SERIF BOLD CAPITAL ZETA → LATIN CAPITAL LETTER Z# →Ζ→
+    {120668, "H"},   // MA# ( 𝝜 → H ) MATHEMATICAL SANS-SERIF BOLD CAPITAL ETA → LATIN CAPITAL LETTER H# →Η→
+    {120670, "l"},   // MA# ( 𝝞 → l ) MATHEMATICAL SANS-SERIF BOLD CAPITAL IOTA → LATIN SMALL LETTER L# →Ι→
+    {120671, "K"},   // MA# ( 𝝟 → K ) MATHEMATICAL SANS-SERIF BOLD CAPITAL KAPPA → LATIN CAPITAL LETTER K# →Κ→
+    {120673, "M"},   // MA# ( 𝝡 → M ) MATHEMATICAL SANS-SERIF BOLD CAPITAL MU → LATIN CAPITAL LETTER M# →Μ→
+    {120674, "N"},   // MA# ( 𝝢 → N ) MATHEMATICAL SANS-SERIF BOLD CAPITAL NU → LATIN CAPITAL LETTER N# →Ν→
+    {120676, "O"},   // MA# ( 𝝤 → O ) MATHEMATICAL SANS-SERIF BOLD CAPITAL OMICRON → LATIN CAPITAL LETTER O# →Ο→
+    {120678, "P"},   // MA# ( 𝝦 → P ) MATHEMATICAL SANS-SERIF BOLD CAPITAL RHO → LATIN CAPITAL LETTER P# →Ρ→
+    {120681, "T"},   // MA# ( 𝝩 → T ) MATHEMATICAL SANS-SERIF BOLD CAPITAL TAU → LATIN CAPITAL LETTER T# →Τ→
+    {120682, "Y"},   // MA# ( 𝝪 → Y ) MATHEMATICAL SANS-SERIF BOLD CAPITAL UPSILON → LATIN CAPITAL LETTER Y# →Υ→
+    {120684, "X"},   // MA# ( 𝝬 → X ) MATHEMATICAL SANS-SERIF BOLD CAPITAL CHI → LATIN CAPITAL LETTER X# →Χ→
+    {120688, "a"},   // MA# ( 𝝰 → a ) MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA → LATIN SMALL LETTER A# →α→
+    {120690, "y"},   // MA# ( 𝝲 → y ) MATHEMATICAL SANS-SERIF BOLD SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {120696, "i"},   // MA# ( 𝝸 → i ) MATHEMATICAL SANS-SERIF BOLD SMALL IOTA → LATIN SMALL LETTER I# →ι→
+    {120700, "v"},   // MA# ( 𝝼 → v ) MATHEMATICAL SANS-SERIF BOLD SMALL NU → LATIN SMALL LETTER V# →ν→
+    {120702, "o"},   // MA# ( 𝝾 → o ) MATHEMATICAL SANS-SERIF BOLD SMALL OMICRON → LATIN SMALL LETTER O# →ο→
+    {120704, "p"},   // MA# ( 𝞀 → p ) MATHEMATICAL SANS-SERIF BOLD SMALL RHO → LATIN SMALL LETTER P# →ρ→
+    {120706, "o"},   // MA# ( 𝞂 → o ) MATHEMATICAL SANS-SERIF BOLD SMALL SIGMA → LATIN SMALL LETTER O# →σ→
+    {120708, "u"},   // MA# ( 𝞄 → u ) MATHEMATICAL SANS-SERIF BOLD SMALL UPSILON → LATIN SMALL LETTER U# →υ→→ʋ→
+    {120718, "p"},   // MA# ( 𝞎 → p ) MATHEMATICAL SANS-SERIF BOLD RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {120720, "A"},   // MA# ( 𝞐 → A ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ALPHA → LATIN CAPITAL LETTER A# →Α→
+    {120721, "B"},   // MA# ( 𝞑 → B ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL BETA → LATIN CAPITAL LETTER B# →Β→
+    {120724, "E"},   // MA# ( 𝞔 → E ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL EPSILON → LATIN CAPITAL LETTER E# →Ε→
+    {120725, "Z"},   // MA# ( 𝞕 → Z ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ZETA → LATIN CAPITAL LETTER Z# →Ζ→
+    {120726, "H"},   // MA# ( 𝞖 → H ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ETA → LATIN CAPITAL LETTER H# →Η→
+    {120728, "l"},   // MA# ( 𝞘 → l ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL IOTA → LATIN SMALL LETTER L# →Ι→
+    {120729, "K"},   // MA# ( 𝞙 → K ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL KAPPA → LATIN CAPITAL LETTER K# →Κ→
+    {120731, "M"},   // MA# ( 𝞛 → M ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL MU → LATIN CAPITAL LETTER M# →Μ→
+    {120732, "N"},   // MA# ( 𝞜 → N ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL NU → LATIN CAPITAL LETTER N# →Ν→
+    {120734, "O"},   // MA# ( 𝞞 → O ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMICRON → LATIN CAPITAL LETTER O# →Ο→
+    {120736, "P"},   // MA# ( 𝞠 → P ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL RHO → LATIN CAPITAL LETTER P# →Ρ→
+    {120739, "T"},   // MA# ( 𝞣 → T ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL TAU → LATIN CAPITAL LETTER T# →Τ→
+    {120740, "Y"},   // MA# ( 𝞤 → Y ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL UPSILON → LATIN CAPITAL LETTER Y# →Υ→
+    {120742, "X"},   // MA# ( 𝞦 → X ) MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL CHI → LATIN CAPITAL LETTER X# →Χ→
+    {120746, "a"},   // MA# ( 𝞪 → a ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA → LATIN SMALL LETTER A# →α→
+    {120748, "y"},   // MA# ( 𝞬 → y ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL GAMMA → LATIN SMALL LETTER Y# →γ→
+    {120754, "i"},   // MA# ( 𝞲 → i ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL IOTA → LATIN SMALL LETTER I# →ι→
+    {120758, "v"},   // MA# ( 𝞶 → v ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL NU → LATIN SMALL LETTER V# →ν→
+    {120760, "o"},   // MA# ( 𝞸 → o ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMICRON → LATIN SMALL LETTER O# →ο→
+    {120762, "p"},   // MA# ( 𝞺 → p ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL RHO → LATIN SMALL LETTER P# →ρ→
+    {120764, "o"},   // MA# ( 𝞼 → o ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL SIGMA → LATIN SMALL LETTER O# →σ→
+    {120766, "u"},   // MA# ( 𝞾 → u ) MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL UPSILON → LATIN SMALL LETTER U# →υ→→ʋ→
+    {120776, "p"},   // MA# ( 𝟈 → p ) MATHEMATICAL SANS-SERIF BOLD ITALIC RHO SYMBOL → LATIN SMALL LETTER P# →ρ→
+    {120778, "F"},   // MA# ( 𝟊 → F ) MATHEMATICAL BOLD CAPITAL DIGAMMA → LATIN CAPITAL LETTER F# →Ϝ→
+    {120782, "O"},   // MA# ( 𝟎 → O ) MATHEMATICAL BOLD DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {120783, "l"},   // MA# ( 𝟏 → l ) MATHEMATICAL BOLD DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {120784, "2"},   // MA# ( 𝟐 → 2 ) MATHEMATICAL BOLD DIGIT TWO → DIGIT TWO#
+    {120785, "3"},   // MA# ( 𝟑 → 3 ) MATHEMATICAL BOLD DIGIT THREE → DIGIT THREE#
+    {120786, "4"},   // MA# ( 𝟒 → 4 ) MATHEMATICAL BOLD DIGIT FOUR → DIGIT FOUR#
+    {120787, "5"},   // MA# ( 𝟓 → 5 ) MATHEMATICAL BOLD DIGIT FIVE → DIGIT FIVE#
+    {120788, "6"},   // MA# ( 𝟔 → 6 ) MATHEMATICAL BOLD DIGIT SIX → DIGIT SIX#
+    {120789, "7"},   // MA# ( 𝟕 → 7 ) MATHEMATICAL BOLD DIGIT SEVEN → DIGIT SEVEN#
+    {120790, "8"},   // MA# ( 𝟖 → 8 ) MATHEMATICAL BOLD DIGIT EIGHT → DIGIT EIGHT#
+    {120791, "9"},   // MA# ( 𝟗 → 9 ) MATHEMATICAL BOLD DIGIT NINE → DIGIT NINE#
+    {120792, "O"},   // MA# ( 𝟘 → O ) MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {120793, "l"},   // MA# ( 𝟙 → l ) MATHEMATICAL DOUBLE-STRUCK DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {120794, "2"},   // MA# ( 𝟚 → 2 ) MATHEMATICAL DOUBLE-STRUCK DIGIT TWO → DIGIT TWO#
+    {120795, "3"},   // MA# ( 𝟛 → 3 ) MATHEMATICAL DOUBLE-STRUCK DIGIT THREE → DIGIT THREE#
+    {120796, "4"},   // MA# ( 𝟜 → 4 ) MATHEMATICAL DOUBLE-STRUCK DIGIT FOUR → DIGIT FOUR#
+    {120797, "5"},   // MA# ( 𝟝 → 5 ) MATHEMATICAL DOUBLE-STRUCK DIGIT FIVE → DIGIT FIVE#
+    {120798, "6"},   // MA# ( 𝟞 → 6 ) MATHEMATICAL DOUBLE-STRUCK DIGIT SIX → DIGIT SIX#
+    {120799, "7"},   // MA# ( 𝟟 → 7 ) MATHEMATICAL DOUBLE-STRUCK DIGIT SEVEN → DIGIT SEVEN#
+    {120800, "8"},   // MA# ( 𝟠 → 8 ) MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT → DIGIT EIGHT#
+    {120801, "9"},   // MA# ( 𝟡 → 9 ) MATHEMATICAL DOUBLE-STRUCK DIGIT NINE → DIGIT NINE#
+    {120802, "O"},   // MA# ( 𝟢 → O ) MATHEMATICAL SANS-SERIF DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {120803, "l"},   // MA# ( 𝟣 → l ) MATHEMATICAL SANS-SERIF DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {120804, "2"},   // MA# ( 𝟤 → 2 ) MATHEMATICAL SANS-SERIF DIGIT TWO → DIGIT TWO#
+    {120805, "3"},   // MA# ( 𝟥 → 3 ) MATHEMATICAL SANS-SERIF DIGIT THREE → DIGIT THREE#
+    {120806, "4"},   // MA# ( 𝟦 → 4 ) MATHEMATICAL SANS-SERIF DIGIT FOUR → DIGIT FOUR#
+    {120807, "5"},   // MA# ( 𝟧 → 5 ) MATHEMATICAL SANS-SERIF DIGIT FIVE → DIGIT FIVE#
+    {120808, "6"},   // MA# ( 𝟨 → 6 ) MATHEMATICAL SANS-SERIF DIGIT SIX → DIGIT SIX#
+    {120809, "7"},   // MA# ( 𝟩 → 7 ) MATHEMATICAL SANS-SERIF DIGIT SEVEN → DIGIT SEVEN#
+    {120810, "8"},   // MA# ( 𝟪 → 8 ) MATHEMATICAL SANS-SERIF DIGIT EIGHT → DIGIT EIGHT#
+    {120811, "9"},   // MA# ( 𝟫 → 9 ) MATHEMATICAL SANS-SERIF DIGIT NINE → DIGIT NINE#
+    {120812, "O"},   // MA# ( 𝟬 → O ) MATHEMATICAL SANS-SERIF BOLD DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {120813, "l"},   // MA# ( 𝟭 → l ) MATHEMATICAL SANS-SERIF BOLD DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {120814, "2"},   // MA# ( 𝟮 → 2 ) MATHEMATICAL SANS-SERIF BOLD DIGIT TWO → DIGIT TWO#
+    {120815, "3"},   // MA# ( 𝟯 → 3 ) MATHEMATICAL SANS-SERIF BOLD DIGIT THREE → DIGIT THREE#
+    {120816, "4"},   // MA# ( 𝟰 → 4 ) MATHEMATICAL SANS-SERIF BOLD DIGIT FOUR → DIGIT FOUR#
+    {120817, "5"},   // MA# ( 𝟱 → 5 ) MATHEMATICAL SANS-SERIF BOLD DIGIT FIVE → DIGIT FIVE#
+    {120818, "6"},   // MA# ( 𝟲 → 6 ) MATHEMATICAL SANS-SERIF BOLD DIGIT SIX → DIGIT SIX#
+    {120819, "7"},   // MA# ( 𝟳 → 7 ) MATHEMATICAL SANS-SERIF BOLD DIGIT SEVEN → DIGIT SEVEN#
+    {120820, "8"},   // MA# ( 𝟴 → 8 ) MATHEMATICAL SANS-SERIF BOLD DIGIT EIGHT → DIGIT EIGHT#
+    {120821, "9"},   // MA# ( 𝟵 → 9 ) MATHEMATICAL SANS-SERIF BOLD DIGIT NINE → DIGIT NINE#
+    {120822, "O"},   // MA# ( 𝟶 → O ) MATHEMATICAL MONOSPACE DIGIT ZERO → LATIN CAPITAL LETTER O# →0→
+    {120823, "l"},   // MA# ( 𝟷 → l ) MATHEMATICAL MONOSPACE DIGIT ONE → LATIN SMALL LETTER L# →1→
+    {120824, "2"},   // MA# ( 𝟸 → 2 ) MATHEMATICAL MONOSPACE DIGIT TWO → DIGIT TWO#
+    {120825, "3"},   // MA# ( 𝟹 → 3 ) MATHEMATICAL MONOSPACE DIGIT THREE → DIGIT THREE#
+    {120826, "4"},   // MA# ( 𝟺 → 4 ) MATHEMATICAL MONOSPACE DIGIT FOUR → DIGIT FOUR#
+    {120827, "5"},   // MA# ( 𝟻 → 5 ) MATHEMATICAL MONOSPACE DIGIT FIVE → DIGIT FIVE#
+    {120828, "6"},   // MA# ( 𝟼 → 6 ) MATHEMATICAL MONOSPACE DIGIT SIX → DIGIT SIX#
+    {120829, "7"},   // MA# ( 𝟽 → 7 ) MATHEMATICAL MONOSPACE DIGIT SEVEN → DIGIT SEVEN#
+    {120830, "8"},   // MA# ( 𝟾 → 8 ) MATHEMATICAL MONOSPACE DIGIT EIGHT → DIGIT EIGHT#
+    {120831, "9"},   // MA# ( 𝟿 → 9 ) MATHEMATICAL MONOSPACE DIGIT NINE → DIGIT NINE#
+    {125127, "l"},   // MA#* ( ‎𞣇‎ → l ) MENDE KIKAKUI DIGIT ONE → LATIN SMALL LETTER L#
+    {125131, "8"},   // MA#* ( ‎𞣋‎ → 8 ) MENDE KIKAKUI DIGIT FIVE → DIGIT EIGHT#
+    {126464, "l"},   // MA# ( ‎𞸀‎ → l ) ARABIC MATHEMATICAL ALEF → LATIN SMALL LETTER L# →‎ا‎→→1→
+    {126500, "o"},   // MA# ( ‎𞸤‎ → o ) ARABIC MATHEMATICAL INITIAL HEH → LATIN SMALL LETTER O# →‎ه‎→
+    {126564, "o"},   // MA# ( ‎𞹤‎ → o ) ARABIC MATHEMATICAL STRETCHED HEH → LATIN SMALL LETTER O# →‎ه‎→
+    {126592, "l"},   // MA# ( ‎𞺀‎ → l ) ARABIC MATHEMATICAL LOOPED ALEF → LATIN SMALL LETTER L# →‎ا‎→→1→
+    {126596, "o"},   // MA# ( ‎𞺄‎ → o ) ARABIC MATHEMATICAL LOOPED HEH → LATIN SMALL LETTER O# →‎ه‎→
+    {127232, "O."},  // MA#* ( 🄀 → O. ) DIGIT ZERO FULL STOP → LATIN CAPITAL LETTER O, FULL STOP# →0.→
+    {127233, "O,"},  // MA#* ( 🄁 → O, ) DIGIT ZERO COMMA → LATIN CAPITAL LETTER O, COMMA# →0,→
+    {127234, "l,"},  // MA#* ( 🄂 → l, ) DIGIT ONE COMMA → LATIN SMALL LETTER L, COMMA# →1,→
+    {127235, "2,"},  // MA#* ( 🄃 → 2, ) DIGIT TWO COMMA → DIGIT TWO, COMMA#
+    {127236, "3,"},  // MA#* ( 🄄 → 3, ) DIGIT THREE COMMA → DIGIT THREE, COMMA#
+    {127237, "4,"},  // MA#* ( 🄅 → 4, ) DIGIT FOUR COMMA → DIGIT FOUR, COMMA#
+    {127238, "5,"},  // MA#* ( 🄆 → 5, ) DIGIT FIVE COMMA → DIGIT FIVE, COMMA#
+    {127239, "6,"},  // MA#* ( 🄇 → 6, ) DIGIT SIX COMMA → DIGIT SIX, COMMA#
+    {127240, "7,"},  // MA#* ( 🄈 → 7, ) DIGIT SEVEN COMMA → DIGIT SEVEN, COMMA#
+    {127241, "8,"},  // MA#* ( 🄉 → 8, ) DIGIT EIGHT COMMA → DIGIT EIGHT, COMMA#
+    {127242, "9,"},  // MA#* ( 🄊 → 9, ) DIGIT NINE COMMA → DIGIT NINE, COMMA#
+    {127248, "(A)"}, // MA#* ( 🄐 → (A) ) PARENTHESIZED LATIN CAPITAL LETTER A → LEFT PARENTHESIS, LATIN CAPITAL LETTER A, RIGHT PARENTHESIS#
+    {127249, "(B)"}, // MA#* ( 🄑 → (B) ) PARENTHESIZED LATIN CAPITAL LETTER B → LEFT PARENTHESIS, LATIN CAPITAL LETTER B, RIGHT PARENTHESIS#
+    {127250, "(C)"}, // MA#* ( 🄒 → (C) ) PARENTHESIZED LATIN CAPITAL LETTER C → LEFT PARENTHESIS, LATIN CAPITAL LETTER C, RIGHT PARENTHESIS#
+    {127251, "(D)"}, // MA#* ( 🄓 → (D) ) PARENTHESIZED LATIN CAPITAL LETTER D → LEFT PARENTHESIS, LATIN CAPITAL LETTER D, RIGHT PARENTHESIS#
+    {127252, "(E)"}, // MA#* ( 🄔 → (E) ) PARENTHESIZED LATIN CAPITAL LETTER E → LEFT PARENTHESIS, LATIN CAPITAL LETTER E, RIGHT PARENTHESIS#
+    {127253, "(F)"}, // MA#* ( 🄕 → (F) ) PARENTHESIZED LATIN CAPITAL LETTER F → LEFT PARENTHESIS, LATIN CAPITAL LETTER F, RIGHT PARENTHESIS#
+    {127254, "(G)"}, // MA#* ( 🄖 → (G) ) PARENTHESIZED LATIN CAPITAL LETTER G → LEFT PARENTHESIS, LATIN CAPITAL LETTER G, RIGHT PARENTHESIS#
+    {127255, "(H)"}, // MA#* ( 🄗 → (H) ) PARENTHESIZED LATIN CAPITAL LETTER H → LEFT PARENTHESIS, LATIN CAPITAL LETTER H, RIGHT PARENTHESIS#
+    {127256, "(l)"}, // MA#* ( 🄘 → (l) ) PARENTHESIZED LATIN CAPITAL LETTER I → LEFT PARENTHESIS, LATIN SMALL LETTER L, RIGHT PARENTHESIS# →(I)→
+    {127257, "(J)"}, // MA#* ( 🄙 → (J) ) PARENTHESIZED LATIN CAPITAL LETTER J → LEFT PARENTHESIS, LATIN CAPITAL LETTER J, RIGHT PARENTHESIS#
+    {127258, "(K)"}, // MA#* ( 🄚 → (K) ) PARENTHESIZED LATIN CAPITAL LETTER K → LEFT PARENTHESIS, LATIN CAPITAL LETTER K, RIGHT PARENTHESIS#
+    {127259, "(L)"}, // MA#* ( 🄛 → (L) ) PARENTHESIZED LATIN CAPITAL LETTER L → LEFT PARENTHESIS, LATIN CAPITAL LETTER L, RIGHT PARENTHESIS#
+    {127260, "(M)"}, // MA#* ( 🄜 → (M) ) PARENTHESIZED LATIN CAPITAL LETTER M → LEFT PARENTHESIS, LATIN CAPITAL LETTER M, RIGHT PARENTHESIS#
+    {127261, "(N)"}, // MA#* ( 🄝 → (N) ) PARENTHESIZED LATIN CAPITAL LETTER N → LEFT PARENTHESIS, LATIN CAPITAL LETTER N, RIGHT PARENTHESIS#
+    {127262, "(O)"}, // MA#* ( 🄞 → (O) ) PARENTHESIZED LATIN CAPITAL LETTER O → LEFT PARENTHESIS, LATIN CAPITAL LETTER O, RIGHT PARENTHESIS#
+    {127263, "(P)"}, // MA#* ( 🄟 → (P) ) PARENTHESIZED LATIN CAPITAL LETTER P → LEFT PARENTHESIS, LATIN CAPITAL LETTER P, RIGHT PARENTHESIS#
+    {127264, "(Q)"}, // MA#* ( 🄠 → (Q) ) PARENTHESIZED LATIN CAPITAL LETTER Q → LEFT PARENTHESIS, LATIN CAPITAL LETTER Q, RIGHT PARENTHESIS#
+    {127265, "(R)"}, // MA#* ( 🄡 → (R) ) PARENTHESIZED LATIN CAPITAL LETTER R → LEFT PARENTHESIS, LATIN CAPITAL LETTER R, RIGHT PARENTHESIS#
+    {127266, "(S)"}, // MA#* ( 🄢 → (S) ) PARENTHESIZED LATIN CAPITAL LETTER S → LEFT PARENTHESIS, LATIN CAPITAL LETTER S, RIGHT PARENTHESIS#
+    {127267, "(T)"}, // MA#* ( 🄣 → (T) ) PARENTHESIZED LATIN CAPITAL LETTER T → LEFT PARENTHESIS, LATIN CAPITAL LETTER T, RIGHT PARENTHESIS#
+    {127268, "(U)"}, // MA#* ( 🄤 → (U) ) PARENTHESIZED LATIN CAPITAL LETTER U → LEFT PARENTHESIS, LATIN CAPITAL LETTER U, RIGHT PARENTHESIS#
+    {127269, "(V)"}, // MA#* ( 🄥 → (V) ) PARENTHESIZED LATIN CAPITAL LETTER V → LEFT PARENTHESIS, LATIN CAPITAL LETTER V, RIGHT PARENTHESIS#
+    {127270, "(W)"}, // MA#* ( 🄦 → (W) ) PARENTHESIZED LATIN CAPITAL LETTER W → LEFT PARENTHESIS, LATIN CAPITAL LETTER W, RIGHT PARENTHESIS#
+    {127271, "(X)"}, // MA#* ( 🄧 → (X) ) PARENTHESIZED LATIN CAPITAL LETTER X → LEFT PARENTHESIS, LATIN CAPITAL LETTER X, RIGHT PARENTHESIS#
+    {127272, "(Y)"}, // MA#* ( 🄨 → (Y) ) PARENTHESIZED LATIN CAPITAL LETTER Y → LEFT PARENTHESIS, LATIN CAPITAL LETTER Y, RIGHT PARENTHESIS#
+    {127273, "(Z)"}, // MA#* ( 🄩 → (Z) ) PARENTHESIZED LATIN CAPITAL LETTER Z → LEFT PARENTHESIS, LATIN CAPITAL LETTER Z, RIGHT PARENTHESIS#
+    {127274, "(S)"}, // MA#* ( 🄪 → (S) ) TORTOISE SHELL BRACKETED LATIN CAPITAL LETTER S → LEFT PARENTHESIS, LATIN CAPITAL LETTER S, RIGHT PARENTHESIS# →〔S〕→
+    {128768, "QE"},  // MA#* ( 🜀 → QE ) ALCHEMICAL SYMBOL FOR QUINTESSENCE → LATIN CAPITAL LETTER Q, LATIN CAPITAL LETTER E#
+    {128775, "AR"},  // MA#* ( 🜇 → AR ) ALCHEMICAL SYMBOL FOR AQUA REGIA-2 → LATIN CAPITAL LETTER A, LATIN CAPITAL LETTER R#
+    {128844, "C"},   // MA#* ( 🝌 → C ) ALCHEMICAL SYMBOL FOR CALX → LATIN CAPITAL LETTER C#
+    {128860, "sss"}, // MA#* ( 🝜 → sss ) ALCHEMICAL SYMBOL FOR STRATUM SUPER STRATUM → LATIN SMALL LETTER S, LATIN SMALL LETTER S, LATIN SMALL LETTER S#
+    {128872, "T"},   // MA#* ( 🝨 → T ) ALCHEMICAL SYMBOL FOR CRUCIBLE-4 → LATIN CAPITAL LETTER T#
+    {128875, "MB"},  // MA#* ( 🝫 → MB ) ALCHEMICAL SYMBOL FOR BATH OF MARY → LATIN CAPITAL LETTER M, LATIN CAPITAL LETTER B#
+    {128876, "VB"},  // MA#* ( 🝬 → VB ) ALCHEMICAL SYMBOL FOR BATH OF VAPOURS → LATIN CAPITAL LETTER V, LATIN CAPITAL LETTER B#
+};
+// clang-format on
+
+const char* findConfusable(uint32_t codepoint)
+{
+    auto it = std::lower_bound(std::begin(kConfusables), std::end(kConfusables), codepoint, [](const Confusable& lhs, uint32_t rhs) {
+        return lhs.codepoint < rhs;
+    });
+
+    return (it != std::end(kConfusables) && it->codepoint == codepoint) ? it->text : nullptr;
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/src/Lexer.cpp
+++ b/lib/luau/Ast/src/Lexer.cpp
@@ -1,0 +1,1318 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Lexer.h"
+
+#include "Luau/Common.h"
+#include "Luau/Confusables.h"
+#include "Luau/StringUtils.h"
+
+#include <limits.h>
+
+LUAU_FASTFLAGVARIABLE(LuauLexerLookaheadRemembersBraceType, false)
+LUAU_FASTFLAGVARIABLE(LuauCheckedFunctionSyntax, false)
+
+namespace Luau
+{
+
+Allocator::Allocator()
+    : root(static_cast<Page*>(operator new(sizeof(Page))))
+    , offset(0)
+{
+    root->next = nullptr;
+}
+
+Allocator::Allocator(Allocator&& rhs)
+    : root(rhs.root)
+    , offset(rhs.offset)
+{
+    rhs.root = nullptr;
+    rhs.offset = 0;
+}
+
+Allocator::~Allocator()
+{
+    Page* page = root;
+
+    while (page)
+    {
+        Page* next = page->next;
+
+        operator delete(page);
+
+        page = next;
+    }
+}
+
+void* Allocator::allocate(size_t size)
+{
+    constexpr size_t align = alignof(void*) > alignof(double) ? alignof(void*) : alignof(double);
+
+    if (root)
+    {
+        uintptr_t data = reinterpret_cast<uintptr_t>(root->data);
+        uintptr_t result = (data + offset + align - 1) & ~(align - 1);
+        if (result + size <= data + sizeof(root->data))
+        {
+            offset = result - data + size;
+            return reinterpret_cast<void*>(result);
+        }
+    }
+
+    // allocate new page
+    size_t pageSize = size > sizeof(root->data) ? size : sizeof(root->data);
+    void* pageData = operator new(offsetof(Page, data) + pageSize);
+
+    Page* page = static_cast<Page*>(pageData);
+
+    page->next = root;
+
+    root = page;
+    offset = size;
+
+    return page->data;
+}
+
+Lexeme::Lexeme(const Location& location, Type type)
+    : type(type)
+    , location(location)
+    , length(0)
+    , data(nullptr)
+{
+}
+
+Lexeme::Lexeme(const Location& location, char character)
+    : type(static_cast<Type>(static_cast<unsigned char>(character)))
+    , location(location)
+    , length(0)
+    , data(nullptr)
+{
+}
+
+Lexeme::Lexeme(const Location& location, Type type, const char* data, size_t size)
+    : type(type)
+    , location(location)
+    , length(unsigned(size))
+    , data(data)
+{
+    LUAU_ASSERT(type == RawString || type == QuotedString || type == InterpStringBegin || type == InterpStringMid || type == InterpStringEnd ||
+                type == InterpStringSimple || type == BrokenInterpDoubleBrace || type == Number || type == Comment || type == BlockComment);
+}
+
+Lexeme::Lexeme(const Location& location, Type type, const char* name)
+    : type(type)
+    , location(location)
+    , length(0)
+    , name(name)
+{
+    LUAU_ASSERT(type == Name || (type >= Reserved_BEGIN && type < Lexeme::Reserved_END));
+}
+
+static const char* kReserved[] = {"and", "break", "do", "else", "elseif", "end", "false", "for", "function", "if", "in", "local", "nil", "not", "or",
+    "repeat", "return", "then", "true", "until", "while", "@checked"};
+
+std::string Lexeme::toString() const
+{
+    switch (type)
+    {
+    case Eof:
+        return "<eof>";
+
+    case Equal:
+        return "'=='";
+
+    case LessEqual:
+        return "'<='";
+
+    case GreaterEqual:
+        return "'>='";
+
+    case NotEqual:
+        return "'~='";
+
+    case Dot2:
+        return "'..'";
+
+    case Dot3:
+        return "'...'";
+
+    case SkinnyArrow:
+        return "'->'";
+
+    case DoubleColon:
+        return "'::'";
+
+    case FloorDiv:
+        return "'//'";
+
+    case AddAssign:
+        return "'+='";
+
+    case SubAssign:
+        return "'-='";
+
+    case MulAssign:
+        return "'*='";
+
+    case DivAssign:
+        return "'/='";
+
+    case FloorDivAssign:
+        return "'//='";
+
+    case ModAssign:
+        return "'%='";
+
+    case PowAssign:
+        return "'^='";
+
+    case ConcatAssign:
+        return "'..='";
+
+    case RawString:
+    case QuotedString:
+        return data ? format("\"%.*s\"", length, data) : "string";
+
+    case InterpStringBegin:
+        return data ? format("`%.*s{", length, data) : "the beginning of an interpolated string";
+
+    case InterpStringMid:
+        return data ? format("}%.*s{", length, data) : "the middle of an interpolated string";
+
+    case InterpStringEnd:
+        return data ? format("}%.*s`", length, data) : "the end of an interpolated string";
+
+    case InterpStringSimple:
+        return data ? format("`%.*s`", length, data) : "interpolated string";
+
+    case Number:
+        return data ? format("'%.*s'", length, data) : "number";
+
+    case Name:
+        return name ? format("'%s'", name) : "identifier";
+
+    case Comment:
+        return "comment";
+
+    case BrokenString:
+        return "malformed string";
+
+    case BrokenComment:
+        return "unfinished comment";
+
+    case BrokenInterpDoubleBrace:
+        return "'{{', which is invalid (did you mean '\\{'?)";
+
+    case BrokenUnicode:
+        if (codepoint)
+        {
+            if (const char* confusable = findConfusable(codepoint))
+                return format("Unicode character U+%x (did you mean '%s'?)", codepoint, confusable);
+
+            return format("Unicode character U+%x", codepoint);
+        }
+        else
+        {
+            return "invalid UTF-8 sequence";
+        }
+
+    default:
+        if (type < Char_END)
+            return format("'%c'", type);
+        else if (type >= Reserved_BEGIN && type < Reserved_END)
+            return format("'%s'", kReserved[type - Reserved_BEGIN]);
+        else
+            return "<unknown>";
+    }
+}
+
+bool AstNameTable::Entry::operator==(const Entry& other) const
+{
+    return length == other.length && memcmp(value.value, other.value.value, length) == 0;
+}
+
+size_t AstNameTable::EntryHash::operator()(const Entry& e) const
+{
+    // FNV1a
+    uint32_t hash = 2166136261;
+
+    for (size_t i = 0; i < e.length; ++i)
+    {
+        hash ^= uint8_t(e.value.value[i]);
+        hash *= 16777619;
+    }
+
+    return hash;
+}
+
+AstNameTable::AstNameTable(Allocator& allocator)
+    : data({AstName(""), 0, Lexeme::Eof}, 128)
+    , allocator(allocator)
+{
+    static_assert(sizeof(kReserved) / sizeof(kReserved[0]) == Lexeme::Reserved_END - Lexeme::Reserved_BEGIN);
+
+    for (int i = Lexeme::Reserved_BEGIN; i < Lexeme::Reserved_END; ++i)
+        addStatic(kReserved[i - Lexeme::Reserved_BEGIN], static_cast<Lexeme::Type>(i));
+}
+
+AstName AstNameTable::addStatic(const char* name, Lexeme::Type type)
+{
+    AstNameTable::Entry entry = {AstName(name), uint32_t(strlen(name)), type};
+
+    LUAU_ASSERT(!data.contains(entry));
+    data.insert(entry);
+
+    return entry.value;
+}
+
+std::pair<AstName, Lexeme::Type> AstNameTable::getOrAddWithType(const char* name, size_t length)
+{
+    AstNameTable::Entry key = {AstName(name), uint32_t(length), Lexeme::Eof};
+    const Entry& entry = data.insert(key);
+
+    // entry already was inserted
+    if (entry.type != Lexeme::Eof)
+        return std::make_pair(entry.value, entry.type);
+
+    // we just inserted an entry with a non-owned pointer into the map
+    // we need to correct it, *but* we need to be careful about not disturbing the hash value
+    char* nameData = static_cast<char*>(allocator.allocate(length + 1));
+    memcpy(nameData, name, length);
+    nameData[length] = 0;
+
+    const_cast<Entry&>(entry).value = AstName(nameData);
+    const_cast<Entry&>(entry).type = Lexeme::Name;
+
+    return std::make_pair(entry.value, entry.type);
+}
+
+std::pair<AstName, Lexeme::Type> AstNameTable::getWithType(const char* name, size_t length) const
+{
+    if (const Entry* entry = data.find({AstName(name), uint32_t(length), Lexeme::Eof}))
+    {
+        return std::make_pair(entry->value, entry->type);
+    }
+    return std::make_pair(AstName(), Lexeme::Name);
+}
+
+AstName AstNameTable::getOrAdd(const char* name)
+{
+    return getOrAddWithType(name, strlen(name)).first;
+}
+
+AstName AstNameTable::get(const char* name) const
+{
+    return getWithType(name, strlen(name)).first;
+}
+
+inline bool isAlpha(char ch)
+{
+    // use or trick to convert to lower case and unsigned comparison to do range check
+    return unsigned((ch | ' ') - 'a') < 26;
+}
+
+inline bool isDigit(char ch)
+{
+    return unsigned(ch - '0') < 10;
+}
+
+inline bool isHexDigit(char ch)
+{
+    // use or trick to convert to lower case and unsigned comparison to do range check
+    return unsigned(ch - '0') < 10 || unsigned((ch | ' ') - 'a') < 6;
+}
+
+inline bool isNewline(char ch)
+{
+    return ch == '\n';
+}
+
+static char unescape(char ch)
+{
+    switch (ch)
+    {
+    case 'a':
+        return '\a';
+    case 'b':
+        return '\b';
+    case 'f':
+        return '\f';
+    case 'n':
+        return '\n';
+    case 'r':
+        return '\r';
+    case 't':
+        return '\t';
+    case 'v':
+        return '\v';
+    default:
+        return ch;
+    }
+}
+
+Lexer::Lexer(const char* buffer, size_t bufferSize, AstNameTable& names)
+    : buffer(buffer)
+    , bufferSize(bufferSize)
+    , offset(0)
+    , line(0)
+    , lineOffset(0)
+    , lexeme(Location(Position(0, 0), 0), Lexeme::Eof)
+    , names(names)
+    , skipComments(false)
+    , readNames(true)
+{
+}
+
+void Lexer::setSkipComments(bool skip)
+{
+    skipComments = skip;
+}
+
+void Lexer::setReadNames(bool read)
+{
+    readNames = read;
+}
+
+const Lexeme& Lexer::next()
+{
+    return next(this->skipComments, true);
+}
+
+const Lexeme& Lexer::next(bool skipComments, bool updatePrevLocation)
+{
+    // in skipComments mode we reject valid comments
+    do
+    {
+        // consume whitespace before the token
+        while (isSpace(peekch()))
+            consumeAny();
+
+        if (updatePrevLocation)
+            prevLocation = lexeme.location;
+
+        lexeme = readNext();
+        updatePrevLocation = false;
+    } while (skipComments && (lexeme.type == Lexeme::Comment || lexeme.type == Lexeme::BlockComment));
+
+    return lexeme;
+}
+
+void Lexer::nextline()
+{
+    while (peekch() != 0 && peekch() != '\r' && !isNewline(peekch()))
+        consume();
+
+    next();
+}
+
+Lexeme Lexer::lookahead()
+{
+    unsigned int currentOffset = offset;
+    unsigned int currentLine = line;
+    unsigned int currentLineOffset = lineOffset;
+    Lexeme currentLexeme = lexeme;
+    Location currentPrevLocation = prevLocation;
+    size_t currentBraceStackSize = braceStack.size();
+    BraceType currentBraceType = braceStack.empty() ? BraceType::Normal : braceStack.back();
+
+    Lexeme result = next();
+
+    offset = currentOffset;
+    line = currentLine;
+    lineOffset = currentLineOffset;
+    lexeme = currentLexeme;
+    prevLocation = currentPrevLocation;
+    if (FFlag::LuauLexerLookaheadRemembersBraceType)
+    {
+        if (braceStack.size() < currentBraceStackSize)
+            braceStack.push_back(currentBraceType);
+        else if (braceStack.size() > currentBraceStackSize)
+            braceStack.pop_back();
+    }
+
+    return result;
+}
+
+bool Lexer::isReserved(const std::string& word)
+{
+    for (int i = Lexeme::Reserved_BEGIN; i < Lexeme::Reserved_END; ++i)
+        if (word == kReserved[i - Lexeme::Reserved_BEGIN])
+            return true;
+
+    return false;
+}
+
+LUAU_FORCEINLINE
+char Lexer::peekch() const
+{
+    return (offset < bufferSize) ? buffer[offset] : 0;
+}
+
+LUAU_FORCEINLINE
+char Lexer::peekch(unsigned int lookahead) const
+{
+    return (offset + lookahead < bufferSize) ? buffer[offset + lookahead] : 0;
+}
+
+Position Lexer::position() const
+{
+    return Position(line, offset - lineOffset);
+}
+
+LUAU_FORCEINLINE
+void Lexer::consume()
+{
+    // consume() assumes current character is known to not be a newline; use consumeAny if this is not guaranteed
+    LUAU_ASSERT(!isNewline(buffer[offset]));
+
+    offset++;
+}
+
+LUAU_FORCEINLINE
+void Lexer::consumeAny()
+{
+    if (isNewline(buffer[offset]))
+    {
+        line++;
+        lineOffset = offset + 1;
+    }
+
+    offset++;
+}
+
+Lexeme Lexer::readCommentBody()
+{
+    Position start = position();
+
+    LUAU_ASSERT(peekch(0) == '-' && peekch(1) == '-');
+    consume();
+    consume();
+
+    size_t startOffset = offset;
+
+    if (peekch() == '[')
+    {
+        int sep = skipLongSeparator();
+
+        if (sep >= 0)
+        {
+            return readLongString(start, sep, Lexeme::BlockComment, Lexeme::BrokenComment);
+        }
+    }
+
+    // fall back to single-line comment
+    while (peekch() != 0 && peekch() != '\r' && !isNewline(peekch()))
+        consume();
+
+    return Lexeme(Location(start, position()), Lexeme::Comment, &buffer[startOffset], offset - startOffset);
+}
+
+// Given a sequence [===[ or ]===], returns:
+// 1. number of equal signs (or 0 if none present) between the brackets
+// 2. -1 if this is not a long comment/string separator
+// 3. -N if this is a malformed separator
+// Does *not* consume the closing brace.
+int Lexer::skipLongSeparator()
+{
+    char start = peekch();
+
+    LUAU_ASSERT(start == '[' || start == ']');
+    consume();
+
+    int count = 0;
+
+    while (peekch() == '=')
+    {
+        consume();
+        count++;
+    }
+
+    return (start == peekch()) ? count : (-count) - 1;
+}
+
+Lexeme Lexer::readLongString(const Position& start, int sep, Lexeme::Type ok, Lexeme::Type broken)
+{
+    // skip (second) [
+    LUAU_ASSERT(peekch() == '[');
+    consume();
+
+    unsigned int startOffset = offset;
+
+    while (peekch())
+    {
+        if (peekch() == ']')
+        {
+            if (skipLongSeparator() == sep)
+            {
+                LUAU_ASSERT(peekch() == ']');
+                consume(); // skip (second) ]
+
+                unsigned int endOffset = offset - sep - 2;
+                LUAU_ASSERT(endOffset >= startOffset);
+
+                return Lexeme(Location(start, position()), ok, &buffer[startOffset], endOffset - startOffset);
+            }
+        }
+        else
+        {
+            consumeAny();
+        }
+    }
+
+    return Lexeme(Location(start, position()), broken);
+}
+
+void Lexer::readBackslashInString()
+{
+    LUAU_ASSERT(peekch() == '\\');
+    consume();
+    switch (peekch())
+    {
+    case '\r':
+        consume();
+        if (peekch() == '\n')
+            consumeAny();
+        break;
+
+    case 0:
+        break;
+
+    case 'z':
+        consume();
+        while (isSpace(peekch()))
+            consumeAny();
+        break;
+
+    default:
+        consumeAny();
+    }
+}
+
+Lexeme Lexer::readQuotedString()
+{
+    Position start = position();
+
+    char delimiter = peekch();
+    LUAU_ASSERT(delimiter == '\'' || delimiter == '"');
+    consume();
+
+    unsigned int startOffset = offset;
+
+    while (peekch() != delimiter)
+    {
+        switch (peekch())
+        {
+        case 0:
+        case '\r':
+        case '\n':
+            return Lexeme(Location(start, position()), Lexeme::BrokenString);
+
+        case '\\':
+            readBackslashInString();
+            break;
+
+        default:
+            consume();
+        }
+    }
+
+    consume();
+
+    return Lexeme(Location(start, position()), Lexeme::QuotedString, &buffer[startOffset], offset - startOffset - 1);
+}
+
+Lexeme Lexer::readInterpolatedStringBegin()
+{
+    LUAU_ASSERT(peekch() == '`');
+
+    Position start = position();
+    consume();
+
+    return readInterpolatedStringSection(start, Lexeme::InterpStringBegin, Lexeme::InterpStringSimple);
+}
+
+Lexeme Lexer::readInterpolatedStringSection(Position start, Lexeme::Type formatType, Lexeme::Type endType)
+{
+    unsigned int startOffset = offset;
+
+    while (peekch() != '`')
+    {
+        switch (peekch())
+        {
+        case 0:
+        case '\r':
+        case '\n':
+            return Lexeme(Location(start, position()), Lexeme::BrokenString);
+
+        case '\\':
+            // Allow for \u{}, which would otherwise be consumed by looking for {
+            if (peekch(1) == 'u' && peekch(2) == '{')
+            {
+                consume(); // backslash
+                consume(); // u
+                consume(); // {
+                break;
+            }
+
+            readBackslashInString();
+            break;
+
+        case '{':
+        {
+            braceStack.push_back(BraceType::InterpolatedString);
+
+            if (peekch(1) == '{')
+            {
+                Lexeme brokenDoubleBrace =
+                    Lexeme(Location(start, position()), Lexeme::BrokenInterpDoubleBrace, &buffer[startOffset], offset - startOffset);
+                consume();
+                consume();
+                return brokenDoubleBrace;
+            }
+
+            consume();
+            return Lexeme(Location(start, position()), formatType, &buffer[startOffset], offset - startOffset - 1);
+        }
+
+        default:
+            consume();
+        }
+    }
+
+    consume();
+
+    return Lexeme(Location(start, position()), endType, &buffer[startOffset], offset - startOffset - 1);
+}
+
+Lexeme Lexer::readNumber(const Position& start, unsigned int startOffset)
+{
+    LUAU_ASSERT(isDigit(peekch()));
+
+    // This function does not do the number parsing - it only skips a number-like pattern.
+    // It uses the same logic as Lua stock lexer; the resulting string is later converted
+    // to a number with proper verification.
+    do
+    {
+        consume();
+    } while (isDigit(peekch()) || peekch() == '.' || peekch() == '_');
+
+    if (peekch() == 'e' || peekch() == 'E')
+    {
+        consume();
+
+        if (peekch() == '+' || peekch() == '-')
+            consume();
+    }
+
+    while (isAlpha(peekch()) || isDigit(peekch()) || peekch() == '_')
+        consume();
+
+    return Lexeme(Location(start, position()), Lexeme::Number, &buffer[startOffset], offset - startOffset);
+}
+
+std::pair<AstName, Lexeme::Type> Lexer::readName()
+{
+    LUAU_ASSERT(isAlpha(peekch()) || peekch() == '_' || peekch() == '@');
+
+    unsigned int startOffset = offset;
+
+    do
+        consume();
+    while (isAlpha(peekch()) || isDigit(peekch()) || peekch() == '_');
+
+    return readNames ? names.getOrAddWithType(&buffer[startOffset], offset - startOffset)
+                     : names.getWithType(&buffer[startOffset], offset - startOffset);
+}
+
+Lexeme Lexer::readNext()
+{
+    Position start = position();
+
+    switch (peekch())
+    {
+    case 0:
+        return Lexeme(Location(start, 0), Lexeme::Eof);
+
+    case '-':
+    {
+        if (peekch(1) == '>')
+        {
+            consume();
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::SkinnyArrow);
+        }
+        else if (peekch(1) == '=')
+        {
+            consume();
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::SubAssign);
+        }
+        else if (peekch(1) == '-')
+        {
+            return readCommentBody();
+        }
+        else
+        {
+            consume();
+            return Lexeme(Location(start, 1), '-');
+        }
+    }
+
+    case '[':
+    {
+        int sep = skipLongSeparator();
+
+        if (sep >= 0)
+        {
+            return readLongString(start, sep, Lexeme::RawString, Lexeme::BrokenString);
+        }
+        else if (sep == -1)
+        {
+            return Lexeme(Location(start, 1), '[');
+        }
+        else
+        {
+            return Lexeme(Location(start, position()), Lexeme::BrokenString);
+        }
+    }
+
+    case '{':
+    {
+        consume();
+
+        if (!braceStack.empty())
+            braceStack.push_back(BraceType::Normal);
+
+        return Lexeme(Location(start, 1), '{');
+    }
+
+    case '}':
+    {
+        consume();
+
+        if (braceStack.empty())
+        {
+            return Lexeme(Location(start, 1), '}');
+        }
+
+        const BraceType braceStackTop = braceStack.back();
+        braceStack.pop_back();
+
+        if (braceStackTop != BraceType::InterpolatedString)
+        {
+            return Lexeme(Location(start, 1), '}');
+        }
+
+        return readInterpolatedStringSection(position(), Lexeme::InterpStringMid, Lexeme::InterpStringEnd);
+    }
+
+    case '=':
+    {
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::Equal);
+        }
+        else
+            return Lexeme(Location(start, 1), '=');
+    }
+
+    case '<':
+    {
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::LessEqual);
+        }
+        else
+            return Lexeme(Location(start, 1), '<');
+    }
+
+    case '>':
+    {
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::GreaterEqual);
+        }
+        else
+            return Lexeme(Location(start, 1), '>');
+    }
+
+    case '~':
+    {
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::NotEqual);
+        }
+        else
+            return Lexeme(Location(start, 1), '~');
+    }
+
+    case '"':
+    case '\'':
+        return readQuotedString();
+
+    case '`':
+        return readInterpolatedStringBegin();
+
+    case '.':
+        consume();
+
+        if (peekch() == '.')
+        {
+            consume();
+
+            if (peekch() == '.')
+            {
+                consume();
+
+                return Lexeme(Location(start, 3), Lexeme::Dot3);
+            }
+            else if (peekch() == '=')
+            {
+                consume();
+
+                return Lexeme(Location(start, 3), Lexeme::ConcatAssign);
+            }
+            else
+                return Lexeme(Location(start, 2), Lexeme::Dot2);
+        }
+        else
+        {
+            if (isDigit(peekch()))
+            {
+                return readNumber(start, offset - 1);
+            }
+            else
+                return Lexeme(Location(start, 1), '.');
+        }
+
+    case '+':
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::AddAssign);
+        }
+        else
+            return Lexeme(Location(start, 1), '+');
+
+    case '/':
+    {
+        consume();
+
+        char ch = peekch();
+
+        if (ch == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::DivAssign);
+        }
+        else if (ch == '/')
+        {
+            consume();
+
+            if (peekch() == '=')
+            {
+                consume();
+                return Lexeme(Location(start, 3), Lexeme::FloorDivAssign);
+            }
+            else
+                return Lexeme(Location(start, 2), Lexeme::FloorDiv);
+        }
+        else
+            return Lexeme(Location(start, 1), '/');
+    }
+
+    case '*':
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::MulAssign);
+        }
+        else
+            return Lexeme(Location(start, 1), '*');
+
+    case '%':
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::ModAssign);
+        }
+        else
+            return Lexeme(Location(start, 1), '%');
+
+    case '^':
+        consume();
+
+        if (peekch() == '=')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::PowAssign);
+        }
+        else
+            return Lexeme(Location(start, 1), '^');
+
+    case ':':
+    {
+        consume();
+        if (peekch() == ':')
+        {
+            consume();
+            return Lexeme(Location(start, 2), Lexeme::DoubleColon);
+        }
+        else
+            return Lexeme(Location(start, 1), ':');
+    }
+
+    case '(':
+    case ')':
+    case ']':
+    case ';':
+    case ',':
+    case '#':
+    case '?':
+    case '&':
+    case '|':
+    {
+        char ch = peekch();
+        consume();
+
+        return Lexeme(Location(start, 1), ch);
+    }
+    case '@':
+    {
+        if (FFlag::LuauCheckedFunctionSyntax)
+        {
+            // We're trying to lex the token @checked
+            LUAU_ASSERT(peekch() == '@');
+
+            std::pair<AstName, Lexeme::Type> maybeChecked = readName();
+            if (maybeChecked.second != Lexeme::ReservedChecked)
+                return Lexeme(Location(start, position()), Lexeme::Error);
+
+            return Lexeme(Location(start, position()), maybeChecked.second, maybeChecked.first.value);
+        }
+    }
+    default:
+        if (isDigit(peekch()))
+        {
+            return readNumber(start, offset);
+        }
+        else if (isAlpha(peekch()) || peekch() == '_')
+        {
+            std::pair<AstName, Lexeme::Type> name = readName();
+
+            return Lexeme(Location(start, position()), name.second, name.first.value);
+        }
+        else if (peekch() & 0x80)
+        {
+            return readUtf8Error();
+        }
+        else
+        {
+            char ch = peekch();
+            consume();
+
+            return Lexeme(Location(start, 1), ch);
+        }
+    }
+}
+
+LUAU_NOINLINE Lexeme Lexer::readUtf8Error()
+{
+    Position start = position();
+    uint32_t codepoint = 0;
+    int size = 0;
+
+    if ((peekch() & 0b10000000) == 0b00000000)
+    {
+        size = 1;
+        codepoint = peekch() & 0x7F;
+    }
+    else if ((peekch() & 0b11100000) == 0b11000000)
+    {
+        size = 2;
+        codepoint = peekch() & 0b11111;
+    }
+    else if ((peekch() & 0b11110000) == 0b11100000)
+    {
+        size = 3;
+        codepoint = peekch() & 0b1111;
+    }
+    else if ((peekch() & 0b11111000) == 0b11110000)
+    {
+        size = 4;
+        codepoint = peekch() & 0b111;
+    }
+    else
+    {
+        consume();
+        return Lexeme(Location(start, position()), Lexeme::BrokenUnicode);
+    }
+
+    consume();
+
+    for (int i = 1; i < size; ++i)
+    {
+        if ((peekch() & 0b11000000) != 0b10000000)
+            return Lexeme(Location(start, position()), Lexeme::BrokenUnicode);
+
+        codepoint = codepoint << 6;
+        codepoint |= (peekch() & 0b00111111);
+        consume();
+    }
+
+    Lexeme result(Location(start, position()), Lexeme::BrokenUnicode);
+    result.codepoint = codepoint;
+    return result;
+}
+
+static size_t toUtf8(char* data, unsigned int code)
+{
+    // U+0000..U+007F
+    if (code < 0x80)
+    {
+        data[0] = char(code);
+        return 1;
+    }
+    // U+0080..U+07FF
+    else if (code < 0x800)
+    {
+        data[0] = char(0xC0 | (code >> 6));
+        data[1] = char(0x80 | (code & 0x3F));
+        return 2;
+    }
+    // U+0800..U+FFFF
+    else if (code < 0x10000)
+    {
+        data[0] = char(0xE0 | (code >> 12));
+        data[1] = char(0x80 | ((code >> 6) & 0x3F));
+        data[2] = char(0x80 | (code & 0x3F));
+        return 3;
+    }
+    // U+10000..U+10FFFF
+    else if (code < 0x110000)
+    {
+        data[0] = char(0xF0 | (code >> 18));
+        data[1] = char(0x80 | ((code >> 12) & 0x3F));
+        data[2] = char(0x80 | ((code >> 6) & 0x3F));
+        data[3] = char(0x80 | (code & 0x3F));
+        return 4;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+bool Lexer::fixupQuotedString(std::string& data)
+{
+    if (data.empty() || data.find('\\') == std::string::npos)
+        return true;
+
+    size_t size = data.size();
+    size_t write = 0;
+
+    for (size_t i = 0; i < size;)
+    {
+        if (data[i] != '\\')
+        {
+            data[write++] = data[i];
+            i++;
+            continue;
+        }
+
+        if (i + 1 == size)
+            return false;
+
+        char escape = data[i + 1];
+        i += 2; // skip \e
+
+        switch (escape)
+        {
+        case '\n':
+            data[write++] = '\n';
+            break;
+
+        case '\r':
+            data[write++] = '\n';
+            if (i < size && data[i] == '\n')
+                i++;
+            break;
+
+        case 0:
+            return false;
+
+        case 'x':
+        {
+            // hex escape codes are exactly 2 hex digits long
+            if (i + 2 > size)
+                return false;
+
+            unsigned int code = 0;
+
+            for (int j = 0; j < 2; ++j)
+            {
+                char ch = data[i + j];
+                if (!isHexDigit(ch))
+                    return false;
+
+                // use or trick to convert to lower case
+                code = 16 * code + (isDigit(ch) ? ch - '0' : (ch | ' ') - 'a' + 10);
+            }
+
+            data[write++] = char(code);
+            i += 2;
+            break;
+        }
+
+        case 'z':
+        {
+            while (i < size && isSpace(data[i]))
+                i++;
+            break;
+        }
+
+        case 'u':
+        {
+            // unicode escape codes are at least 3 characters including braces
+            if (i + 3 > size)
+                return false;
+
+            if (data[i] != '{')
+                return false;
+            i++;
+
+            if (data[i] == '}')
+                return false;
+
+            unsigned int code = 0;
+
+            for (int j = 0; j < 16; ++j)
+            {
+                if (i == size)
+                    return false;
+
+                char ch = data[i];
+
+                if (ch == '}')
+                    break;
+
+                if (!isHexDigit(ch))
+                    return false;
+
+                // use or trick to convert to lower case
+                code = 16 * code + (isDigit(ch) ? ch - '0' : (ch | ' ') - 'a' + 10);
+                i++;
+            }
+
+            if (i == size || data[i] != '}')
+                return false;
+            i++;
+
+            size_t utf8 = toUtf8(&data[write], code);
+            if (utf8 == 0)
+                return false;
+
+            write += utf8;
+            break;
+        }
+
+        default:
+        {
+            if (isDigit(escape))
+            {
+                unsigned int code = escape - '0';
+
+                for (int j = 0; j < 2; ++j)
+                {
+                    if (i == size || !isDigit(data[i]))
+                        break;
+
+                    code = 10 * code + (data[i] - '0');
+                    i++;
+                }
+
+                if (code > UCHAR_MAX)
+                    return false;
+
+                data[write++] = char(code);
+            }
+            else
+            {
+                data[write++] = unescape(escape);
+            }
+        }
+        }
+    }
+
+    LUAU_ASSERT(write <= size);
+    data.resize(write);
+
+    return true;
+}
+
+void Lexer::fixupMultilineString(std::string& data)
+{
+    if (data.empty())
+        return;
+
+    // Lua rules for multiline strings are as follows:
+    // - standalone \r, \r\n, \n\r and \n are all considered newlines
+    // - first newline in the multiline string is skipped
+    // - all other newlines are normalized to \n
+
+    // Since our lexer just treats \n as newlines, we apply a simplified set of rules that is sufficient to get normalized newlines for Windows/Unix:
+    // - \r\n and \n are considered newlines
+    // - first newline is skipped
+    // - newlines are normalized to \n
+
+    // This makes the string parsing behavior consistent with general lexing behavior - a standalone \r isn't considered a new line from the line
+    // tracking perspective
+
+    const char* src = data.c_str();
+    char* dst = &data[0];
+
+    // skip leading newline
+    if (src[0] == '\r' && src[1] == '\n')
+    {
+        src += 2;
+    }
+    else if (src[0] == '\n')
+    {
+        src += 1;
+    }
+
+    // parse the rest of the string, converting newlines as we go
+    while (*src)
+    {
+        if (src[0] == '\r' && src[1] == '\n')
+        {
+            *dst++ = '\n';
+            src += 2;
+        }
+        else // note, this handles \n by just writing it without changes
+        {
+            *dst++ = *src;
+            src += 1;
+        }
+    }
+
+    data.resize(dst - &data[0]);
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/src/Location.cpp
+++ b/lib/luau/Ast/src/Location.cpp
@@ -1,0 +1,101 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Location.h"
+
+namespace Luau
+{
+
+bool Position::operator==(const Position& rhs) const
+{
+    return this->column == rhs.column && this->line == rhs.line;
+}
+
+bool Position::operator!=(const Position& rhs) const
+{
+    return !(*this == rhs);
+}
+
+bool Position::operator<(const Position& rhs) const
+{
+    if (line == rhs.line)
+        return column < rhs.column;
+    else
+        return line < rhs.line;
+}
+
+bool Position::operator>(const Position& rhs) const
+{
+    if (line == rhs.line)
+        return column > rhs.column;
+    else
+        return line > rhs.line;
+}
+
+bool Position::operator<=(const Position& rhs) const
+{
+    return *this == rhs || *this < rhs;
+}
+
+bool Position::operator>=(const Position& rhs) const
+{
+    return *this == rhs || *this > rhs;
+}
+
+void Position::shift(const Position& start, const Position& oldEnd, const Position& newEnd)
+{
+    if (*this >= start)
+    {
+        if (this->line > oldEnd.line)
+            this->line += (newEnd.line - oldEnd.line);
+        else
+        {
+            this->line = newEnd.line;
+            this->column += (newEnd.column - oldEnd.column);
+        }
+    }
+}
+
+bool Location::operator==(const Location& rhs) const
+{
+    return this->begin == rhs.begin && this->end == rhs.end;
+}
+
+bool Location::operator!=(const Location& rhs) const
+{
+    return !(*this == rhs);
+}
+
+bool Location::encloses(const Location& l) const
+{
+    return begin <= l.begin && end >= l.end;
+}
+
+bool Location::overlaps(const Location& l) const
+{
+    return (begin <= l.begin && end >= l.begin) || (begin <= l.end && end >= l.end) || (begin >= l.begin && end <= l.end);
+}
+
+bool Location::contains(const Position& p) const
+{
+    return begin <= p && p < end;
+}
+
+bool Location::containsClosed(const Position& p) const
+{
+    return begin <= p && p <= end;
+}
+
+void Location::extend(const Location& other)
+{
+    if (other.begin < begin)
+        begin = other.begin;
+    if (other.end > end)
+        end = other.end;
+}
+
+void Location::shift(const Position& start, const Position& oldEnd, const Position& newEnd)
+{
+    begin.shift(start, oldEnd, newEnd);
+    end.shift(start, oldEnd, newEnd);
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/src/Parser.cpp
+++ b/lib/luau/Ast/src/Parser.cpp
@@ -1,0 +1,3154 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Parser.h"
+
+#include "Luau/Common.h"
+#include "Luau/TimeTrace.h"
+
+#include <algorithm>
+
+#include <errno.h>
+#include <limits.h>
+
+LUAU_FASTINTVARIABLE(LuauRecursionLimit, 1000)
+LUAU_FASTINTVARIABLE(LuauTypeLengthLimit, 1000)
+LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
+
+// Warning: If you are introducing new syntax, ensure that it is behind a separate
+// flag so that we don't break production games by reverting syntax changes.
+// See docs/SyntaxChanges.md for an explanation.
+LUAU_FASTFLAGVARIABLE(LuauClipExtraHasEndProps, false)
+LUAU_FASTFLAG(LuauCheckedFunctionSyntax)
+
+namespace Luau
+{
+
+ParseError::ParseError(const Location& location, const std::string& message)
+    : location(location)
+    , message(message)
+{
+}
+
+const char* ParseError::what() const throw()
+{
+    return message.c_str();
+}
+
+const Location& ParseError::getLocation() const
+{
+    return location;
+}
+
+const std::string& ParseError::getMessage() const
+{
+    return message;
+}
+
+// LUAU_NOINLINE is used to limit the stack cost of this function due to std::string object / exception plumbing
+LUAU_NOINLINE void ParseError::raise(const Location& location, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    std::string message = vformat(format, args);
+    va_end(args);
+
+    throw ParseError(location, message);
+}
+
+ParseErrors::ParseErrors(std::vector<ParseError> errors)
+    : errors(std::move(errors))
+{
+    LUAU_ASSERT(!this->errors.empty());
+
+    if (this->errors.size() == 1)
+        message = this->errors.front().what();
+    else
+        message = format("%d parse errors", int(this->errors.size()));
+}
+
+const char* ParseErrors::what() const throw()
+{
+    return message.c_str();
+}
+
+const std::vector<ParseError>& ParseErrors::getErrors() const
+{
+    return errors;
+}
+
+template<typename T>
+TempVector<T>::TempVector(std::vector<T>& storage)
+    : storage(storage)
+    , offset(storage.size())
+    , size_(0)
+{
+}
+
+template<typename T>
+TempVector<T>::~TempVector()
+{
+    LUAU_ASSERT(storage.size() == offset + size_);
+    storage.erase(storage.begin() + offset, storage.end());
+}
+
+template<typename T>
+const T& TempVector<T>::operator[](size_t index) const
+{
+    LUAU_ASSERT(index < size_);
+    return storage[offset + index];
+}
+
+template<typename T>
+const T& TempVector<T>::front() const
+{
+    LUAU_ASSERT(size_ > 0);
+    return storage[offset];
+}
+
+template<typename T>
+const T& TempVector<T>::back() const
+{
+    LUAU_ASSERT(size_ > 0);
+    return storage.back();
+}
+
+template<typename T>
+bool TempVector<T>::empty() const
+{
+    return size_ == 0;
+}
+
+template<typename T>
+size_t TempVector<T>::size() const
+{
+    return size_;
+}
+
+template<typename T>
+void TempVector<T>::push_back(const T& item)
+{
+    LUAU_ASSERT(storage.size() == offset + size_);
+    storage.push_back(item);
+    size_++;
+}
+
+static bool shouldParseTypePack(Lexer& lexer)
+{
+    if (lexer.current().type == Lexeme::Dot3)
+        return true;
+    else if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == Lexeme::Dot3)
+        return true;
+
+    return false;
+}
+
+ParseResult Parser::parse(const char* buffer, size_t bufferSize, AstNameTable& names, Allocator& allocator, ParseOptions options)
+{
+    LUAU_TIMETRACE_SCOPE("Parser::parse", "Parser");
+
+    Parser p(buffer, bufferSize, names, allocator, options);
+
+    try
+    {
+        AstStatBlock* root = p.parseChunk();
+        size_t lines = p.lexer.current().location.end.line + (bufferSize > 0 && buffer[bufferSize - 1] != '\n');
+
+        return ParseResult{root, lines, std::move(p.hotcomments), std::move(p.parseErrors), std::move(p.commentLocations)};
+    }
+    catch (ParseError& err)
+    {
+        // when catching a fatal error, append it to the list of non-fatal errors and return
+        p.parseErrors.push_back(err);
+
+        return ParseResult{nullptr, 0, {}, p.parseErrors};
+    }
+}
+
+Parser::Parser(const char* buffer, size_t bufferSize, AstNameTable& names, Allocator& allocator, const ParseOptions& options)
+    : options(options)
+    , lexer(buffer, bufferSize, names)
+    , allocator(allocator)
+    , recursionCounter(0)
+    , endMismatchSuspect(Lexeme(Location(), Lexeme::Eof))
+    , localMap(AstName())
+{
+    Function top;
+    top.vararg = true;
+
+    functionStack.reserve(8);
+    functionStack.push_back(top);
+
+    nameSelf = names.addStatic("self");
+    nameNumber = names.addStatic("number");
+    nameError = names.addStatic(kParseNameError);
+    nameNil = names.getOrAdd("nil"); // nil is a reserved keyword
+
+    matchRecoveryStopOnToken.assign(Lexeme::Type::Reserved_END, 0);
+    matchRecoveryStopOnToken[Lexeme::Type::Eof] = 1;
+
+    // required for lookahead() to work across a comment boundary and for nextLexeme() to work when captureComments is false
+    lexer.setSkipComments(true);
+
+    // read first lexeme (any hot comments get .header = true)
+    LUAU_ASSERT(hotcommentHeader);
+    nextLexeme();
+
+    // all hot comments parsed after the first non-comment lexeme are special in that they don't affect type checking / linting mode
+    hotcommentHeader = false;
+
+    // preallocate some buffers that are very likely to grow anyway; this works around std::vector's inefficient growth policy for small arrays
+    localStack.reserve(16);
+    scratchStat.reserve(16);
+    scratchExpr.reserve(16);
+    scratchLocal.reserve(16);
+    scratchBinding.reserve(16);
+}
+
+bool Parser::blockFollow(const Lexeme& l)
+{
+    return l.type == Lexeme::Eof || l.type == Lexeme::ReservedElse || l.type == Lexeme::ReservedElseif || l.type == Lexeme::ReservedEnd ||
+           l.type == Lexeme::ReservedUntil;
+}
+
+AstStatBlock* Parser::parseChunk()
+{
+    AstStatBlock* result = parseBlock();
+
+    if (lexer.current().type != Lexeme::Eof)
+        expectAndConsumeFail(Lexeme::Eof, nullptr);
+
+    return result;
+}
+
+// chunk ::= {stat [`;']} [laststat [`;']]
+// block ::= chunk
+AstStatBlock* Parser::parseBlock()
+{
+    unsigned int localsBegin = saveLocals();
+
+    AstStatBlock* result = parseBlockNoScope();
+
+    restoreLocals(localsBegin);
+
+    return result;
+}
+
+static bool isStatLast(AstStat* stat)
+{
+    return stat->is<AstStatBreak>() || stat->is<AstStatContinue>() || stat->is<AstStatReturn>();
+}
+
+AstStatBlock* Parser::parseBlockNoScope()
+{
+    TempVector<AstStat*> body(scratchStat);
+
+    const Position prevPosition = lexer.previousLocation().end;
+
+    while (!blockFollow(lexer.current()))
+    {
+        unsigned int oldRecursionCount = recursionCounter;
+
+        incrementRecursionCounter("block");
+
+        AstStat* stat = parseStat();
+
+        recursionCounter = oldRecursionCount;
+
+        if (lexer.current().type == ';')
+        {
+            nextLexeme();
+            stat->hasSemicolon = true;
+        }
+
+        body.push_back(stat);
+
+        if (isStatLast(stat))
+            break;
+    }
+
+    const Location location = Location(prevPosition, lexer.current().location.begin);
+
+    return allocator.alloc<AstStatBlock>(location, copy(body));
+}
+
+// stat ::=
+// varlist `=' explist |
+// functioncall |
+// do block end |
+// while exp do block end |
+// repeat block until exp |
+// if exp then block {elseif exp then block} [else block] end |
+// for binding `=' exp `,' exp [`,' exp] do block end |
+// for namelist in explist do block end |
+// function funcname funcbody |
+// local function Name funcbody |
+// local namelist [`=' explist]
+// laststat ::= return [explist] | break
+AstStat* Parser::parseStat()
+{
+    // guess the type from the token type
+    switch (lexer.current().type)
+    {
+    case Lexeme::ReservedIf:
+        return parseIf();
+    case Lexeme::ReservedWhile:
+        return parseWhile();
+    case Lexeme::ReservedDo:
+        return parseDo();
+    case Lexeme::ReservedFor:
+        return parseFor();
+    case Lexeme::ReservedRepeat:
+        return parseRepeat();
+    case Lexeme::ReservedFunction:
+        return parseFunctionStat();
+    case Lexeme::ReservedLocal:
+        return parseLocal();
+    case Lexeme::ReservedReturn:
+        return parseReturn();
+    case Lexeme::ReservedBreak:
+        return parseBreak();
+    default:;
+    }
+
+    Location start = lexer.current().location;
+
+    // we need to disambiguate a few cases, primarily assignment (lvalue = ...) vs statements-that-are calls
+    AstExpr* expr = parsePrimaryExpr(/* asStatement= */ true);
+
+    if (expr->is<AstExprCall>())
+        return allocator.alloc<AstStatExpr>(expr->location, expr);
+
+    // if the next token is , or =, it's an assignment (, means it's an assignment with multiple variables)
+    if (lexer.current().type == ',' || lexer.current().type == '=')
+        return parseAssignment(expr);
+
+    // if the next token is a compound assignment operator, it's a compound assignment (these don't support multiple variables)
+    if (std::optional<AstExprBinary::Op> op = parseCompoundOp(lexer.current()))
+        return parseCompoundAssignment(expr, *op);
+
+    // we know this isn't a call or an assignment; therefore it must be a context-sensitive keyword such as `type` or `continue`
+    AstName ident = getIdentifier(expr);
+
+    if (ident == "type")
+        return parseTypeAlias(expr->location, /* exported= */ false);
+
+    if (ident == "export" && lexer.current().type == Lexeme::Name && AstName(lexer.current().name) == "type")
+    {
+        nextLexeme();
+        return parseTypeAlias(expr->location, /* exported= */ true);
+    }
+
+    if (ident == "continue")
+        return parseContinue(expr->location);
+
+    if (options.allowDeclarationSyntax)
+    {
+        if (ident == "declare")
+            return parseDeclaration(expr->location);
+    }
+
+    // skip unexpected symbol if lexer couldn't advance at all (statements are parsed in a loop)
+    if (start == lexer.current().location)
+        nextLexeme();
+
+    return reportStatError(expr->location, copy({expr}), {}, "Incomplete statement: expected assignment or a function call");
+}
+
+// if exp then block {elseif exp then block} [else block] end
+AstStat* Parser::parseIf()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme(); // if / elseif
+
+    AstExpr* cond = parseExpr();
+
+    Lexeme matchThen = lexer.current();
+    std::optional<Location> thenLocation;
+    if (expectAndConsume(Lexeme::ReservedThen, "if statement"))
+        thenLocation = matchThen.location;
+
+    AstStatBlock* thenbody = parseBlock();
+
+    AstStat* elsebody = nullptr;
+    Location end = start;
+    std::optional<Location> elseLocation;
+    bool DEPRECATED_hasEnd = false;
+
+    if (lexer.current().type == Lexeme::ReservedElseif)
+    {
+        if (FFlag::LuauClipExtraHasEndProps)
+            thenbody->hasEnd = true;
+        unsigned int oldRecursionCount = recursionCounter;
+        incrementRecursionCounter("elseif");
+        elseLocation = lexer.current().location;
+        elsebody = parseIf();
+        end = elsebody->location;
+        DEPRECATED_hasEnd = elsebody->as<AstStatIf>()->DEPRECATED_hasEnd;
+        recursionCounter = oldRecursionCount;
+    }
+    else
+    {
+        Lexeme matchThenElse = matchThen;
+
+        if (lexer.current().type == Lexeme::ReservedElse)
+        {
+            if (FFlag::LuauClipExtraHasEndProps)
+                thenbody->hasEnd = true;
+            elseLocation = lexer.current().location;
+            matchThenElse = lexer.current();
+            nextLexeme();
+
+            elsebody = parseBlock();
+            elsebody->location.begin = matchThenElse.location.end;
+        }
+
+        end = lexer.current().location;
+
+        bool hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchThenElse);
+        DEPRECATED_hasEnd = hasEnd;
+
+        if (FFlag::LuauClipExtraHasEndProps)
+        {
+            if (elsebody)
+            {
+                if (AstStatBlock* elseBlock = elsebody->as<AstStatBlock>())
+                    elseBlock->hasEnd = hasEnd;
+            }
+            else
+                thenbody->hasEnd = hasEnd;
+        }
+    }
+
+    return allocator.alloc<AstStatIf>(Location(start, end), cond, thenbody, elsebody, thenLocation, elseLocation, DEPRECATED_hasEnd);
+}
+
+// while exp do block end
+AstStat* Parser::parseWhile()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme(); // while
+
+    AstExpr* cond = parseExpr();
+
+    Lexeme matchDo = lexer.current();
+    bool hasDo = expectAndConsume(Lexeme::ReservedDo, "while loop");
+
+    functionStack.back().loopDepth++;
+
+    AstStatBlock* body = parseBlock();
+
+    functionStack.back().loopDepth--;
+
+    Location end = lexer.current().location;
+
+    bool hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
+    if (FFlag::LuauClipExtraHasEndProps)
+        body->hasEnd = hasEnd;
+
+    return allocator.alloc<AstStatWhile>(Location(start, end), cond, body, hasDo, matchDo.location, hasEnd);
+}
+
+// repeat block until exp
+AstStat* Parser::parseRepeat()
+{
+    Location start = lexer.current().location;
+
+    Lexeme matchRepeat = lexer.current();
+    nextLexeme(); // repeat
+
+    unsigned int localsBegin = saveLocals();
+
+    functionStack.back().loopDepth++;
+
+    AstStatBlock* body = parseBlockNoScope();
+
+    functionStack.back().loopDepth--;
+
+    bool hasUntil = expectMatchEndAndConsume(Lexeme::ReservedUntil, matchRepeat);
+    if (FFlag::LuauClipExtraHasEndProps)
+        body->hasEnd = hasUntil;
+
+    AstExpr* cond = parseExpr();
+
+    restoreLocals(localsBegin);
+
+    return allocator.alloc<AstStatRepeat>(Location(start, cond->location), cond, body, hasUntil);
+}
+
+// do block end
+AstStat* Parser::parseDo()
+{
+    Location start = lexer.current().location;
+
+    Lexeme matchDo = lexer.current();
+    nextLexeme(); // do
+
+    AstStatBlock* body = parseBlock();
+
+    body->location.begin = start.begin;
+
+    body->hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
+
+    return body;
+}
+
+// break
+AstStat* Parser::parseBreak()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme(); // break
+
+    if (functionStack.back().loopDepth == 0)
+        return reportStatError(start, {}, copy<AstStat*>({allocator.alloc<AstStatBreak>(start)}), "break statement must be inside a loop");
+
+    return allocator.alloc<AstStatBreak>(start);
+}
+
+// continue
+AstStat* Parser::parseContinue(const Location& start)
+{
+    if (functionStack.back().loopDepth == 0)
+        return reportStatError(start, {}, copy<AstStat*>({allocator.alloc<AstStatContinue>(start)}), "continue statement must be inside a loop");
+
+    // note: the token is already parsed for us!
+
+    return allocator.alloc<AstStatContinue>(start);
+}
+
+// for binding `=' exp `,' exp [`,' exp] do block end |
+// for bindinglist in explist do block end |
+AstStat* Parser::parseFor()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme(); // for
+
+    Binding varname = parseBinding();
+
+    if (lexer.current().type == '=')
+    {
+        nextLexeme();
+
+        AstExpr* from = parseExpr();
+
+        expectAndConsume(',', "index range");
+
+        AstExpr* to = parseExpr();
+
+        AstExpr* step = nullptr;
+
+        if (lexer.current().type == ',')
+        {
+            nextLexeme();
+
+            step = parseExpr();
+        }
+
+        Lexeme matchDo = lexer.current();
+        bool hasDo = expectAndConsume(Lexeme::ReservedDo, "for loop");
+
+        unsigned int localsBegin = saveLocals();
+
+        functionStack.back().loopDepth++;
+
+        AstLocal* var = pushLocal(varname);
+
+        AstStatBlock* body = parseBlock();
+
+        functionStack.back().loopDepth--;
+
+        restoreLocals(localsBegin);
+
+        Location end = lexer.current().location;
+
+        bool hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
+        if (FFlag::LuauClipExtraHasEndProps)
+            body->hasEnd = hasEnd;
+
+        return allocator.alloc<AstStatFor>(Location(start, end), var, from, to, step, body, hasDo, matchDo.location, hasEnd);
+    }
+    else
+    {
+        TempVector<Binding> names(scratchBinding);
+        names.push_back(varname);
+
+        if (lexer.current().type == ',')
+        {
+            nextLexeme();
+
+            parseBindingList(names);
+        }
+
+        Location inLocation = lexer.current().location;
+        bool hasIn = expectAndConsume(Lexeme::ReservedIn, "for loop");
+
+        TempVector<AstExpr*> values(scratchExpr);
+        parseExprList(values);
+
+        Lexeme matchDo = lexer.current();
+        bool hasDo = expectAndConsume(Lexeme::ReservedDo, "for loop");
+
+        unsigned int localsBegin = saveLocals();
+
+        functionStack.back().loopDepth++;
+
+        TempVector<AstLocal*> vars(scratchLocal);
+
+        for (size_t i = 0; i < names.size(); ++i)
+            vars.push_back(pushLocal(names[i]));
+
+        AstStatBlock* body = parseBlock();
+
+        functionStack.back().loopDepth--;
+
+        restoreLocals(localsBegin);
+
+        Location end = lexer.current().location;
+
+        bool hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
+        if (FFlag::LuauClipExtraHasEndProps)
+            body->hasEnd = hasEnd;
+
+        return allocator.alloc<AstStatForIn>(
+            Location(start, end), copy(vars), copy(values), body, hasIn, inLocation, hasDo, matchDo.location, hasEnd);
+    }
+}
+
+// funcname ::= Name {`.' Name} [`:' Name]
+AstExpr* Parser::parseFunctionName(Location start, bool& hasself, AstName& debugname)
+{
+    if (lexer.current().type == Lexeme::Name)
+        debugname = AstName(lexer.current().name);
+
+    // parse funcname into a chain of indexing operators
+    AstExpr* expr = parseNameExpr("function name");
+
+    unsigned int oldRecursionCount = recursionCounter;
+
+    while (lexer.current().type == '.')
+    {
+        Position opPosition = lexer.current().location.begin;
+        nextLexeme();
+
+        Name name = parseName("field name");
+
+        // while we could concatenate the name chain, for now let's just write the short name
+        debugname = name.name;
+
+        expr = allocator.alloc<AstExprIndexName>(Location(start, name.location), expr, name.name, name.location, opPosition, '.');
+
+        // note: while the parser isn't recursive here, we're generating recursive structures of unbounded depth
+        incrementRecursionCounter("function name");
+    }
+
+    recursionCounter = oldRecursionCount;
+
+    // finish with :
+    if (lexer.current().type == ':')
+    {
+        Position opPosition = lexer.current().location.begin;
+        nextLexeme();
+
+        Name name = parseName("method name");
+
+        // while we could concatenate the name chain, for now let's just write the short name
+        debugname = name.name;
+
+        expr = allocator.alloc<AstExprIndexName>(Location(start, name.location), expr, name.name, name.location, opPosition, ':');
+
+        hasself = true;
+    }
+
+    return expr;
+}
+
+// function funcname funcbody
+AstStat* Parser::parseFunctionStat()
+{
+    Location start = lexer.current().location;
+
+    Lexeme matchFunction = lexer.current();
+    nextLexeme();
+
+    bool hasself = false;
+    AstName debugname;
+    AstExpr* expr = parseFunctionName(start, hasself, debugname);
+
+    matchRecoveryStopOnToken[Lexeme::ReservedEnd]++;
+
+    AstExprFunction* body = parseFunctionBody(hasself, matchFunction, debugname, nullptr).first;
+
+    matchRecoveryStopOnToken[Lexeme::ReservedEnd]--;
+
+    return allocator.alloc<AstStatFunction>(Location(start, body->location), expr, body);
+}
+
+// local function Name funcbody |
+// local bindinglist [`=' explist]
+AstStat* Parser::parseLocal()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme(); // local
+
+    if (lexer.current().type == Lexeme::ReservedFunction)
+    {
+        Lexeme matchFunction = lexer.current();
+        nextLexeme();
+
+        // matchFunction is only used for diagnostics; to make it suitable for detecting missed indentation between
+        // `local function` and `end`, we patch the token to begin at the column where `local` starts
+        if (matchFunction.location.begin.line == start.begin.line)
+            matchFunction.location.begin.column = start.begin.column;
+
+        Name name = parseName("variable name");
+
+        matchRecoveryStopOnToken[Lexeme::ReservedEnd]++;
+
+        auto [body, var] = parseFunctionBody(false, matchFunction, name.name, &name);
+
+        matchRecoveryStopOnToken[Lexeme::ReservedEnd]--;
+
+        Location location{start.begin, body->location.end};
+
+        return allocator.alloc<AstStatLocalFunction>(location, var, body);
+    }
+    else
+    {
+        matchRecoveryStopOnToken['=']++;
+
+        TempVector<Binding> names(scratchBinding);
+        parseBindingList(names);
+
+        matchRecoveryStopOnToken['=']--;
+
+        TempVector<AstLocal*> vars(scratchLocal);
+
+        TempVector<AstExpr*> values(scratchExpr);
+
+        std::optional<Location> equalsSignLocation;
+
+        if (lexer.current().type == '=')
+        {
+            equalsSignLocation = lexer.current().location;
+
+            nextLexeme();
+
+            parseExprList(values);
+        }
+
+        for (size_t i = 0; i < names.size(); ++i)
+            vars.push_back(pushLocal(names[i]));
+
+        Location end = values.empty() ? lexer.previousLocation() : values.back()->location;
+
+        return allocator.alloc<AstStatLocal>(Location(start, end), copy(vars), copy(values), equalsSignLocation);
+    }
+}
+
+// return [explist]
+AstStat* Parser::parseReturn()
+{
+    Location start = lexer.current().location;
+
+    nextLexeme();
+
+    TempVector<AstExpr*> list(scratchExpr);
+
+    if (!blockFollow(lexer.current()) && lexer.current().type != ';')
+        parseExprList(list);
+
+    Location end = list.empty() ? start : list.back()->location;
+
+    return allocator.alloc<AstStatReturn>(Location(start, end), copy(list));
+}
+
+// type Name [`<' varlist `>'] `=' Type
+AstStat* Parser::parseTypeAlias(const Location& start, bool exported)
+{
+    // note: `type` token is already parsed for us, so we just need to parse the rest
+
+    std::optional<Name> name = parseNameOpt("type name");
+
+    // Use error name if the name is missing
+    if (!name)
+        name = Name(nameError, lexer.current().location);
+
+    auto [generics, genericPacks] = parseGenericTypeList(/* withDefaultValues= */ true);
+
+    expectAndConsume('=', "type alias");
+
+    AstType* type = parseType();
+
+    return allocator.alloc<AstStatTypeAlias>(Location(start, type->location), name->name, name->location, generics, genericPacks, type, exported);
+}
+
+AstDeclaredClassProp Parser::parseDeclaredClassMethod()
+{
+    nextLexeme();
+    Location start = lexer.current().location;
+    Name fnName = parseName("function name");
+
+    // TODO: generic method declarations CLI-39909
+    AstArray<AstGenericType> generics;
+    AstArray<AstGenericTypePack> genericPacks;
+    generics.size = 0;
+    generics.data = nullptr;
+    genericPacks.size = 0;
+    genericPacks.data = nullptr;
+
+    MatchLexeme matchParen = lexer.current();
+    expectAndConsume('(', "function parameter list start");
+
+    TempVector<Binding> args(scratchBinding);
+
+    bool vararg = false;
+    Location varargLocation;
+    AstTypePack* varargAnnotation = nullptr;
+    if (lexer.current().type != ')')
+        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3 */ true);
+
+    expectMatchAndConsume(')', matchParen);
+
+    AstTypeList retTypes = parseOptionalReturnType().value_or(AstTypeList{copy<AstType*>(nullptr, 0), nullptr});
+    Location end = lexer.current().location;
+
+    TempVector<AstType*> vars(scratchType);
+    TempVector<std::optional<AstArgumentName>> varNames(scratchOptArgName);
+
+    if (args.size() == 0 || args[0].name.name != "self" || args[0].annotation != nullptr)
+    {
+        return AstDeclaredClassProp{
+            fnName.name, reportTypeError(Location(start, end), {}, "'self' must be present as the unannotated first parameter"), true};
+    }
+
+    // Skip the first index.
+    for (size_t i = 1; i < args.size(); ++i)
+    {
+        varNames.push_back(AstArgumentName{args[i].name.name, args[i].name.location});
+
+        if (args[i].annotation)
+            vars.push_back(args[i].annotation);
+        else
+            vars.push_back(reportTypeError(Location(start, end), {}, "All declaration parameters aside from 'self' must be annotated"));
+    }
+
+    if (vararg && !varargAnnotation)
+        report(start, "All declaration parameters aside from 'self' must be annotated");
+
+    AstType* fnType = allocator.alloc<AstTypeFunction>(
+        Location(start, end), generics, genericPacks, AstTypeList{copy(vars), varargAnnotation}, copy(varNames), retTypes);
+
+    return AstDeclaredClassProp{fnName.name, fnType, true};
+}
+
+AstStat* Parser::parseDeclaration(const Location& start)
+{
+    // `declare` token is already parsed at this point
+    if (lexer.current().type == Lexeme::ReservedFunction)
+    {
+        nextLexeme();
+        bool checkedFunction = false;
+        if (FFlag::LuauCheckedFunctionSyntax && lexer.current().type == Lexeme::ReservedChecked)
+        {
+            checkedFunction = true;
+            nextLexeme();
+        }
+
+        Name globalName = parseName("global function name");
+        auto [generics, genericPacks] = parseGenericTypeList(/* withDefaultValues= */ false);
+
+        MatchLexeme matchParen = lexer.current();
+
+        expectAndConsume('(', "global function declaration");
+
+        TempVector<Binding> args(scratchBinding);
+
+        bool vararg = false;
+        Location varargLocation;
+        AstTypePack* varargAnnotation = nullptr;
+
+        if (lexer.current().type != ')')
+            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true);
+
+        expectMatchAndConsume(')', matchParen);
+
+        AstTypeList retTypes = parseOptionalReturnType().value_or(AstTypeList{copy<AstType*>(nullptr, 0)});
+        Location end = lexer.current().location;
+
+        TempVector<AstType*> vars(scratchType);
+        TempVector<AstArgumentName> varNames(scratchArgName);
+
+        for (size_t i = 0; i < args.size(); ++i)
+        {
+            if (!args[i].annotation)
+                return reportStatError(Location(start, end), {}, {}, "All declaration parameters must be annotated");
+
+            vars.push_back(args[i].annotation);
+            varNames.push_back({args[i].name.name, args[i].name.location});
+        }
+
+        if (vararg && !varargAnnotation)
+            return reportStatError(Location(start, end), {}, {}, "All declaration parameters must be annotated");
+
+        return allocator.alloc<AstStatDeclareFunction>(Location(start, end), globalName.name, generics, genericPacks,
+            AstTypeList{copy(vars), varargAnnotation}, copy(varNames), retTypes, checkedFunction);
+    }
+    else if (AstName(lexer.current().name) == "class")
+    {
+        nextLexeme();
+        Location classStart = lexer.current().location;
+        Name className = parseName("class name");
+        std::optional<AstName> superName = std::nullopt;
+
+        if (AstName(lexer.current().name) == "extends")
+        {
+            nextLexeme();
+            superName = parseName("superclass name").name;
+        }
+
+        TempVector<AstDeclaredClassProp> props(scratchDeclaredClassProps);
+        AstTableIndexer* indexer = nullptr;
+
+        while (lexer.current().type != Lexeme::ReservedEnd)
+        {
+            // There are two possibilities: Either it's a property or a function.
+            if (lexer.current().type == Lexeme::ReservedFunction)
+            {
+                props.push_back(parseDeclaredClassMethod());
+            }
+            else if (lexer.current().type == '[' && (lexer.lookahead().type == Lexeme::RawString ||
+                                                        lexer.lookahead().type == Lexeme::QuotedString))
+            {
+                const Lexeme begin = lexer.current();
+                nextLexeme(); // [
+
+                std::optional<AstArray<char>> chars = parseCharArray();
+
+                expectMatchAndConsume(']', begin);
+                expectAndConsume(':', "property type annotation");
+                AstType* type = parseType();
+
+                // since AstName contains a char*, it can't contain null
+                bool containsNull = chars && (strnlen(chars->data, chars->size) < chars->size);
+
+                if (chars && !containsNull)
+                    props.push_back(AstDeclaredClassProp{AstName(chars->data), type, false});
+                else
+                    report(begin.location, "String literal contains malformed escape sequence or \\0");
+            }
+            else if (lexer.current().type == '[')
+            {
+                if (indexer)
+                {
+                    // maybe we don't need to parse the entire badIndexer...
+                    // however, we either have { or [ to lint, not the entire table type or the bad indexer.
+                    AstTableIndexer* badIndexer = parseTableIndexer();
+
+                    // we lose all additional indexer expressions from the AST after error recovery here
+                    report(badIndexer->location, "Cannot have more than one class indexer");
+                }
+                else
+                {
+                    indexer = parseTableIndexer();
+                }
+            }
+            else
+            {
+                Name propName = parseName("property name");
+                expectAndConsume(':', "property type annotation");
+                AstType* propType = parseType();
+                props.push_back(AstDeclaredClassProp{propName.name, propType, false});
+            }
+        }
+
+        Location classEnd = lexer.current().location;
+        nextLexeme(); // skip past `end`
+
+        return allocator.alloc<AstStatDeclareClass>(Location(classStart, classEnd), className.name, superName, copy(props), indexer);
+    }
+    else if (std::optional<Name> globalName = parseNameOpt("global variable name"))
+    {
+        expectAndConsume(':', "global variable declaration");
+
+        AstType* type = parseType(/* in declaration context */ true);
+        return allocator.alloc<AstStatDeclareGlobal>(Location(start, type->location), globalName->name, type);
+    }
+    else
+    {
+        return reportStatError(start, {}, {}, "declare must be followed by an identifier, 'function', or 'class'");
+    }
+}
+
+static bool isExprLValue(AstExpr* expr)
+{
+    return expr->is<AstExprLocal>() || expr->is<AstExprGlobal>() || expr->is<AstExprIndexExpr>() || expr->is<AstExprIndexName>();
+}
+
+// varlist `=' explist
+AstStat* Parser::parseAssignment(AstExpr* initial)
+{
+    if (!isExprLValue(initial))
+        initial = reportExprError(initial->location, copy({initial}), "Assigned expression must be a variable or a field");
+
+    TempVector<AstExpr*> vars(scratchExpr);
+    vars.push_back(initial);
+
+    while (lexer.current().type == ',')
+    {
+        nextLexeme();
+
+        AstExpr* expr = parsePrimaryExpr(/* asStatement= */ true);
+
+        if (!isExprLValue(expr))
+            expr = reportExprError(expr->location, copy({expr}), "Assigned expression must be a variable or a field");
+
+        vars.push_back(expr);
+    }
+
+    expectAndConsume('=', "assignment");
+
+    TempVector<AstExpr*> values(scratchExprAux);
+    parseExprList(values);
+
+    return allocator.alloc<AstStatAssign>(Location(initial->location, values.back()->location), copy(vars), copy(values));
+}
+
+// var [`+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='] exp
+AstStat* Parser::parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op)
+{
+    if (!isExprLValue(initial))
+    {
+        initial = reportExprError(initial->location, copy({initial}), "Assigned expression must be a variable or a field");
+    }
+
+    nextLexeme();
+
+    AstExpr* value = parseExpr();
+
+    return allocator.alloc<AstStatCompoundAssign>(Location(initial->location, value->location), op, initial, value);
+}
+
+std::pair<AstLocal*, AstArray<AstLocal*>> Parser::prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args)
+{
+    AstLocal* self = nullptr;
+
+    if (hasself)
+        self = pushLocal(Binding(Name(nameSelf, start), nullptr));
+
+    TempVector<AstLocal*> vars(scratchLocal);
+
+    for (size_t i = 0; i < args.size(); ++i)
+        vars.push_back(pushLocal(args[i]));
+
+    return {self, copy(vars)};
+}
+
+// funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
+// parlist ::= bindinglist [`,' `...'] | `...'
+std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
+    bool hasself, const Lexeme& matchFunction, const AstName& debugname, const Name* localName)
+{
+    Location start = matchFunction.location;
+
+    auto [generics, genericPacks] = parseGenericTypeList(/* withDefaultValues= */ false);
+
+    MatchLexeme matchParen = lexer.current();
+    expectAndConsume('(', "function");
+
+    TempVector<Binding> args(scratchBinding);
+
+    bool vararg = false;
+    Location varargLocation;
+    AstTypePack* varargAnnotation = nullptr;
+
+    if (lexer.current().type != ')')
+        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true);
+
+    std::optional<Location> argLocation;
+
+    if (matchParen.type == Lexeme::Type('(') && lexer.current().type == Lexeme::Type(')'))
+        argLocation = Location(matchParen.position, lexer.current().location.end);
+
+    expectMatchAndConsume(')', matchParen, true);
+
+    std::optional<AstTypeList> typelist = parseOptionalReturnType();
+
+    AstLocal* funLocal = nullptr;
+
+    if (localName)
+        funLocal = pushLocal(Binding(*localName, nullptr));
+
+    unsigned int localsBegin = saveLocals();
+
+    Function fun;
+    fun.vararg = vararg;
+
+    functionStack.emplace_back(fun);
+
+    auto [self, vars] = prepareFunctionArguments(start, hasself, args);
+
+    AstStatBlock* body = parseBlock();
+
+    functionStack.pop_back();
+
+    restoreLocals(localsBegin);
+
+    Location end = lexer.current().location;
+
+    bool hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchFunction);
+    if (FFlag::LuauClipExtraHasEndProps)
+        body->hasEnd = hasEnd;
+
+    return {allocator.alloc<AstExprFunction>(Location(start, end), generics, genericPacks, self, vars, vararg, varargLocation, body,
+                functionStack.size(), debugname, typelist, varargAnnotation, hasEnd, argLocation),
+        funLocal};
+}
+
+// explist ::= {exp `,'} exp
+void Parser::parseExprList(TempVector<AstExpr*>& result)
+{
+    result.push_back(parseExpr());
+
+    while (lexer.current().type == ',')
+    {
+        nextLexeme();
+
+        if (lexer.current().type == ')')
+        {
+            report(lexer.current().location, "Expected expression after ',' but got ')' instead");
+            break;
+        }
+
+        result.push_back(parseExpr());
+    }
+}
+
+Parser::Binding Parser::parseBinding()
+{
+    std::optional<Name> name = parseNameOpt("variable name");
+
+    // Use placeholder if the name is missing
+    if (!name)
+        name = Name(nameError, lexer.current().location);
+
+    AstType* annotation = parseOptionalType();
+
+    return Binding(*name, annotation);
+}
+
+// bindinglist ::= (binding | `...') [`,' bindinglist]
+std::tuple<bool, Location, AstTypePack*> Parser::parseBindingList(TempVector<Binding>& result, bool allowDot3)
+{
+    while (true)
+    {
+        if (lexer.current().type == Lexeme::Dot3 && allowDot3)
+        {
+            Location varargLocation = lexer.current().location;
+            nextLexeme();
+
+            AstTypePack* tailAnnotation = nullptr;
+            if (lexer.current().type == ':')
+            {
+                nextLexeme();
+                tailAnnotation = parseVariadicArgumentTypePack();
+            }
+
+            return {true, varargLocation, tailAnnotation};
+        }
+
+        result.push_back(parseBinding());
+
+        if (lexer.current().type != ',')
+            break;
+        nextLexeme();
+    }
+
+    return {false, Location(), nullptr};
+}
+
+AstType* Parser::parseOptionalType()
+{
+    if (lexer.current().type == ':')
+    {
+        nextLexeme();
+        return parseType();
+    }
+    else
+        return nullptr;
+}
+
+// TypeList ::= Type [`,' TypeList] | ...Type
+AstTypePack* Parser::parseTypeList(TempVector<AstType*>& result, TempVector<std::optional<AstArgumentName>>& resultNames)
+{
+    while (true)
+    {
+        if (shouldParseTypePack(lexer))
+            return parseTypePack();
+
+        if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == ':')
+        {
+            // Fill in previous argument names with empty slots
+            while (resultNames.size() < result.size())
+                resultNames.push_back({});
+
+            resultNames.push_back(AstArgumentName{AstName(lexer.current().name), lexer.current().location});
+            nextLexeme();
+
+            expectAndConsume(':');
+        }
+        else if (!resultNames.empty())
+        {
+            // If we have a type with named arguments, provide elements for all types
+            resultNames.push_back({});
+        }
+
+        result.push_back(parseType());
+        if (lexer.current().type != ',')
+            break;
+
+        nextLexeme();
+
+        if (lexer.current().type == ')')
+        {
+            report(lexer.current().location, "Expected type after ',' but got ')' instead");
+            break;
+        }
+    }
+
+    return nullptr;
+}
+
+std::optional<AstTypeList> Parser::parseOptionalReturnType()
+{
+    if (lexer.current().type == ':' || lexer.current().type == Lexeme::SkinnyArrow)
+    {
+        if (lexer.current().type == Lexeme::SkinnyArrow)
+            report(lexer.current().location, "Function return type annotations are written after ':' instead of '->'");
+
+        nextLexeme();
+
+        unsigned int oldRecursionCount = recursionCounter;
+
+        auto [_location, result] = parseReturnType();
+
+        // At this point, if we find a , character, it indicates that there are multiple return types
+        // in this type annotation, but the list wasn't wrapped in parentheses.
+        if (lexer.current().type == ',')
+        {
+            report(lexer.current().location, "Expected a statement, got ','; did you forget to wrap the list of return types in parentheses?");
+
+            nextLexeme();
+        }
+
+        recursionCounter = oldRecursionCount;
+
+        return result;
+    }
+
+    return std::nullopt;
+}
+
+// ReturnType ::= Type | `(' TypeList `)'
+std::pair<Location, AstTypeList> Parser::parseReturnType()
+{
+    incrementRecursionCounter("type annotation");
+
+    Lexeme begin = lexer.current();
+
+    if (lexer.current().type != '(')
+    {
+        if (shouldParseTypePack(lexer))
+        {
+            AstTypePack* typePack = parseTypePack();
+
+            return {typePack->location, AstTypeList{{}, typePack}};
+        }
+        else
+        {
+            AstType* type = parseType();
+
+            return {type->location, AstTypeList{copy(&type, 1), nullptr}};
+        }
+    }
+
+    nextLexeme();
+
+    Location innerBegin = lexer.current().location;
+
+    matchRecoveryStopOnToken[Lexeme::SkinnyArrow]++;
+
+    TempVector<AstType*> result(scratchType);
+    TempVector<std::optional<AstArgumentName>> resultNames(scratchOptArgName);
+    AstTypePack* varargAnnotation = nullptr;
+
+    // possibly () -> ReturnType
+    if (lexer.current().type != ')')
+        varargAnnotation = parseTypeList(result, resultNames);
+
+    const Location location{begin.location, lexer.current().location};
+
+    expectMatchAndConsume(')', begin, true);
+
+    matchRecoveryStopOnToken[Lexeme::SkinnyArrow]--;
+
+    if (lexer.current().type != Lexeme::SkinnyArrow && resultNames.empty())
+    {
+        // If it turns out that it's just '(A)', it's possible that there are unions/intersections to follow, so fold over it.
+        if (result.size() == 1)
+        {
+            AstType* returnType = parseTypeSuffix(result[0], innerBegin);
+
+            // If parseType parses nothing, then returnType->location.end only points at the last non-type-pack
+            // type to successfully parse.  We need the span of the whole annotation.
+            Position endPos = result.size() == 1 ? location.end : returnType->location.end;
+
+            return {Location{location.begin, endPos}, AstTypeList{copy(&returnType, 1), varargAnnotation}};
+        }
+
+        return {location, AstTypeList{copy(result), varargAnnotation}};
+    }
+
+    AstType* tail = parseFunctionTypeTail(begin, {}, {}, copy(result), copy(resultNames), varargAnnotation);
+
+    return {Location{location, tail->location}, AstTypeList{copy(&tail, 1), varargAnnotation}};
+}
+
+// TableIndexer ::= `[' Type `]' `:' Type
+AstTableIndexer* Parser::parseTableIndexer()
+{
+    const Lexeme begin = lexer.current();
+    nextLexeme(); // [
+
+    AstType* index = parseType();
+
+    expectMatchAndConsume(']', begin);
+
+    expectAndConsume(':', "table field");
+
+    AstType* result = parseType();
+
+    return allocator.alloc<AstTableIndexer>(AstTableIndexer{index, result, Location(begin.location, result->location)});
+}
+
+// TableProp ::= Name `:' Type
+// TablePropOrIndexer ::= TableProp | TableIndexer
+// PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
+// TableType ::= `{' PropList `}'
+AstType* Parser::parseTableType(bool inDeclarationContext)
+{
+    incrementRecursionCounter("type annotation");
+
+    TempVector<AstTableProp> props(scratchTableTypeProps);
+    AstTableIndexer* indexer = nullptr;
+
+    Location start = lexer.current().location;
+
+    MatchLexeme matchBrace = lexer.current();
+    expectAndConsume('{', "table type");
+
+    while (lexer.current().type != '}')
+    {
+        if (lexer.current().type == '[' && (lexer.lookahead().type == Lexeme::RawString || lexer.lookahead().type == Lexeme::QuotedString))
+        {
+            const Lexeme begin = lexer.current();
+            nextLexeme(); // [
+            std::optional<AstArray<char>> chars = parseCharArray();
+
+            expectMatchAndConsume(']', begin);
+            expectAndConsume(':', "table field");
+
+            AstType* type = parseType();
+
+            // since AstName contains a char*, it can't contain null
+            bool containsNull = chars && (strnlen(chars->data, chars->size) < chars->size);
+
+            if (chars && !containsNull)
+                props.push_back({AstName(chars->data), begin.location, type});
+            else
+                report(begin.location, "String literal contains malformed escape sequence or \\0");
+        }
+        else if (lexer.current().type == '[')
+        {
+            if (indexer)
+            {
+                // maybe we don't need to parse the entire badIndexer...
+                // however, we either have { or [ to lint, not the entire table type or the bad indexer.
+                AstTableIndexer* badIndexer = parseTableIndexer();
+
+                // we lose all additional indexer expressions from the AST after error recovery here
+                report(badIndexer->location, "Cannot have more than one table indexer");
+            }
+            else
+            {
+                indexer = parseTableIndexer();
+            }
+        }
+        else if (props.empty() && !indexer && !(lexer.current().type == Lexeme::Name && lexer.lookahead().type == ':'))
+        {
+            AstType* type = parseType();
+
+            // array-like table type: {T} desugars into {[number]: T}
+            AstType* index = allocator.alloc<AstTypeReference>(type->location, std::nullopt, nameNumber, std::nullopt, type->location);
+            indexer = allocator.alloc<AstTableIndexer>(AstTableIndexer{index, type, type->location});
+
+            break;
+        }
+        else
+        {
+            std::optional<Name> name = parseNameOpt("table field");
+
+            if (!name)
+                break;
+
+            expectAndConsume(':', "table field");
+
+            AstType* type = parseType(inDeclarationContext);
+
+            props.push_back({name->name, name->location, type});
+        }
+
+        if (lexer.current().type == ',' || lexer.current().type == ';')
+        {
+            nextLexeme();
+        }
+        else
+        {
+            if (lexer.current().type != '}')
+                break;
+        }
+    }
+
+    Location end = lexer.current().location;
+
+    if (!expectMatchAndConsume('}', matchBrace))
+        end = lexer.previousLocation();
+
+    return allocator.alloc<AstTypeTable>(Location(start, end), copy(props), indexer);
+}
+
+// ReturnType ::= Type | `(' TypeList `)'
+// FunctionType ::= [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+AstTypeOrPack Parser::parseFunctionType(bool allowPack, bool isCheckedFunction)
+{
+    incrementRecursionCounter("type annotation");
+
+    bool forceFunctionType = lexer.current().type == '<';
+
+    Lexeme begin = lexer.current();
+
+    auto [generics, genericPacks] = parseGenericTypeList(/* withDefaultValues= */ false);
+
+    Lexeme parameterStart = lexer.current();
+
+    expectAndConsume('(', "function parameters");
+
+    matchRecoveryStopOnToken[Lexeme::SkinnyArrow]++;
+
+    TempVector<AstType*> params(scratchType);
+    TempVector<std::optional<AstArgumentName>> names(scratchOptArgName);
+    AstTypePack* varargAnnotation = nullptr;
+
+    if (lexer.current().type != ')')
+        varargAnnotation = parseTypeList(params, names);
+
+    expectMatchAndConsume(')', parameterStart, true);
+
+    matchRecoveryStopOnToken[Lexeme::SkinnyArrow]--;
+
+    AstArray<AstType*> paramTypes = copy(params);
+
+    if (!names.empty())
+        forceFunctionType = true;
+
+    bool returnTypeIntroducer = lexer.current().type == Lexeme::SkinnyArrow || lexer.current().type == ':';
+
+    // Not a function at all. Just a parenthesized type. Or maybe a type pack with a single element
+    if (params.size() == 1 && !varargAnnotation && !forceFunctionType && !returnTypeIntroducer)
+    {
+        if (allowPack)
+            return {{}, allocator.alloc<AstTypePackExplicit>(begin.location, AstTypeList{paramTypes, nullptr})};
+        else
+            return {params[0], {}};
+    }
+
+    if (!forceFunctionType && !returnTypeIntroducer && allowPack)
+        return {{}, allocator.alloc<AstTypePackExplicit>(begin.location, AstTypeList{paramTypes, varargAnnotation})};
+
+    AstArray<std::optional<AstArgumentName>> paramNames = copy(names);
+
+    return {parseFunctionTypeTail(begin, generics, genericPacks, paramTypes, paramNames, varargAnnotation, isCheckedFunction), {}};
+}
+
+AstType* Parser::parseFunctionTypeTail(const Lexeme& begin, AstArray<AstGenericType> generics, AstArray<AstGenericTypePack> genericPacks,
+    AstArray<AstType*> params, AstArray<std::optional<AstArgumentName>> paramNames, AstTypePack* varargAnnotation, bool isCheckedFunction)
+{
+    incrementRecursionCounter("type annotation");
+
+    if (lexer.current().type == ':')
+    {
+        report(lexer.current().location, "Return types in function type annotations are written after '->' instead of ':'");
+        lexer.next();
+    }
+    // Users occasionally write '()' as the 'unit' type when they actually want to use 'nil', here we'll try to give a more specific error
+    else if (lexer.current().type != Lexeme::SkinnyArrow && generics.size == 0 && genericPacks.size == 0 && params.size == 0)
+    {
+        report(Location(begin.location, lexer.previousLocation()), "Expected '->' after '()' when parsing function type; did you mean 'nil'?");
+
+        return allocator.alloc<AstTypeReference>(begin.location, std::nullopt, nameNil, std::nullopt, begin.location);
+    }
+    else
+    {
+        expectAndConsume(Lexeme::SkinnyArrow, "function type");
+    }
+
+    auto [endLocation, returnTypeList] = parseReturnType();
+
+    AstTypeList paramTypes = AstTypeList{params, varargAnnotation};
+    return allocator.alloc<AstTypeFunction>(
+        Location(begin.location, endLocation), generics, genericPacks, paramTypes, paramNames, returnTypeList, isCheckedFunction);
+}
+
+// Type ::=
+//      nil |
+//      Name[`.' Name] [`<' namelist `>'] |
+//      `{' [PropList] `}' |
+//      `(' [TypeList] `)' `->` ReturnType
+//      `typeof` Type
+AstType* Parser::parseTypeSuffix(AstType* type, const Location& begin)
+{
+    TempVector<AstType*> parts(scratchType);
+    parts.push_back(type);
+
+    incrementRecursionCounter("type annotation");
+
+    bool isUnion = false;
+    bool isIntersection = false;
+    bool hasOptional = false;
+
+    Location location = begin;
+
+    while (true)
+    {
+        Lexeme::Type c = lexer.current().type;
+        if (c == '|')
+        {
+            nextLexeme();
+
+            unsigned int oldRecursionCount = recursionCounter;
+            parts.push_back(parseSimpleType(/* allowPack= */ false).type);
+            recursionCounter = oldRecursionCount;
+
+            isUnion = true;
+        }
+        else if (c == '?')
+        {
+            Location loc = lexer.current().location;
+            nextLexeme();
+
+            if (!hasOptional)
+                parts.push_back(allocator.alloc<AstTypeReference>(loc, std::nullopt, nameNil, std::nullopt, loc));
+
+            isUnion = true;
+            hasOptional = true;
+        }
+        else if (c == '&')
+        {
+            nextLexeme();
+
+            unsigned int oldRecursionCount = recursionCounter;
+            parts.push_back(parseSimpleType(/* allowPack= */ false).type);
+            recursionCounter = oldRecursionCount;
+
+            isIntersection = true;
+        }
+        else if (c == Lexeme::Dot3)
+        {
+            report(lexer.current().location, "Unexpected '...' after type annotation");
+            nextLexeme();
+        }
+        else
+            break;
+
+        if (parts.size() > unsigned(FInt::LuauTypeLengthLimit) + hasOptional)
+            ParseError::raise(parts.back()->location, "Exceeded allowed type length; simplify your type annotation to make the code compile");
+    }
+
+    if (parts.size() == 1)
+        return type;
+
+    if (isUnion && isIntersection)
+    {
+        return reportTypeError(Location(begin, parts.back()->location), copy(parts),
+            "Mixing union and intersection types is not allowed; consider wrapping in parentheses.");
+    }
+
+    location.end = parts.back()->location.end;
+
+    if (isUnion)
+        return allocator.alloc<AstTypeUnion>(location, copy(parts));
+
+    if (isIntersection)
+        return allocator.alloc<AstTypeIntersection>(location, copy(parts));
+
+    LUAU_ASSERT(false);
+    ParseError::raise(begin, "Composite type was not an intersection or union.");
+}
+
+AstTypeOrPack Parser::parseTypeOrPack()
+{
+    unsigned int oldRecursionCount = recursionCounter;
+    // recursion counter is incremented in parseSimpleType
+
+    Location begin = lexer.current().location;
+
+    auto [type, typePack] = parseSimpleType(/* allowPack= */ true);
+
+    if (typePack)
+    {
+        LUAU_ASSERT(!type);
+        return {{}, typePack};
+    }
+
+    recursionCounter = oldRecursionCount;
+
+    return {parseTypeSuffix(type, begin), {}};
+}
+
+AstType* Parser::parseType(bool inDeclarationContext)
+{
+    unsigned int oldRecursionCount = recursionCounter;
+    // recursion counter is incremented in parseSimpleType
+
+    Location begin = lexer.current().location;
+
+    AstType* type = parseSimpleType(/* allowPack= */ false, /* in declaration context */ inDeclarationContext).type;
+
+    recursionCounter = oldRecursionCount;
+
+    return parseTypeSuffix(type, begin);
+}
+
+// Type ::= nil | Name[`.' Name] [ `<' Type [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}'
+//   | [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+AstTypeOrPack Parser::parseSimpleType(bool allowPack, bool inDeclarationContext)
+{
+    incrementRecursionCounter("type annotation");
+
+    Location start = lexer.current().location;
+
+    if (lexer.current().type == Lexeme::ReservedNil)
+    {
+        nextLexeme();
+        return {allocator.alloc<AstTypeReference>(start, std::nullopt, nameNil, std::nullopt, start), {}};
+    }
+    else if (lexer.current().type == Lexeme::ReservedTrue)
+    {
+        nextLexeme();
+        return {allocator.alloc<AstTypeSingletonBool>(start, true)};
+    }
+    else if (lexer.current().type == Lexeme::ReservedFalse)
+    {
+        nextLexeme();
+        return {allocator.alloc<AstTypeSingletonBool>(start, false)};
+    }
+    else if (lexer.current().type == Lexeme::RawString || lexer.current().type == Lexeme::QuotedString)
+    {
+        if (std::optional<AstArray<char>> value = parseCharArray())
+        {
+            AstArray<char> svalue = *value;
+            return {allocator.alloc<AstTypeSingletonString>(start, svalue)};
+        }
+        else
+            return {reportTypeError(start, {}, "String literal contains malformed escape sequence")};
+    }
+    else if (lexer.current().type == Lexeme::InterpStringBegin || lexer.current().type == Lexeme::InterpStringSimple)
+    {
+        parseInterpString();
+
+        return {reportTypeError(start, {}, "Interpolated string literals cannot be used as types")};
+    }
+    else if (lexer.current().type == Lexeme::BrokenString)
+    {
+        nextLexeme();
+        return {reportTypeError(start, {}, "Malformed string; did you forget to finish it?")};
+    }
+    else if (lexer.current().type == Lexeme::Name)
+    {
+        std::optional<AstName> prefix;
+        std::optional<Location> prefixLocation;
+        Name name = parseName("type name");
+
+        if (lexer.current().type == '.')
+        {
+            Position pointPosition = lexer.current().location.begin;
+            nextLexeme();
+
+            prefix = name.name;
+            prefixLocation = name.location;
+            name = parseIndexName("field name", pointPosition);
+        }
+        else if (lexer.current().type == Lexeme::Dot3)
+        {
+            report(lexer.current().location, "Unexpected '...' after type name; type pack is not allowed in this context");
+            nextLexeme();
+        }
+        else if (name.name == "typeof")
+        {
+            Lexeme typeofBegin = lexer.current();
+            expectAndConsume('(', "typeof type");
+
+            AstExpr* expr = parseExpr();
+
+            Location end = lexer.current().location;
+
+            expectMatchAndConsume(')', typeofBegin);
+
+            return {allocator.alloc<AstTypeTypeof>(Location(start, end), expr), {}};
+        }
+
+        bool hasParameters = false;
+        AstArray<AstTypeOrPack> parameters{};
+
+        if (lexer.current().type == '<')
+        {
+            hasParameters = true;
+            parameters = parseTypeParams();
+        }
+
+        Location end = lexer.previousLocation();
+
+        return {
+            allocator.alloc<AstTypeReference>(Location(start, end), prefix, name.name, prefixLocation, name.location, hasParameters, parameters), {}};
+    }
+    else if (lexer.current().type == '{')
+    {
+        return {parseTableType(/* inDeclarationContext */ inDeclarationContext), {}};
+    }
+    else if (FFlag::LuauCheckedFunctionSyntax && inDeclarationContext && lexer.current().type == Lexeme::ReservedChecked)
+    {
+        LUAU_ASSERT(FFlag::LuauCheckedFunctionSyntax);
+        nextLexeme();
+        return parseFunctionType(allowPack, /* isCheckedFunction */ true);
+    }
+    else if (lexer.current().type == '(' || lexer.current().type == '<')
+    {
+        return parseFunctionType(allowPack);
+    }
+    else if (lexer.current().type == Lexeme::ReservedFunction)
+    {
+        nextLexeme();
+
+        return {reportTypeError(start, {},
+                    "Using 'function' as a type annotation is not supported, consider replacing with a function type annotation e.g. '(...any) -> "
+                    "...any'"),
+            {}};
+    }
+    else
+    {
+        // For a missing type annotation, capture 'space' between last token and the next one
+        Location astErrorlocation(lexer.previousLocation().end, start.begin);
+        // The parse error includes the next lexeme to make it easier to display where the error is (e.g. in an IDE or a CLI error message).
+        // Including the current lexeme also makes the parse error consistent with other parse errors returned by Luau.
+        Location parseErrorLocation(lexer.previousLocation().end, start.end);
+        return {reportMissingTypeError(parseErrorLocation, astErrorlocation, "Expected type, got %s", lexer.current().toString().c_str()), {}};
+    }
+}
+
+AstTypePack* Parser::parseVariadicArgumentTypePack()
+{
+    // Generic: a...
+    if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == Lexeme::Dot3)
+    {
+        Name name = parseName("generic name");
+        Location end = lexer.current().location;
+
+        // This will not fail because of the lookahead guard.
+        expectAndConsume(Lexeme::Dot3, "generic type pack annotation");
+        return allocator.alloc<AstTypePackGeneric>(Location(name.location, end), name.name);
+    }
+    // Variadic: T
+    else
+    {
+        AstType* variadicAnnotation = parseType();
+        return allocator.alloc<AstTypePackVariadic>(variadicAnnotation->location, variadicAnnotation);
+    }
+}
+
+AstTypePack* Parser::parseTypePack()
+{
+    // Variadic: ...T
+    if (lexer.current().type == Lexeme::Dot3)
+    {
+        Location start = lexer.current().location;
+        nextLexeme();
+        AstType* varargTy = parseType();
+        return allocator.alloc<AstTypePackVariadic>(Location(start, varargTy->location), varargTy);
+    }
+    // Generic: a...
+    else if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == Lexeme::Dot3)
+    {
+        Name name = parseName("generic name");
+        Location end = lexer.current().location;
+
+        // This will not fail because of the lookahead guard.
+        expectAndConsume(Lexeme::Dot3, "generic type pack annotation");
+        return allocator.alloc<AstTypePackGeneric>(Location(name.location, end), name.name);
+    }
+
+    // TODO: shouldParseTypePack can be removed and parseTypePack can be called unconditionally instead
+    LUAU_ASSERT(!"parseTypePack can't be called if shouldParseTypePack() returned false");
+    return nullptr;
+}
+
+std::optional<AstExprUnary::Op> Parser::parseUnaryOp(const Lexeme& l)
+{
+    if (l.type == Lexeme::ReservedNot)
+        return AstExprUnary::Not;
+    else if (l.type == '-')
+        return AstExprUnary::Minus;
+    else if (l.type == '#')
+        return AstExprUnary::Len;
+    else
+        return std::nullopt;
+}
+
+std::optional<AstExprBinary::Op> Parser::parseBinaryOp(const Lexeme& l)
+{
+    if (l.type == '+')
+        return AstExprBinary::Add;
+    else if (l.type == '-')
+        return AstExprBinary::Sub;
+    else if (l.type == '*')
+        return AstExprBinary::Mul;
+    else if (l.type == '/')
+        return AstExprBinary::Div;
+    else if (l.type == Lexeme::FloorDiv)
+        return AstExprBinary::FloorDiv;
+    else if (l.type == '%')
+        return AstExprBinary::Mod;
+    else if (l.type == '^')
+        return AstExprBinary::Pow;
+    else if (l.type == Lexeme::Dot2)
+        return AstExprBinary::Concat;
+    else if (l.type == Lexeme::NotEqual)
+        return AstExprBinary::CompareNe;
+    else if (l.type == Lexeme::Equal)
+        return AstExprBinary::CompareEq;
+    else if (l.type == '<')
+        return AstExprBinary::CompareLt;
+    else if (l.type == Lexeme::LessEqual)
+        return AstExprBinary::CompareLe;
+    else if (l.type == '>')
+        return AstExprBinary::CompareGt;
+    else if (l.type == Lexeme::GreaterEqual)
+        return AstExprBinary::CompareGe;
+    else if (l.type == Lexeme::ReservedAnd)
+        return AstExprBinary::And;
+    else if (l.type == Lexeme::ReservedOr)
+        return AstExprBinary::Or;
+    else
+        return std::nullopt;
+}
+
+std::optional<AstExprBinary::Op> Parser::parseCompoundOp(const Lexeme& l)
+{
+    if (l.type == Lexeme::AddAssign)
+        return AstExprBinary::Add;
+    else if (l.type == Lexeme::SubAssign)
+        return AstExprBinary::Sub;
+    else if (l.type == Lexeme::MulAssign)
+        return AstExprBinary::Mul;
+    else if (l.type == Lexeme::DivAssign)
+        return AstExprBinary::Div;
+    else if (l.type == Lexeme::FloorDivAssign)
+        return AstExprBinary::FloorDiv;
+    else if (l.type == Lexeme::ModAssign)
+        return AstExprBinary::Mod;
+    else if (l.type == Lexeme::PowAssign)
+        return AstExprBinary::Pow;
+    else if (l.type == Lexeme::ConcatAssign)
+        return AstExprBinary::Concat;
+    else
+        return std::nullopt;
+}
+
+std::optional<AstExprUnary::Op> Parser::checkUnaryConfusables()
+{
+    const Lexeme& curr = lexer.current();
+
+    // early-out: need to check if this is a possible confusable quickly
+    if (curr.type != '!')
+        return {};
+
+    // slow path: possible confusable
+    Location start = curr.location;
+
+    if (curr.type == '!')
+    {
+        report(start, "Unexpected '!'; did you mean 'not'?");
+        return AstExprUnary::Not;
+    }
+
+    return {};
+}
+
+std::optional<AstExprBinary::Op> Parser::checkBinaryConfusables(const BinaryOpPriority binaryPriority[], unsigned int limit)
+{
+    const Lexeme& curr = lexer.current();
+
+    // early-out: need to check if this is a possible confusable quickly
+    if (curr.type != '&' && curr.type != '|' && curr.type != '!')
+        return {};
+
+    // slow path: possible confusable
+    Location start = curr.location;
+    Lexeme next = lexer.lookahead();
+
+    if (curr.type == '&' && next.type == '&' && curr.location.end == next.location.begin && binaryPriority[AstExprBinary::And].left > limit)
+    {
+        nextLexeme();
+        report(Location(start, next.location), "Unexpected '&&'; did you mean 'and'?");
+        return AstExprBinary::And;
+    }
+    else if (curr.type == '|' && next.type == '|' && curr.location.end == next.location.begin && binaryPriority[AstExprBinary::Or].left > limit)
+    {
+        nextLexeme();
+        report(Location(start, next.location), "Unexpected '||'; did you mean 'or'?");
+        return AstExprBinary::Or;
+    }
+    else if (curr.type == '!' && next.type == '=' && curr.location.end == next.location.begin &&
+             binaryPriority[AstExprBinary::CompareNe].left > limit)
+    {
+        nextLexeme();
+        report(Location(start, next.location), "Unexpected '!='; did you mean '~='?");
+        return AstExprBinary::CompareNe;
+    }
+
+    return std::nullopt;
+}
+
+// subexpr -> (asexp | unop subexpr) { binop subexpr }
+// where `binop' is any binary operator with a priority higher than `limit'
+AstExpr* Parser::parseExpr(unsigned int limit)
+{
+    static const BinaryOpPriority binaryPriority[] = {
+        {6, 6}, {6, 6}, {7, 7}, {7, 7}, {7, 7}, {7, 7}, // `+' `-' `*' `/' `//' `%'
+        {10, 9}, {5, 4},                                // power and concat (right associative)
+        {3, 3}, {3, 3},                                 // equality and inequality
+        {3, 3}, {3, 3}, {3, 3}, {3, 3},                 // order
+        {2, 2}, {1, 1}                                  // logical (and/or)
+    };
+    static_assert(sizeof(binaryPriority) / sizeof(binaryPriority[0]) == size_t(AstExprBinary::Op__Count), "binaryPriority needs an entry per op");
+
+    unsigned int oldRecursionCount = recursionCounter;
+
+    // this handles recursive calls to parseSubExpr/parseExpr
+    incrementRecursionCounter("expression");
+
+    const unsigned int unaryPriority = 8;
+
+    Location start = lexer.current().location;
+
+    AstExpr* expr;
+
+    std::optional<AstExprUnary::Op> uop = parseUnaryOp(lexer.current());
+
+    if (!uop)
+        uop = checkUnaryConfusables();
+
+    if (uop)
+    {
+        nextLexeme();
+
+        AstExpr* subexpr = parseExpr(unaryPriority);
+
+        expr = allocator.alloc<AstExprUnary>(Location(start, subexpr->location), *uop, subexpr);
+    }
+    else
+    {
+        expr = parseAssertionExpr();
+    }
+
+    // expand while operators have priorities higher than `limit'
+    std::optional<AstExprBinary::Op> op = parseBinaryOp(lexer.current());
+
+    if (!op)
+        op = checkBinaryConfusables(binaryPriority, limit);
+
+    while (op && binaryPriority[*op].left > limit)
+    {
+        nextLexeme();
+
+        // read sub-expression with higher priority
+        AstExpr* next = parseExpr(binaryPriority[*op].right);
+
+        expr = allocator.alloc<AstExprBinary>(Location(start, next->location), *op, expr, next);
+        op = parseBinaryOp(lexer.current());
+
+        if (!op)
+            op = checkBinaryConfusables(binaryPriority, limit);
+
+        // note: while the parser isn't recursive here, we're generating recursive structures of unbounded depth
+        incrementRecursionCounter("expression");
+    }
+
+    recursionCounter = oldRecursionCount;
+
+    return expr;
+}
+
+// NAME
+AstExpr* Parser::parseNameExpr(const char* context)
+{
+    std::optional<Name> name = parseNameOpt(context);
+
+    if (!name)
+        return allocator.alloc<AstExprError>(lexer.current().location, copy<AstExpr*>({}), unsigned(parseErrors.size() - 1));
+
+    AstLocal* const* value = localMap.find(name->name);
+
+    if (value && *value)
+    {
+        AstLocal* local = *value;
+
+        return allocator.alloc<AstExprLocal>(name->location, local, local->functionDepth != functionStack.size() - 1);
+    }
+
+    return allocator.alloc<AstExprGlobal>(name->location, name->name);
+}
+
+// prefixexp -> NAME | '(' expr ')'
+AstExpr* Parser::parsePrefixExpr()
+{
+    if (lexer.current().type == '(')
+    {
+        Position start = lexer.current().location.begin;
+
+        MatchLexeme matchParen = lexer.current();
+        nextLexeme();
+
+        AstExpr* expr = parseExpr();
+
+        Position end = lexer.current().location.end;
+
+        if (lexer.current().type != ')')
+        {
+            const char* suggestion = (lexer.current().type == '=') ? "; did you mean to use '{' when defining a table?" : nullptr;
+
+            expectMatchAndConsumeFail(static_cast<Lexeme::Type>(')'), matchParen, suggestion);
+
+            end = lexer.previousLocation().end;
+        }
+        else
+        {
+            nextLexeme();
+        }
+
+        return allocator.alloc<AstExprGroup>(Location(start, end), expr);
+    }
+    else
+    {
+        return parseNameExpr("expression");
+    }
+}
+
+// primaryexp -> prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
+AstExpr* Parser::parsePrimaryExpr(bool asStatement)
+{
+    Position start = lexer.current().location.begin;
+
+    AstExpr* expr = parsePrefixExpr();
+
+    unsigned int oldRecursionCount = recursionCounter;
+
+    while (true)
+    {
+        if (lexer.current().type == '.')
+        {
+            Position opPosition = lexer.current().location.begin;
+            nextLexeme();
+
+            Name index = parseIndexName(nullptr, opPosition);
+
+            expr = allocator.alloc<AstExprIndexName>(Location(start, index.location.end), expr, index.name, index.location, opPosition, '.');
+        }
+        else if (lexer.current().type == '[')
+        {
+            MatchLexeme matchBracket = lexer.current();
+            nextLexeme();
+
+            AstExpr* index = parseExpr();
+
+            Position end = lexer.current().location.end;
+
+            expectMatchAndConsume(']', matchBracket);
+
+            expr = allocator.alloc<AstExprIndexExpr>(Location(start, end), expr, index);
+        }
+        else if (lexer.current().type == ':')
+        {
+            Position opPosition = lexer.current().location.begin;
+            nextLexeme();
+
+            Name index = parseIndexName("method name", opPosition);
+            AstExpr* func = allocator.alloc<AstExprIndexName>(Location(start, index.location.end), expr, index.name, index.location, opPosition, ':');
+
+            expr = parseFunctionArgs(func, true);
+        }
+        else if (lexer.current().type == '(')
+        {
+            // This error is handled inside 'parseFunctionArgs' as well, but for better error recovery we need to break out the current loop here
+            if (!asStatement && expr->location.end.line != lexer.current().location.begin.line)
+            {
+                reportAmbiguousCallError();
+                break;
+            }
+
+            expr = parseFunctionArgs(expr, false);
+        }
+        else if (lexer.current().type == '{' || lexer.current().type == Lexeme::RawString || lexer.current().type == Lexeme::QuotedString)
+        {
+            expr = parseFunctionArgs(expr, false);
+        }
+        else
+        {
+            break;
+        }
+
+        // note: while the parser isn't recursive here, we're generating recursive structures of unbounded depth
+        incrementRecursionCounter("expression");
+    }
+
+    recursionCounter = oldRecursionCount;
+
+    return expr;
+}
+
+// asexp -> simpleexp [`::' Type]
+AstExpr* Parser::parseAssertionExpr()
+{
+    Location start = lexer.current().location;
+    AstExpr* expr = parseSimpleExpr();
+
+    if (lexer.current().type == Lexeme::DoubleColon)
+    {
+        nextLexeme();
+        AstType* annotation = parseType();
+        return allocator.alloc<AstExprTypeAssertion>(Location(start, annotation->location), expr, annotation);
+    }
+    else
+        return expr;
+}
+
+static ConstantNumberParseResult parseInteger(double& result, const char* data, int base)
+{
+    LUAU_ASSERT(base == 2 || base == 16);
+
+    char* end = nullptr;
+    unsigned long long value = strtoull(data, &end, base);
+
+    if (*end != 0)
+        return ConstantNumberParseResult::Malformed;
+
+    result = double(value);
+
+    if (value == ULLONG_MAX && errno == ERANGE)
+    {
+        // 'errno' might have been set before we called 'strtoull', but we don't want the overhead of resetting a TLS variable on each call
+        // so we only reset it when we get a result that might be an out-of-range error and parse again to make sure
+        errno = 0;
+        value = strtoull(data, &end, base);
+
+        if (errno == ERANGE)
+            return base == 2 ? ConstantNumberParseResult::BinOverflow : ConstantNumberParseResult::HexOverflow;
+    }
+
+    if (value >= (1ull << 53) && static_cast<unsigned long long>(result) != value)
+        return ConstantNumberParseResult::Imprecise;
+
+    return ConstantNumberParseResult::Ok;
+}
+
+static ConstantNumberParseResult parseDouble(double& result, const char* data)
+{
+    // binary literal
+    if (data[0] == '0' && (data[1] == 'b' || data[1] == 'B') && data[2])
+        return parseInteger(result, data + 2, 2);
+
+    // hexadecimal literal
+    if (data[0] == '0' && (data[1] == 'x' || data[1] == 'X') && data[2])
+        return parseInteger(result, data, 16); // pass in '0x' prefix, it's handled by 'strtoull'
+
+    char* end = nullptr;
+    double value = strtod(data, &end);
+
+    // trailing non-numeric characters
+    if (*end != 0)
+        return ConstantNumberParseResult::Malformed;
+
+    result = value;
+
+    // for linting, we detect integer constants that are parsed imprecisely
+    // since the check is expensive we only perform it when the number is larger than the precise integer range
+    if (value >= double(1ull << 53) && strspn(data, "0123456789") == strlen(data))
+    {
+        char repr[512];
+        snprintf(repr, sizeof(repr), "%.0f", value);
+
+        if (strcmp(repr, data) != 0)
+            return ConstantNumberParseResult::Imprecise;
+    }
+
+    return ConstantNumberParseResult::Ok;
+}
+
+// simpleexp -> NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
+AstExpr* Parser::parseSimpleExpr()
+{
+    Location start = lexer.current().location;
+
+    if (lexer.current().type == Lexeme::ReservedNil)
+    {
+        nextLexeme();
+
+        return allocator.alloc<AstExprConstantNil>(start);
+    }
+    else if (lexer.current().type == Lexeme::ReservedTrue)
+    {
+        nextLexeme();
+
+        return allocator.alloc<AstExprConstantBool>(start, true);
+    }
+    else if (lexer.current().type == Lexeme::ReservedFalse)
+    {
+        nextLexeme();
+
+        return allocator.alloc<AstExprConstantBool>(start, false);
+    }
+    else if (lexer.current().type == Lexeme::ReservedFunction)
+    {
+        Lexeme matchFunction = lexer.current();
+        nextLexeme();
+
+        return parseFunctionBody(false, matchFunction, AstName(), nullptr).first;
+    }
+    else if (lexer.current().type == Lexeme::Number)
+    {
+        return parseNumber();
+    }
+    else if (lexer.current().type == Lexeme::RawString || lexer.current().type == Lexeme::QuotedString ||
+             lexer.current().type == Lexeme::InterpStringSimple)
+    {
+        return parseString();
+    }
+    else if (lexer.current().type == Lexeme::InterpStringBegin)
+    {
+        return parseInterpString();
+    }
+    else if (lexer.current().type == Lexeme::BrokenString)
+    {
+        nextLexeme();
+        return reportExprError(start, {}, "Malformed string; did you forget to finish it?");
+    }
+    else if (lexer.current().type == Lexeme::BrokenInterpDoubleBrace)
+    {
+        nextLexeme();
+        return reportExprError(start, {}, "Double braces are not permitted within interpolated strings; did you mean '\\{'?");
+    }
+    else if (lexer.current().type == Lexeme::Dot3)
+    {
+        if (functionStack.back().vararg)
+        {
+            nextLexeme();
+
+            return allocator.alloc<AstExprVarargs>(start);
+        }
+        else
+        {
+            nextLexeme();
+
+            return reportExprError(start, {}, "Cannot use '...' outside of a vararg function");
+        }
+    }
+    else if (lexer.current().type == '{')
+    {
+        return parseTableConstructor();
+    }
+    else if (lexer.current().type == Lexeme::ReservedIf)
+    {
+        return parseIfElseExpr();
+    }
+    else
+    {
+        return parsePrimaryExpr(/* asStatement= */ false);
+    }
+}
+
+// args ::=  `(' [explist] `)' | tableconstructor | String
+AstExpr* Parser::parseFunctionArgs(AstExpr* func, bool self)
+{
+    if (lexer.current().type == '(')
+    {
+        Position argStart = lexer.current().location.end;
+        if (func->location.end.line != lexer.current().location.begin.line)
+            reportAmbiguousCallError();
+
+        MatchLexeme matchParen = lexer.current();
+        nextLexeme();
+
+        TempVector<AstExpr*> args(scratchExpr);
+
+        if (lexer.current().type != ')')
+            parseExprList(args);
+
+        Location end = lexer.current().location;
+        Position argEnd = end.end;
+
+        expectMatchAndConsume(')', matchParen);
+
+        return allocator.alloc<AstExprCall>(Location(func->location, end), func, copy(args), self, Location(argStart, argEnd));
+    }
+    else if (lexer.current().type == '{')
+    {
+        Position argStart = lexer.current().location.end;
+        AstExpr* expr = parseTableConstructor();
+        Position argEnd = lexer.previousLocation().end;
+
+        return allocator.alloc<AstExprCall>(Location(func->location, expr->location), func, copy(&expr, 1), self, Location(argStart, argEnd));
+    }
+    else if (lexer.current().type == Lexeme::RawString || lexer.current().type == Lexeme::QuotedString)
+    {
+        Location argLocation = lexer.current().location;
+        AstExpr* expr = parseString();
+
+        return allocator.alloc<AstExprCall>(Location(func->location, expr->location), func, copy(&expr, 1), self, argLocation);
+    }
+    else
+    {
+        return reportFunctionArgsError(func, self);
+    }
+}
+
+LUAU_NOINLINE AstExpr* Parser::reportFunctionArgsError(AstExpr* func, bool self)
+{
+    if (self && lexer.current().location.begin.line != func->location.end.line)
+    {
+        return reportExprError(func->location, copy({func}), "Expected function call arguments after '('");
+    }
+    else
+    {
+        return reportExprError(Location(func->location.begin, lexer.current().location.begin), copy({func}),
+            "Expected '(', '{' or <string> when parsing function call, got %s", lexer.current().toString().c_str());
+    }
+}
+
+LUAU_NOINLINE void Parser::reportAmbiguousCallError()
+{
+    report(lexer.current().location, "Ambiguous syntax: this looks like an argument list for a function call, but could also be a start of "
+                                     "new statement; use ';' to separate statements");
+}
+
+// tableconstructor ::= `{' [fieldlist] `}'
+// fieldlist ::= field {fieldsep field} [fieldsep]
+// field ::= `[' exp `]' `=' exp | Name `=' exp | exp
+// fieldsep ::= `,' | `;'
+AstExpr* Parser::parseTableConstructor()
+{
+    TempVector<AstExprTable::Item> items(scratchItem);
+
+    Location start = lexer.current().location;
+
+    MatchLexeme matchBrace = lexer.current();
+    expectAndConsume('{', "table literal");
+    unsigned lastElementIndent = 0;
+
+    while (lexer.current().type != '}')
+    {
+        lastElementIndent = lexer.current().location.begin.column;
+
+        if (lexer.current().type == '[')
+        {
+            MatchLexeme matchLocationBracket = lexer.current();
+            nextLexeme();
+
+            AstExpr* key = parseExpr();
+
+            expectMatchAndConsume(']', matchLocationBracket);
+
+            expectAndConsume('=', "table field");
+
+            AstExpr* value = parseExpr();
+
+            items.push_back({AstExprTable::Item::General, key, value});
+        }
+        else if (lexer.current().type == Lexeme::Name && lexer.lookahead().type == '=')
+        {
+            Name name = parseName("table field");
+
+            expectAndConsume('=', "table field");
+
+            AstArray<char> nameString;
+            nameString.data = const_cast<char*>(name.name.value);
+            nameString.size = strlen(name.name.value);
+
+            AstExpr* key = allocator.alloc<AstExprConstantString>(name.location, nameString, AstExprConstantString::Unquoted);
+            AstExpr* value = parseExpr();
+
+            if (AstExprFunction* func = value->as<AstExprFunction>())
+                func->debugname = name.name;
+
+            items.push_back({AstExprTable::Item::Record, key, value});
+        }
+        else
+        {
+            AstExpr* expr = parseExpr();
+
+            items.push_back({AstExprTable::Item::List, nullptr, expr});
+        }
+
+        if (lexer.current().type == ',' || lexer.current().type == ';')
+        {
+            nextLexeme();
+        }
+        else if ((lexer.current().type == '[' || lexer.current().type == Lexeme::Name) && lexer.current().location.begin.column == lastElementIndent)
+        {
+            report(lexer.current().location, "Expected ',' after table constructor element");
+        }
+        else if (lexer.current().type != '}')
+        {
+            break;
+        }
+    }
+
+    Location end = lexer.current().location;
+
+    if (!expectMatchAndConsume('}', matchBrace))
+        end = lexer.previousLocation();
+
+    return allocator.alloc<AstExprTable>(Location(start, end), copy(items));
+}
+
+AstExpr* Parser::parseIfElseExpr()
+{
+    bool hasElse = false;
+    Location start = lexer.current().location;
+
+    nextLexeme(); // skip if / elseif
+
+    AstExpr* condition = parseExpr();
+
+    bool hasThen = expectAndConsume(Lexeme::ReservedThen, "if then else expression");
+
+    AstExpr* trueExpr = parseExpr();
+    AstExpr* falseExpr = nullptr;
+
+    if (lexer.current().type == Lexeme::ReservedElseif)
+    {
+        unsigned int oldRecursionCount = recursionCounter;
+        incrementRecursionCounter("expression");
+        hasElse = true;
+        falseExpr = parseIfElseExpr();
+        recursionCounter = oldRecursionCount;
+    }
+    else
+    {
+        hasElse = expectAndConsume(Lexeme::ReservedElse, "if then else expression");
+        falseExpr = parseExpr();
+    }
+
+    Location end = falseExpr->location;
+
+    return allocator.alloc<AstExprIfElse>(Location(start, end), condition, hasThen, trueExpr, hasElse, falseExpr);
+}
+
+// Name
+std::optional<Parser::Name> Parser::parseNameOpt(const char* context)
+{
+    if (lexer.current().type != Lexeme::Name)
+    {
+        reportNameError(context);
+
+        return {};
+    }
+
+    Name result(AstName(lexer.current().name), lexer.current().location);
+
+    nextLexeme();
+
+    return result;
+}
+
+Parser::Name Parser::parseName(const char* context)
+{
+    if (std::optional<Name> name = parseNameOpt(context))
+        return *name;
+
+    Location location = lexer.current().location;
+    location.end = location.begin;
+
+    return Name(nameError, location);
+}
+
+Parser::Name Parser::parseIndexName(const char* context, const Position& previous)
+{
+    if (std::optional<Name> name = parseNameOpt(context))
+        return *name;
+
+    // If we have a reserved keyword next at the same line, assume it's an incomplete name
+    if (lexer.current().type >= Lexeme::Reserved_BEGIN && lexer.current().type < Lexeme::Reserved_END &&
+        lexer.current().location.begin.line == previous.line)
+    {
+        Name result(AstName(lexer.current().name), lexer.current().location);
+
+        nextLexeme();
+
+        return result;
+    }
+
+    Location location = lexer.current().location;
+    location.end = location.begin;
+
+    return Name(nameError, location);
+}
+
+std::pair<AstArray<AstGenericType>, AstArray<AstGenericTypePack>> Parser::parseGenericTypeList(bool withDefaultValues)
+{
+    TempVector<AstGenericType> names{scratchGenericTypes};
+    TempVector<AstGenericTypePack> namePacks{scratchGenericTypePacks};
+
+    if (lexer.current().type == '<')
+    {
+        Lexeme begin = lexer.current();
+        nextLexeme();
+
+        bool seenPack = false;
+        bool seenDefault = false;
+
+        while (true)
+        {
+            Location nameLocation = lexer.current().location;
+            AstName name = parseName().name;
+            if (lexer.current().type == Lexeme::Dot3 || seenPack)
+            {
+                seenPack = true;
+
+                if (lexer.current().type != Lexeme::Dot3)
+                    report(lexer.current().location, "Generic types come before generic type packs");
+                else
+                    nextLexeme();
+
+                if (withDefaultValues && lexer.current().type == '=')
+                {
+                    seenDefault = true;
+                    nextLexeme();
+
+                    if (shouldParseTypePack(lexer))
+                    {
+                        AstTypePack* typePack = parseTypePack();
+
+                        namePacks.push_back({name, nameLocation, typePack});
+                    }
+                    else
+                    {
+                        auto [type, typePack] = parseTypeOrPack();
+
+                        if (type)
+                            report(type->location, "Expected type pack after '=', got type");
+
+                        namePacks.push_back({name, nameLocation, typePack});
+                    }
+                }
+                else
+                {
+                    if (seenDefault)
+                        report(lexer.current().location, "Expected default type pack after type pack name");
+
+                    namePacks.push_back({name, nameLocation, nullptr});
+                }
+            }
+            else
+            {
+                if (withDefaultValues && lexer.current().type == '=')
+                {
+                    seenDefault = true;
+                    nextLexeme();
+
+                    AstType* defaultType = parseType();
+
+                    names.push_back({name, nameLocation, defaultType});
+                }
+                else
+                {
+                    if (seenDefault)
+                        report(lexer.current().location, "Expected default type after type name");
+
+                    names.push_back({name, nameLocation, nullptr});
+                }
+            }
+
+            if (lexer.current().type == ',')
+            {
+                nextLexeme();
+
+                if (lexer.current().type == '>')
+                {
+                    report(lexer.current().location, "Expected type after ',' but got '>' instead");
+                    break;
+                }
+            }
+            else
+                break;
+        }
+
+        expectMatchAndConsume('>', begin);
+    }
+
+    AstArray<AstGenericType> generics = copy(names);
+    AstArray<AstGenericTypePack> genericPacks = copy(namePacks);
+    return {generics, genericPacks};
+}
+
+AstArray<AstTypeOrPack> Parser::parseTypeParams()
+{
+    TempVector<AstTypeOrPack> parameters{scratchTypeOrPack};
+
+    if (lexer.current().type == '<')
+    {
+        Lexeme begin = lexer.current();
+        nextLexeme();
+
+        while (true)
+        {
+            if (shouldParseTypePack(lexer))
+            {
+                AstTypePack* typePack = parseTypePack();
+
+                parameters.push_back({{}, typePack});
+            }
+            else if (lexer.current().type == '(')
+            {
+                auto [type, typePack] = parseTypeOrPack();
+
+                if (typePack)
+                    parameters.push_back({{}, typePack});
+                else
+                    parameters.push_back({type, {}});
+            }
+            else if (lexer.current().type == '>' && parameters.empty())
+            {
+                break;
+            }
+            else
+            {
+                parameters.push_back({parseType(), {}});
+            }
+
+            if (lexer.current().type == ',')
+                nextLexeme();
+            else
+                break;
+        }
+
+        expectMatchAndConsume('>', begin);
+    }
+
+    return copy(parameters);
+}
+
+std::optional<AstArray<char>> Parser::parseCharArray()
+{
+    LUAU_ASSERT(lexer.current().type == Lexeme::QuotedString || lexer.current().type == Lexeme::RawString ||
+                lexer.current().type == Lexeme::InterpStringSimple);
+
+    scratchData.assign(lexer.current().data, lexer.current().length);
+
+    if (lexer.current().type == Lexeme::QuotedString || lexer.current().type == Lexeme::InterpStringSimple)
+    {
+        if (!Lexer::fixupQuotedString(scratchData))
+        {
+            nextLexeme();
+            return std::nullopt;
+        }
+    }
+    else
+    {
+        Lexer::fixupMultilineString(scratchData);
+    }
+
+    AstArray<char> value = copy(scratchData);
+    nextLexeme();
+    return value;
+}
+
+AstExpr* Parser::parseString()
+{
+    Location location = lexer.current().location;
+    if (std::optional<AstArray<char>> value = parseCharArray())
+        return allocator.alloc<AstExprConstantString>(location, *value);
+    else
+        return reportExprError(location, {}, "String literal contains malformed escape sequence");
+}
+
+AstExpr* Parser::parseInterpString()
+{
+    TempVector<AstArray<char>> strings(scratchString);
+    TempVector<AstExpr*> expressions(scratchExpr);
+
+    Location startLocation = lexer.current().location;
+    Location endLocation;
+
+    do
+    {
+        Lexeme currentLexeme = lexer.current();
+        LUAU_ASSERT(currentLexeme.type == Lexeme::InterpStringBegin || currentLexeme.type == Lexeme::InterpStringMid ||
+                    currentLexeme.type == Lexeme::InterpStringEnd || currentLexeme.type == Lexeme::InterpStringSimple);
+
+        endLocation = currentLexeme.location;
+
+        scratchData.assign(currentLexeme.data, currentLexeme.length);
+
+        if (!Lexer::fixupQuotedString(scratchData))
+        {
+            nextLexeme();
+            return reportExprError(Location{startLocation, endLocation}, {}, "Interpolated string literal contains malformed escape sequence");
+        }
+
+        AstArray<char> chars = copy(scratchData);
+
+        nextLexeme();
+
+        strings.push_back(chars);
+
+        if (currentLexeme.type == Lexeme::InterpStringEnd || currentLexeme.type == Lexeme::InterpStringSimple)
+        {
+            break;
+        }
+
+        bool errorWhileChecking = false;
+
+        switch (lexer.current().type)
+        {
+        case Lexeme::InterpStringMid:
+        case Lexeme::InterpStringEnd:
+        {
+            errorWhileChecking = true;
+            nextLexeme();
+            expressions.push_back(reportExprError(endLocation, {}, "Malformed interpolated string, expected expression inside '{}'"));
+            break;
+        }
+        case Lexeme::BrokenString:
+        {
+            errorWhileChecking = true;
+            nextLexeme();
+            expressions.push_back(reportExprError(endLocation, {}, "Malformed interpolated string; did you forget to add a '`'?"));
+            break;
+        }
+        default:
+            expressions.push_back(parseExpr());
+        }
+
+        if (errorWhileChecking)
+        {
+            break;
+        }
+
+        switch (lexer.current().type)
+        {
+        case Lexeme::InterpStringBegin:
+        case Lexeme::InterpStringMid:
+        case Lexeme::InterpStringEnd:
+            break;
+        case Lexeme::BrokenInterpDoubleBrace:
+            nextLexeme();
+            return reportExprError(endLocation, {}, "Double braces are not permitted within interpolated strings; did you mean '\\{'?");
+        case Lexeme::BrokenString:
+            nextLexeme();
+            return reportExprError(endLocation, {}, "Malformed interpolated string; did you forget to add a '}'?");
+        default:
+            return reportExprError(endLocation, {}, "Malformed interpolated string, got %s", lexer.current().toString().c_str());
+        }
+    } while (true);
+
+    AstArray<AstArray<char>> stringsArray = copy(strings);
+    AstArray<AstExpr*> expressionsArray = copy(expressions);
+    return allocator.alloc<AstExprInterpString>(Location{startLocation, endLocation}, stringsArray, expressionsArray);
+}
+
+AstExpr* Parser::parseNumber()
+{
+    Location start = lexer.current().location;
+
+    scratchData.assign(lexer.current().data, lexer.current().length);
+
+    // Remove all internal _ - they don't hold any meaning and this allows parsing code to just pass the string pointer to strtod et al
+    if (scratchData.find('_') != std::string::npos)
+    {
+        scratchData.erase(std::remove(scratchData.begin(), scratchData.end(), '_'), scratchData.end());
+    }
+
+    double value = 0;
+    ConstantNumberParseResult result = parseDouble(value, scratchData.c_str());
+    nextLexeme();
+
+    if (result == ConstantNumberParseResult::Malformed)
+        return reportExprError(start, {}, "Malformed number");
+
+    return allocator.alloc<AstExprConstantNumber>(start, value, result);
+}
+
+AstLocal* Parser::pushLocal(const Binding& binding)
+{
+    const Name& name = binding.name;
+    AstLocal*& local = localMap[name.name];
+
+    local = allocator.alloc<AstLocal>(
+        name.name, name.location, /* shadow= */ local, functionStack.size() - 1, functionStack.back().loopDepth, binding.annotation);
+
+    localStack.push_back(local);
+
+    return local;
+}
+
+unsigned int Parser::saveLocals()
+{
+    return unsigned(localStack.size());
+}
+
+void Parser::restoreLocals(unsigned int offset)
+{
+    for (size_t i = localStack.size(); i > offset; --i)
+    {
+        AstLocal* l = localStack[i - 1];
+
+        localMap[l->name] = l->shadow;
+    }
+
+    localStack.resize(offset);
+}
+
+bool Parser::expectAndConsume(char value, const char* context)
+{
+    return expectAndConsume(static_cast<Lexeme::Type>(static_cast<unsigned char>(value)), context);
+}
+
+bool Parser::expectAndConsume(Lexeme::Type type, const char* context)
+{
+    if (lexer.current().type != type)
+    {
+        expectAndConsumeFail(type, context);
+
+        // check if this is an extra token and the expected token is next
+        if (lexer.lookahead().type == type)
+        {
+            // skip invalid and consume expected
+            nextLexeme();
+            nextLexeme();
+        }
+
+        return false;
+    }
+    else
+    {
+        nextLexeme();
+        return true;
+    }
+}
+
+// LUAU_NOINLINE is used to limit the stack cost of this function due to std::string objects, and to increase caller performance since this code is
+// cold
+LUAU_NOINLINE void Parser::expectAndConsumeFail(Lexeme::Type type, const char* context)
+{
+    std::string typeString = Lexeme(Location(Position(0, 0), 0), type).toString();
+    std::string currLexemeString = lexer.current().toString();
+
+    if (context)
+        report(lexer.current().location, "Expected %s when parsing %s, got %s", typeString.c_str(), context, currLexemeString.c_str());
+    else
+        report(lexer.current().location, "Expected %s, got %s", typeString.c_str(), currLexemeString.c_str());
+}
+
+bool Parser::expectMatchAndConsume(char value, const MatchLexeme& begin, bool searchForMissing)
+{
+    Lexeme::Type type = static_cast<Lexeme::Type>(static_cast<unsigned char>(value));
+
+    if (lexer.current().type != type)
+    {
+        expectMatchAndConsumeFail(type, begin);
+
+        return expectMatchAndConsumeRecover(value, begin, searchForMissing);
+    }
+    else
+    {
+        nextLexeme();
+
+        return true;
+    }
+}
+
+LUAU_NOINLINE bool Parser::expectMatchAndConsumeRecover(char value, const MatchLexeme& begin, bool searchForMissing)
+{
+    Lexeme::Type type = static_cast<Lexeme::Type>(static_cast<unsigned char>(value));
+
+    if (searchForMissing)
+    {
+        // previous location is taken because 'current' lexeme is already the next token
+        unsigned currentLine = lexer.previousLocation().end.line;
+
+        // search to the end of the line for expected token
+        // we will also stop if we hit a token that can be handled by parsing function above the current one
+        Lexeme::Type lexemeType = lexer.current().type;
+
+        while (currentLine == lexer.current().location.begin.line && lexemeType != type && matchRecoveryStopOnToken[lexemeType] == 0)
+        {
+            nextLexeme();
+            lexemeType = lexer.current().type;
+        }
+
+        if (lexemeType == type)
+        {
+            nextLexeme();
+
+            return true;
+        }
+    }
+    else
+    {
+        // check if this is an extra token and the expected token is next
+        if (lexer.lookahead().type == type)
+        {
+            // skip invalid and consume expected
+            nextLexeme();
+            nextLexeme();
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// LUAU_NOINLINE is used to limit the stack cost of this function due to std::string objects, and to increase caller performance since this code is
+// cold
+LUAU_NOINLINE void Parser::expectMatchAndConsumeFail(Lexeme::Type type, const MatchLexeme& begin, const char* extra)
+{
+    std::string typeString = Lexeme(Location(Position(0, 0), 0), type).toString();
+    std::string matchString = Lexeme(Location(Position(0, 0), 0), begin.type).toString();
+
+    if (lexer.current().location.begin.line == begin.position.line)
+        report(lexer.current().location, "Expected %s (to close %s at column %d), got %s%s", typeString.c_str(), matchString.c_str(),
+            begin.position.column + 1, lexer.current().toString().c_str(), extra ? extra : "");
+    else
+        report(lexer.current().location, "Expected %s (to close %s at line %d), got %s%s", typeString.c_str(), matchString.c_str(),
+            begin.position.line + 1, lexer.current().toString().c_str(), extra ? extra : "");
+}
+
+bool Parser::expectMatchEndAndConsume(Lexeme::Type type, const MatchLexeme& begin)
+{
+    if (lexer.current().type != type)
+    {
+        expectMatchEndAndConsumeFail(type, begin);
+
+        // check if this is an extra token and the expected token is next
+        if (lexer.lookahead().type == type)
+        {
+            // skip invalid and consume expected
+            nextLexeme();
+            nextLexeme();
+
+            return true;
+        }
+
+        return false;
+    }
+    else
+    {
+        // If the token matches on a different line and a different column, it suggests misleading indentation
+        // This can be used to pinpoint the problem location for a possible future *actual* mismatch
+        if (lexer.current().location.begin.line != begin.position.line && lexer.current().location.begin.column != begin.position.column &&
+            endMismatchSuspect.position.line < begin.position.line) // Only replace the previous suspect with more recent suspects
+        {
+            endMismatchSuspect = begin;
+        }
+
+        nextLexeme();
+
+        return true;
+    }
+}
+
+// LUAU_NOINLINE is used to limit the stack cost of this function due to std::string objects, and to increase caller performance since this code is
+// cold
+LUAU_NOINLINE void Parser::expectMatchEndAndConsumeFail(Lexeme::Type type, const MatchLexeme& begin)
+{
+    if (endMismatchSuspect.type != Lexeme::Eof && endMismatchSuspect.position.line > begin.position.line)
+    {
+        std::string matchString = Lexeme(Location(Position(0, 0), 0), endMismatchSuspect.type).toString();
+        std::string suggestion = format("; did you forget to close %s at line %d?", matchString.c_str(), endMismatchSuspect.position.line + 1);
+
+        expectMatchAndConsumeFail(type, begin, suggestion.c_str());
+    }
+    else
+    {
+        expectMatchAndConsumeFail(type, begin);
+    }
+}
+
+template<typename T>
+AstArray<T> Parser::copy(const T* data, size_t size)
+{
+    AstArray<T> result;
+
+    result.data = size ? static_cast<T*>(allocator.allocate(sizeof(T) * size)) : nullptr;
+    result.size = size;
+
+    // This is equivalent to std::uninitialized_copy, but without the exception guarantee
+    // since our types don't have destructors
+    for (size_t i = 0; i < size; ++i)
+        new (result.data + i) T(data[i]);
+
+    return result;
+}
+
+template<typename T>
+AstArray<T> Parser::copy(const TempVector<T>& data)
+{
+    return copy(data.empty() ? nullptr : &data[0], data.size());
+}
+
+template<typename T>
+AstArray<T> Parser::copy(std::initializer_list<T> data)
+{
+    return copy(data.size() == 0 ? nullptr : data.begin(), data.size());
+}
+
+AstArray<char> Parser::copy(const std::string& data)
+{
+    AstArray<char> result = copy(data.c_str(), data.size() + 1);
+
+    result.size = data.size();
+
+    return result;
+}
+
+void Parser::incrementRecursionCounter(const char* context)
+{
+    recursionCounter++;
+
+    if (recursionCounter > unsigned(FInt::LuauRecursionLimit))
+    {
+        ParseError::raise(lexer.current().location, "Exceeded allowed recursion depth; simplify your %s to make the code compile", context);
+    }
+}
+
+void Parser::report(const Location& location, const char* format, va_list args)
+{
+    // To reduce number of errors reported to user for incomplete statements, we skip multiple errors at the same location
+    // For example, consider 'local a = (((b + ' where multiple tokens haven't been written yet
+    if (!parseErrors.empty() && location == parseErrors.back().getLocation())
+        return;
+
+    std::string message = vformat(format, args);
+
+    // when limited to a single error, behave as if the error recovery is disabled
+    if (FInt::LuauParseErrorLimit == 1)
+        throw ParseError(location, message);
+
+    parseErrors.emplace_back(location, message);
+
+    if (parseErrors.size() >= unsigned(FInt::LuauParseErrorLimit))
+        ParseError::raise(location, "Reached error limit (%d)", int(FInt::LuauParseErrorLimit));
+}
+
+void Parser::report(const Location& location, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    report(location, format, args);
+    va_end(args);
+}
+
+LUAU_NOINLINE void Parser::reportNameError(const char* context)
+{
+    if (context)
+        report(lexer.current().location, "Expected identifier when parsing %s, got %s", context, lexer.current().toString().c_str());
+    else
+        report(lexer.current().location, "Expected identifier, got %s", lexer.current().toString().c_str());
+}
+
+AstStatError* Parser::reportStatError(
+    const Location& location, const AstArray<AstExpr*>& expressions, const AstArray<AstStat*>& statements, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    report(location, format, args);
+    va_end(args);
+
+    return allocator.alloc<AstStatError>(location, expressions, statements, unsigned(parseErrors.size() - 1));
+}
+
+AstExprError* Parser::reportExprError(const Location& location, const AstArray<AstExpr*>& expressions, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    report(location, format, args);
+    va_end(args);
+
+    return allocator.alloc<AstExprError>(location, expressions, unsigned(parseErrors.size() - 1));
+}
+
+AstTypeError* Parser::reportTypeError(const Location& location, const AstArray<AstType*>& types, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    report(location, format, args);
+    va_end(args);
+
+    return allocator.alloc<AstTypeError>(location, types, false, unsigned(parseErrors.size() - 1));
+}
+
+AstTypeError* Parser::reportMissingTypeError(const Location& parseErrorLocation, const Location& astErrorLocation, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    report(parseErrorLocation, format, args);
+    va_end(args);
+
+    return allocator.alloc<AstTypeError>(astErrorLocation, AstArray<AstType*>{}, true, unsigned(parseErrors.size() - 1));
+}
+
+void Parser::nextLexeme()
+{
+    Lexeme::Type type = lexer.next(/* skipComments= */ false, true).type;
+
+    while (type == Lexeme::BrokenComment || type == Lexeme::Comment || type == Lexeme::BlockComment)
+    {
+        const Lexeme& lexeme = lexer.current();
+
+        if (options.captureComments)
+            commentLocations.push_back(Comment{lexeme.type, lexeme.location});
+
+        // Subtlety: Broken comments are weird because we record them as comments AND pass them to the parser as a lexeme.
+        // The parser will turn this into a proper syntax error.
+        if (lexeme.type == Lexeme::BrokenComment)
+            return;
+
+        // Comments starting with ! are called "hot comments" and contain directives for type checking / linting / compiling
+        if (lexeme.type == Lexeme::Comment && lexeme.length && lexeme.data[0] == '!')
+        {
+            const char* text = lexeme.data;
+
+            unsigned int end = lexeme.length;
+            while (end > 0 && isSpace(text[end - 1]))
+                --end;
+
+            hotcomments.push_back({hotcommentHeader, lexeme.location, std::string(text + 1, text + end)});
+        }
+
+        type = lexer.next(/* skipComments= */ false, /* updatePrevLocation= */ false).type;
+    }
+}
+
+} // namespace Luau

--- a/lib/luau/Ast/src/StringUtils.cpp
+++ b/lib/luau/Ast/src/StringUtils.cpp
@@ -1,0 +1,297 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/StringUtils.h"
+
+#include "Luau/Common.h"
+
+#include <array>
+#include <vector>
+#include <string>
+#include <string.h>
+#include <stdint.h>
+
+namespace Luau
+{
+
+void vformatAppend(std::string& ret, const char* fmt, va_list args)
+{
+    va_list argscopy;
+    va_copy(argscopy, args);
+#ifdef _MSC_VER
+    int actualSize = _vscprintf(fmt, argscopy);
+#else
+    int actualSize = vsnprintf(NULL, 0, fmt, argscopy);
+#endif
+    va_end(argscopy);
+
+    if (actualSize <= 0)
+        return;
+
+    size_t sz = ret.size();
+    ret.resize(sz + actualSize);
+    vsnprintf(&ret[0] + sz, actualSize + 1, fmt, args);
+}
+
+std::string format(const char* fmt, ...)
+{
+    std::string result;
+    va_list args;
+    va_start(args, fmt);
+    vformatAppend(result, fmt, args);
+    va_end(args);
+    return result;
+}
+
+void formatAppend(std::string& str, const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vformatAppend(str, fmt, args);
+    va_end(args);
+}
+
+std::string vformat(const char* fmt, va_list args)
+{
+    std::string ret;
+    vformatAppend(ret, fmt, args);
+    return ret;
+}
+
+template<typename String>
+static std::string joinImpl(const std::vector<String>& segments, std::string_view delimiter)
+{
+    if (segments.empty())
+        return "";
+
+    size_t len = (segments.size() - 1) * delimiter.size();
+    for (const auto& sv : segments)
+        len += sv.size();
+
+    std::string result;
+    result.resize(len);
+    char* dest = const_cast<char*>(result.data()); // This const_cast is only necessary until C++17
+
+    auto it = segments.begin();
+    memcpy(dest, it->data(), it->size());
+    dest += it->size();
+    ++it;
+    for (; it != segments.end(); ++it)
+    {
+        memcpy(dest, delimiter.data(), delimiter.size());
+        dest += delimiter.size();
+        memcpy(dest, it->data(), it->size());
+        dest += it->size();
+    }
+
+    LUAU_ASSERT(dest == result.data() + len);
+
+    return result;
+}
+
+std::string join(const std::vector<std::string_view>& segments, std::string_view delimiter)
+{
+    return joinImpl(segments, delimiter);
+}
+
+std::string join(const std::vector<std::string>& segments, std::string_view delimiter)
+{
+    return joinImpl(segments, delimiter);
+}
+
+std::vector<std::string_view> split(std::string_view s, char delimiter)
+{
+    std::vector<std::string_view> result;
+
+    while (!s.empty())
+    {
+        auto index = s.find(delimiter);
+        if (index == std::string::npos)
+        {
+            result.push_back(s);
+            break;
+        }
+        result.push_back(s.substr(0, index));
+        s.remove_prefix(index + 1);
+    }
+
+    return result;
+}
+
+size_t editDistance(std::string_view a, std::string_view b)
+{
+    // When there are matching prefix and suffix, they end up computing as zero cost, effectively making it no-op. We drop these characters.
+    while (!a.empty() && !b.empty() && a.front() == b.front())
+    {
+        a.remove_prefix(1);
+        b.remove_prefix(1);
+    }
+
+    while (!a.empty() && !b.empty() && a.back() == b.back())
+    {
+        a.remove_suffix(1);
+        b.remove_suffix(1);
+    }
+
+    // Since we know the edit distance is the difference of the length of A and B discounting the matching prefixes and suffixes,
+    // it is therefore pointless to run the rest of this function to find that out. We immediately infer this size and return it.
+    if (a.empty())
+        return b.size();
+    if (b.empty())
+        return a.size();
+
+    size_t maxDistance = a.size() + b.size();
+
+    std::vector<size_t> distances((a.size() + 2) * (b.size() + 2), 0);
+    auto getPos = [b](size_t x, size_t y) -> size_t {
+        return (x * (b.size() + 2)) + y;
+    };
+
+    distances[0] = maxDistance;
+
+    for (size_t x = 0; x <= a.size(); ++x)
+    {
+        distances[getPos(x + 1, 0)] = maxDistance;
+        distances[getPos(x + 1, 1)] = x;
+    }
+
+    for (size_t y = 0; y <= b.size(); ++y)
+    {
+        distances[getPos(0, y + 1)] = maxDistance;
+        distances[getPos(1, y + 1)] = y;
+    }
+
+    std::array<size_t, 256> seenCharToRow;
+    seenCharToRow.fill(0);
+
+    for (size_t x = 1; x <= a.size(); ++x)
+    {
+        size_t lastMatchedY = 0;
+
+        for (size_t y = 1; y <= b.size(); ++y)
+        {
+            // The value of b[N] can be negative with unicode characters
+            unsigned char bSeenCharIndex = static_cast<unsigned char>(b[y - 1]);
+            size_t x1 = seenCharToRow[bSeenCharIndex];
+            size_t y1 = lastMatchedY;
+
+            size_t cost = 1;
+            if (a[x - 1] == b[y - 1])
+            {
+                cost = 0;
+                lastMatchedY = y;
+            }
+
+            size_t transposition = distances[getPos(x1, y1)] + (x - x1 - 1) + 1 + (y - y1 - 1);
+            size_t substitution = distances[getPos(x, y)] + cost;
+            size_t insertion = distances[getPos(x, y + 1)] + 1;
+            size_t deletion = distances[getPos(x + 1, y)] + 1;
+
+            // It's more performant to use std::min(size_t, size_t) rather than the initializer_list overload.
+            // Until proven otherwise, please do not change this.
+            distances[getPos(x + 1, y + 1)] = std::min(std::min(insertion, deletion), std::min(substitution, transposition));
+        }
+
+        // The value of a[N] can be negative with unicode characters
+        unsigned char aSeenCharIndex = static_cast<unsigned char>(a[x - 1]);
+        seenCharToRow[aSeenCharIndex] = x;
+    }
+
+    return distances[getPos(a.size() + 1, b.size() + 1)];
+}
+
+bool startsWith(std::string_view haystack, std::string_view needle)
+{
+    // ::starts_with is C++20
+    return haystack.size() >= needle.size() && haystack.substr(0, needle.size()) == needle;
+}
+
+bool equalsLower(std::string_view lhs, std::string_view rhs)
+{
+    if (lhs.size() != rhs.size())
+        return false;
+
+    for (size_t i = 0; i < lhs.size(); ++i)
+        if (tolower(uint8_t(lhs[i])) != tolower(uint8_t(rhs[i])))
+            return false;
+
+    return true;
+}
+
+size_t hashRange(const char* data, size_t size)
+{
+    // FNV-1a
+    uint32_t hash = 2166136261;
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        hash ^= uint8_t(data[i]);
+        hash *= 16777619;
+    }
+
+    return hash;
+}
+
+bool isIdentifier(std::string_view s)
+{
+    return (s.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_") == std::string::npos);
+}
+
+std::string escape(std::string_view s, bool escapeForInterpString)
+{
+    std::string r;
+    r.reserve(s.size() + 50); // arbitrary number to guess how many characters we'll be inserting
+
+    for (uint8_t c : s)
+    {
+        if (c >= ' ' && c != '\\' && c != '\'' && c != '\"' && c != '`' && c != '{')
+            r += c;
+        else
+        {
+            r += '\\';
+
+            if (escapeForInterpString && (c == '`' || c == '{'))
+            {
+                r += c;
+                continue;
+            }
+
+            switch (c)
+            {
+            case '\a':
+                r += 'a';
+                break;
+            case '\b':
+                r += 'b';
+                break;
+            case '\f':
+                r += 'f';
+                break;
+            case '\n':
+                r += 'n';
+                break;
+            case '\r':
+                r += 'r';
+                break;
+            case '\t':
+                r += 't';
+                break;
+            case '\v':
+                r += 'v';
+                break;
+            case '\'':
+                r += '\'';
+                break;
+            case '\"':
+                r += '\"';
+                break;
+            case '\\':
+                r += '\\';
+                break;
+            default:
+                Luau::formatAppend(r, "%03u", c);
+            }
+        }
+    }
+
+    return r;
+}
+} // namespace Luau

--- a/lib/luau/Ast/src/TimeTrace.cpp
+++ b/lib/luau/Ast/src/TimeTrace.cpp
@@ -1,0 +1,264 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/TimeTrace.h"
+
+#include "Luau/StringUtils.h"
+
+#include <mutex>
+#include <string>
+
+#include <stdlib.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+#include <time.h>
+
+LUAU_FASTFLAGVARIABLE(DebugLuauTimeTracing, false)
+namespace Luau
+{
+namespace TimeTrace
+{
+static double getClockPeriod()
+{
+#if defined(_WIN32)
+    LARGE_INTEGER result = {};
+    QueryPerformanceFrequency(&result);
+    return 1.0 / double(result.QuadPart);
+#elif defined(__APPLE__)
+    mach_timebase_info_data_t result = {};
+    mach_timebase_info(&result);
+    return double(result.numer) / double(result.denom) * 1e-9;
+#elif defined(__linux__)
+    return 1e-9;
+#else
+    return 1.0 / double(CLOCKS_PER_SEC);
+#endif
+}
+
+static double getClockTimestamp()
+{
+#if defined(_WIN32)
+    LARGE_INTEGER result = {};
+    QueryPerformanceCounter(&result);
+    return double(result.QuadPart);
+#elif defined(__APPLE__)
+    return double(mach_absolute_time());
+#elif defined(__linux__)
+    timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return now.tv_sec * 1e9 + now.tv_nsec;
+#else
+    return double(clock());
+#endif
+}
+
+double getClock()
+{
+    static double period = getClockPeriod();
+    static double start = getClockTimestamp();
+
+    return (getClockTimestamp() - start) * period;
+}
+
+uint32_t getClockMicroseconds()
+{
+    static double period = getClockPeriod() * 1e6;
+    static double start = getClockTimestamp();
+
+    return uint32_t((getClockTimestamp() - start) * period);
+}
+} // namespace TimeTrace
+} // namespace Luau
+
+#if defined(LUAU_ENABLE_TIME_TRACE)
+
+namespace Luau
+{
+namespace TimeTrace
+{
+struct GlobalContext
+{
+    ~GlobalContext()
+    {
+        if (traceFile)
+            fclose(traceFile);
+    }
+
+    std::mutex mutex;
+    std::vector<ThreadContext*> threads;
+    uint32_t nextThreadId = 0;
+    std::vector<Token> tokens;
+    FILE* traceFile = nullptr;
+
+private:
+    friend std::shared_ptr<GlobalContext> getGlobalContext();
+    GlobalContext() = default;
+};
+
+std::shared_ptr<GlobalContext> getGlobalContext()
+{
+    static std::shared_ptr<GlobalContext> context = std::shared_ptr<GlobalContext>{new GlobalContext};
+    return context;
+}
+
+uint16_t createToken(GlobalContext& context, const char* name, const char* category)
+{
+    std::scoped_lock lock(context.mutex);
+
+    LUAU_ASSERT(context.tokens.size() < 64 * 1024);
+
+    context.tokens.push_back({name, category});
+    return uint16_t(context.tokens.size() - 1);
+}
+
+uint32_t createThread(GlobalContext& context, ThreadContext* threadContext)
+{
+    std::scoped_lock lock(context.mutex);
+
+    context.threads.push_back(threadContext);
+
+    return ++context.nextThreadId;
+}
+
+void releaseThread(GlobalContext& context, ThreadContext* threadContext)
+{
+    std::scoped_lock lock(context.mutex);
+
+    if (auto it = std::find(context.threads.begin(), context.threads.end(), threadContext); it != context.threads.end())
+        context.threads.erase(it);
+}
+
+void flushEvents(GlobalContext& context, uint32_t threadId, const std::vector<Event>& events, const std::vector<char>& data)
+{
+    std::scoped_lock lock(context.mutex);
+
+    if (!context.traceFile)
+    {
+        context.traceFile = fopen("trace.json", "w");
+
+        if (!context.traceFile)
+            return;
+
+        fprintf(context.traceFile, "[\n");
+    }
+
+    std::string temp;
+    const unsigned tempReserve = 64 * 1024;
+    temp.reserve(tempReserve);
+
+    const char* rawData = data.data();
+
+    // Formatting state
+    bool unfinishedEnter = false;
+    bool unfinishedArgs = false;
+
+    for (const Event& ev : events)
+    {
+        switch (ev.type)
+        {
+        case EventType::Enter:
+        {
+            if (unfinishedArgs)
+            {
+                formatAppend(temp, "}");
+                unfinishedArgs = false;
+            }
+
+            if (unfinishedEnter)
+            {
+                formatAppend(temp, "},\n");
+                unfinishedEnter = false;
+            }
+
+            Token& token = context.tokens[ev.token];
+
+            formatAppend(temp, R"({"name": "%s", "cat": "%s", "ph": "B", "ts": %u, "pid": 0, "tid": %u)", token.name, token.category,
+                ev.data.microsec, threadId);
+            unfinishedEnter = true;
+        }
+        break;
+        case EventType::Leave:
+            if (unfinishedArgs)
+            {
+                formatAppend(temp, "}");
+                unfinishedArgs = false;
+            }
+            if (unfinishedEnter)
+            {
+                formatAppend(temp, "},\n");
+                unfinishedEnter = false;
+            }
+
+            formatAppend(temp,
+                R"({"ph": "E", "ts": %u, "pid": 0, "tid": %u},)"
+                "\n",
+                ev.data.microsec, threadId);
+            break;
+        case EventType::ArgName:
+            LUAU_ASSERT(unfinishedEnter);
+
+            if (!unfinishedArgs)
+            {
+                formatAppend(temp, R"(, "args": { "%s": )", rawData + ev.data.dataPos);
+                unfinishedArgs = true;
+            }
+            else
+            {
+                formatAppend(temp, R"(, "%s": )", rawData + ev.data.dataPos);
+            }
+            break;
+        case EventType::ArgValue:
+            LUAU_ASSERT(unfinishedArgs);
+            formatAppend(temp, R"("%s")", rawData + ev.data.dataPos);
+            break;
+        }
+
+        // Don't want to hit the string capacity and reallocate
+        if (temp.size() > tempReserve - 1024)
+        {
+            fwrite(temp.data(), 1, temp.size(), context.traceFile);
+            temp.clear();
+        }
+    }
+
+    if (unfinishedArgs)
+    {
+        formatAppend(temp, "}");
+        unfinishedArgs = false;
+    }
+    if (unfinishedEnter)
+    {
+        formatAppend(temp, "},\n");
+        unfinishedEnter = false;
+    }
+
+    fwrite(temp.data(), 1, temp.size(), context.traceFile);
+    fflush(context.traceFile);
+}
+
+ThreadContext& getThreadContext()
+{
+    thread_local ThreadContext context;
+    return context;
+}
+
+uint16_t createScopeData(const char* name, const char* category)
+{
+    return createToken(*Luau::TimeTrace::getGlobalContext(), name, category);
+}
+} // namespace TimeTrace
+} // namespace Luau
+
+#endif

--- a/lib/luau/Common/include/Luau/Bytecode.h
+++ b/lib/luau/Common/include/Luau/Bytecode.h
@@ -1,0 +1,604 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+// clang-format off
+
+// This header contains the bytecode definition for Luau interpreter
+// Creating the bytecode is outside the scope of this file and is handled by bytecode builder (BytecodeBuilder.h) and bytecode compiler (Compiler.h)
+// Note that ALL enums declared in this file are order-sensitive since the values are baked into bytecode that needs to be processed by legacy clients.
+
+// # Bytecode definitions
+// Bytecode instructions are using "word code" - each instruction is one or many 32-bit words.
+// The first word in the instruction is always the instruction header, and *must* contain the opcode (enum below) in the least significant byte.
+//
+// Instruction word can be encoded using one of the following encodings:
+//     ABC - least-significant byte for the opcode, followed by three bytes, A, B and C; each byte declares a register index, small index into some other table or an unsigned integral value
+//     AD - least-significant byte for the opcode, followed by A byte, followed by D half-word (16-bit integer). D is a signed integer that commonly specifies constant table index or jump offset
+//     E - least-significant byte for the opcode, followed by E (24-bit integer). E is a signed integer that commonly specifies a jump offset
+//
+// Instruction word is sometimes followed by one extra word, indicated as AUX - this is just a 32-bit word and is decoded according to the specification for each opcode.
+// For each opcode the encoding is *static* - that is, based on the opcode you know a-priory how large the instruction is, with the exception of NEWCLOSURE
+
+// # Bytecode indices
+// Bytecode instructions commonly refer to integer values that define offsets or indices for various entities. For each type, there's a maximum encodable value.
+// Note that in some cases, the compiler will set a lower limit than the maximum encodable value is to prevent fragile code into bumping against the limits whenever we change the compilation details.
+// Additionally, in some specific instructions such as ANDK, the limit on the encoded value is smaller; this means that if a value is larger, a different instruction must be selected.
+//
+// Registers: 0-254. Registers refer to the values on the function's stack frame, including arguments.
+// Upvalues: 0-199. Upvalues refer to the values stored in the closure object.
+// Constants: 0-2^23-1. Constants are stored in a table allocated with each proto; to allow for future bytecode tweaks the encodable value is limited to 23 bits.
+// Closures: 0-2^15-1. Closures are created from child protos via a child index; the limit is for the number of closures immediately referenced in each function.
+// Jumps: -2^23..2^23. Jump offsets are specified in word increments, so jumping over an instruction may sometimes require an offset of 2 or more. Note that for jump instructions with AUX, the AUX word is included as part of the jump offset.
+
+// # Bytecode versions
+// Bytecode serialized format embeds a version number, that dictates both the serialized form as well as the allowed instructions. As long as the bytecode version falls into supported
+// range (indicated by LBC_BYTECODE_MIN / LBC_BYTECODE_MAX) and was produced by Luau compiler, it should load and execute correctly.
+//
+// Note that Luau runtime doesn't provide indefinite bytecode compatibility: support for older versions gets removed over time. As such, bytecode isn't a durable storage format and it's expected
+// that Luau users can recompile bytecode from source on Luau version upgrades if necessary.
+
+// # Bytecode version history
+//
+// Note: due to limitations of the versioning scheme, some bytecode blobs that carry version 2 are using features from version 3. Starting from version 3, version should be sufficient to indicate bytecode compatibility.
+//
+// Version 1: Baseline version for the open-source release. Supported until 0.521.
+// Version 2: Adds Proto::linedefined. Supported until 0.544.
+// Version 3: Adds FORGPREP/JUMPXEQK* and enhances AUX encoding for FORGLOOP. Removes FORGLOOP_NEXT/INEXT and JUMPIFEQK/JUMPIFNOTEQK. Currently supported.
+// Version 4: Adds Proto::flags, typeinfo, and floor division opcodes IDIV/IDIVK. Currently supported.
+// Version 5: Adds SUBRK/DIVRK and vector constants. Currently supported.
+
+// Bytecode opcode, part of the instruction header
+enum LuauOpcode
+{
+    // NOP: noop
+    LOP_NOP,
+
+    // BREAK: debugger break
+    LOP_BREAK,
+
+    // LOADNIL: sets register to nil
+    // A: target register
+    LOP_LOADNIL,
+
+    // LOADB: sets register to boolean and jumps to a given short offset (used to compile comparison results into a boolean)
+    // A: target register
+    // B: value (0/1)
+    // C: jump offset
+    LOP_LOADB,
+
+    // LOADN: sets register to a number literal
+    // A: target register
+    // D: value (-32768..32767)
+    LOP_LOADN,
+
+    // LOADK: sets register to an entry from the constant table from the proto (number/vector/string)
+    // A: target register
+    // D: constant table index (0..32767)
+    LOP_LOADK,
+
+    // MOVE: move (copy) value from one register to another
+    // A: target register
+    // B: source register
+    LOP_MOVE,
+
+    // GETGLOBAL: load value from global table using constant string as a key
+    // A: target register
+    // C: predicted slot index (based on hash)
+    // AUX: constant table index
+    LOP_GETGLOBAL,
+
+    // SETGLOBAL: set value in global table using constant string as a key
+    // A: source register
+    // C: predicted slot index (based on hash)
+    // AUX: constant table index
+    LOP_SETGLOBAL,
+
+    // GETUPVAL: load upvalue from the upvalue table for the current function
+    // A: target register
+    // B: upvalue index
+    LOP_GETUPVAL,
+
+    // SETUPVAL: store value into the upvalue table for the current function
+    // A: target register
+    // B: upvalue index
+    LOP_SETUPVAL,
+
+    // CLOSEUPVALS: close (migrate to heap) all upvalues that were captured for registers >= target
+    // A: target register
+    LOP_CLOSEUPVALS,
+
+    // GETIMPORT: load imported global table global from the constant table
+    // A: target register
+    // D: constant table index (0..32767); we assume that imports are loaded into the constant table
+    // AUX: 3 10-bit indices of constant strings that, combined, constitute an import path; length of the path is set by the top 2 bits (1,2,3)
+    LOP_GETIMPORT,
+
+    // GETTABLE: load value from table into target register using key from register
+    // A: target register
+    // B: table register
+    // C: index register
+    LOP_GETTABLE,
+
+    // SETTABLE: store source register into table using key from register
+    // A: source register
+    // B: table register
+    // C: index register
+    LOP_SETTABLE,
+
+    // GETTABLEKS: load value from table into target register using constant string as a key
+    // A: target register
+    // B: table register
+    // C: predicted slot index (based on hash)
+    // AUX: constant table index
+    LOP_GETTABLEKS,
+
+    // SETTABLEKS: store source register into table using constant string as a key
+    // A: source register
+    // B: table register
+    // C: predicted slot index (based on hash)
+    // AUX: constant table index
+    LOP_SETTABLEKS,
+
+    // GETTABLEN: load value from table into target register using small integer index as a key
+    // A: target register
+    // B: table register
+    // C: index-1 (index is 1..256)
+    LOP_GETTABLEN,
+
+    // SETTABLEN: store source register into table using small integer index as a key
+    // A: source register
+    // B: table register
+    // C: index-1 (index is 1..256)
+    LOP_SETTABLEN,
+
+    // NEWCLOSURE: create closure from a child proto; followed by a CAPTURE instruction for each upvalue
+    // A: target register
+    // D: child proto index (0..32767)
+    LOP_NEWCLOSURE,
+
+    // NAMECALL: prepare to call specified method by name by loading function from source register using constant index into target register and copying source register into target register + 1
+    // A: target register
+    // B: source register
+    // C: predicted slot index (based on hash)
+    // AUX: constant table index
+    // Note that this instruction must be followed directly by CALL; it prepares the arguments
+    // This instruction is roughly equivalent to GETTABLEKS + MOVE pair, but we need a special instruction to support custom __namecall metamethod
+    LOP_NAMECALL,
+
+    // CALL: call specified function
+    // A: register where the function object lives, followed by arguments; results are placed starting from the same register
+    // B: argument count + 1, or 0 to preserve all arguments up to top (MULTRET)
+    // C: result count + 1, or 0 to preserve all values and adjust top (MULTRET)
+    LOP_CALL,
+
+    // RETURN: returns specified values from the function
+    // A: register where the returned values start
+    // B: number of returned values + 1, or 0 to return all values up to top (MULTRET)
+    LOP_RETURN,
+
+    // JUMP: jumps to target offset
+    // D: jump offset (-32768..32767; 0 means "next instruction" aka "don't jump")
+    LOP_JUMP,
+
+    // JUMPBACK: jumps to target offset; this is equivalent to JUMP but is used as a safepoint to be able to interrupt while/repeat loops
+    // D: jump offset (-32768..32767; 0 means "next instruction" aka "don't jump")
+    LOP_JUMPBACK,
+
+    // JUMPIF: jumps to target offset if register is not nil/false
+    // A: source register
+    // D: jump offset (-32768..32767; 0 means "next instruction" aka "don't jump")
+    LOP_JUMPIF,
+
+    // JUMPIFNOT: jumps to target offset if register is nil/false
+    // A: source register
+    // D: jump offset (-32768..32767; 0 means "next instruction" aka "don't jump")
+    LOP_JUMPIFNOT,
+
+    // JUMPIFEQ, JUMPIFLE, JUMPIFLT, JUMPIFNOTEQ, JUMPIFNOTLE, JUMPIFNOTLT: jumps to target offset if the comparison is true (or false, for NOT variants)
+    // A: source register 1
+    // D: jump offset (-32768..32767; 1 means "next instruction" aka "don't jump")
+    // AUX: source register 2
+    LOP_JUMPIFEQ,
+    LOP_JUMPIFLE,
+    LOP_JUMPIFLT,
+    LOP_JUMPIFNOTEQ,
+    LOP_JUMPIFNOTLE,
+    LOP_JUMPIFNOTLT,
+
+    // ADD, SUB, MUL, DIV, MOD, POW: compute arithmetic operation between two source registers and put the result into target register
+    // A: target register
+    // B: source register 1
+    // C: source register 2
+    LOP_ADD,
+    LOP_SUB,
+    LOP_MUL,
+    LOP_DIV,
+    LOP_MOD,
+    LOP_POW,
+
+    // ADDK, SUBK, MULK, DIVK, MODK, POWK: compute arithmetic operation between the source register and a constant and put the result into target register
+    // A: target register
+    // B: source register
+    // C: constant table index (0..255); must refer to a number
+    LOP_ADDK,
+    LOP_SUBK,
+    LOP_MULK,
+    LOP_DIVK,
+    LOP_MODK,
+    LOP_POWK,
+
+    // AND, OR: perform `and` or `or` operation (selecting first or second register based on whether the first one is truthy) and put the result into target register
+    // A: target register
+    // B: source register 1
+    // C: source register 2
+    LOP_AND,
+    LOP_OR,
+
+    // ANDK, ORK: perform `and` or `or` operation (selecting source register or constant based on whether the source register is truthy) and put the result into target register
+    // A: target register
+    // B: source register
+    // C: constant table index (0..255)
+    LOP_ANDK,
+    LOP_ORK,
+
+    // CONCAT: concatenate all strings between B and C (inclusive) and put the result into A
+    // A: target register
+    // B: source register start
+    // C: source register end
+    LOP_CONCAT,
+
+    // NOT, MINUS, LENGTH: compute unary operation for source register and put the result into target register
+    // A: target register
+    // B: source register
+    LOP_NOT,
+    LOP_MINUS,
+    LOP_LENGTH,
+
+    // NEWTABLE: create table in target register
+    // A: target register
+    // B: table size, stored as 0 for v=0 and ceil(log2(v))+1 for v!=0
+    // AUX: array size
+    LOP_NEWTABLE,
+
+    // DUPTABLE: duplicate table using the constant table template to target register
+    // A: target register
+    // D: constant table index (0..32767)
+    LOP_DUPTABLE,
+
+    // SETLIST: set a list of values to table in target register
+    // A: target register
+    // B: source register start
+    // C: value count + 1, or 0 to use all values up to top (MULTRET)
+    // AUX: table index to start from
+    LOP_SETLIST,
+
+    // FORNPREP: prepare a numeric for loop, jump over the loop if first iteration doesn't need to run
+    // A: target register; numeric for loops assume a register layout [limit, step, index, variable]
+    // D: jump offset (-32768..32767)
+    // limit/step are immutable, index isn't visible to user code since it's copied into variable
+    LOP_FORNPREP,
+
+    // FORNLOOP: adjust loop variables for one iteration, jump back to the loop header if loop needs to continue
+    // A: target register; see FORNPREP for register layout
+    // D: jump offset (-32768..32767)
+    LOP_FORNLOOP,
+
+    // FORGLOOP: adjust loop variables for one iteration of a generic for loop, jump back to the loop header if loop needs to continue
+    // A: target register; generic for loops assume a register layout [generator, state, index, variables...]
+    // D: jump offset (-32768..32767)
+    // AUX: variable count (1..255) in the low 8 bits, high bit indicates whether to use ipairs-style traversal in the fast path
+    // loop variables are adjusted by calling generator(state, index) and expecting it to return a tuple that's copied to the user variables
+    // the first variable is then copied into index; generator/state are immutable, index isn't visible to user code
+    LOP_FORGLOOP,
+
+    // FORGPREP_INEXT: prepare FORGLOOP with 2 output variables (no AUX encoding), assuming generator is luaB_inext, and jump to FORGLOOP
+    // A: target register (see FORGLOOP for register layout)
+    LOP_FORGPREP_INEXT,
+
+    // removed in v3
+    LOP_DEP_FORGLOOP_INEXT,
+
+    // FORGPREP_NEXT: prepare FORGLOOP with 2 output variables (no AUX encoding), assuming generator is luaB_next, and jump to FORGLOOP
+    // A: target register (see FORGLOOP for register layout)
+    LOP_FORGPREP_NEXT,
+
+    // NATIVECALL: start executing new function in native code
+    // this is a pseudo-instruction that is never emitted by bytecode compiler, but can be constructed at runtime to accelerate native code dispatch
+    LOP_NATIVECALL,
+
+    // GETVARARGS: copy variables into the target register from vararg storage for current function
+    // A: target register
+    // B: variable count + 1, or 0 to copy all variables and adjust top (MULTRET)
+    LOP_GETVARARGS,
+
+    // DUPCLOSURE: create closure from a pre-created function object (reusing it unless environments diverge)
+    // A: target register
+    // D: constant table index (0..32767)
+    LOP_DUPCLOSURE,
+
+    // PREPVARARGS: prepare stack for variadic functions so that GETVARARGS works correctly
+    // A: number of fixed arguments
+    LOP_PREPVARARGS,
+
+    // LOADKX: sets register to an entry from the constant table from the proto (number/string)
+    // A: target register
+    // AUX: constant table index
+    LOP_LOADKX,
+
+    // JUMPX: jumps to the target offset; like JUMPBACK, supports interruption
+    // E: jump offset (-2^23..2^23; 0 means "next instruction" aka "don't jump")
+    LOP_JUMPX,
+
+    // FASTCALL: perform a fast call of a built-in function
+    // A: builtin function id (see LuauBuiltinFunction)
+    // C: jump offset to get to following CALL
+    // FASTCALL is followed by one of (GETIMPORT, MOVE, GETUPVAL) instructions and by CALL instruction
+    // This is necessary so that if FASTCALL can't perform the call inline, it can continue normal execution
+    // If FASTCALL *can* perform the call, it jumps over the instructions *and* over the next CALL
+    // Note that FASTCALL will read the actual call arguments, such as argument/result registers and counts, from the CALL instruction
+    LOP_FASTCALL,
+
+    // COVERAGE: update coverage information stored in the instruction
+    // E: hit count for the instruction (0..2^23-1)
+    // The hit count is incremented by VM every time the instruction is executed, and saturates at 2^23-1
+    LOP_COVERAGE,
+
+    // CAPTURE: capture a local or an upvalue as an upvalue into a newly created closure; only valid after NEWCLOSURE
+    // A: capture type, see LuauCaptureType
+    // B: source register (for VAL/REF) or upvalue index (for UPVAL/UPREF)
+    LOP_CAPTURE,
+
+    // SUBRK, DIVRK: compute arithmetic operation between the constant and a source register and put the result into target register
+    // A: target register
+    // B: source register
+    // C: constant table index (0..255); must refer to a number
+    LOP_SUBRK,
+    LOP_DIVRK,
+
+    // FASTCALL1: perform a fast call of a built-in function using 1 register argument
+    // A: builtin function id (see LuauBuiltinFunction)
+    // B: source argument register
+    // C: jump offset to get to following CALL
+    LOP_FASTCALL1,
+
+    // FASTCALL2: perform a fast call of a built-in function using 2 register arguments
+    // A: builtin function id (see LuauBuiltinFunction)
+    // B: source argument register
+    // C: jump offset to get to following CALL
+    // AUX: source register 2 in least-significant byte
+    LOP_FASTCALL2,
+
+    // FASTCALL2K: perform a fast call of a built-in function using 1 register argument and 1 constant argument
+    // A: builtin function id (see LuauBuiltinFunction)
+    // B: source argument register
+    // C: jump offset to get to following CALL
+    // AUX: constant index
+    LOP_FASTCALL2K,
+
+    // FORGPREP: prepare loop variables for a generic for loop, jump to the loop backedge unconditionally
+    // A: target register; generic for loops assume a register layout [generator, state, index, variables...]
+    // D: jump offset (-32768..32767)
+    LOP_FORGPREP,
+
+    // JUMPXEQKNIL, JUMPXEQKB: jumps to target offset if the comparison with constant is true (or false, see AUX)
+    // A: source register 1
+    // D: jump offset (-32768..32767; 1 means "next instruction" aka "don't jump")
+    // AUX: constant value (for boolean) in low bit, NOT flag (that flips comparison result) in high bit
+    LOP_JUMPXEQKNIL,
+    LOP_JUMPXEQKB,
+
+    // JUMPXEQKN, JUMPXEQKS: jumps to target offset if the comparison with constant is true (or false, see AUX)
+    // A: source register 1
+    // D: jump offset (-32768..32767; 1 means "next instruction" aka "don't jump")
+    // AUX: constant table index in low 24 bits, NOT flag (that flips comparison result) in high bit
+    LOP_JUMPXEQKN,
+    LOP_JUMPXEQKS,
+
+    // IDIV: compute floor division between two source registers and put the result into target register
+    // A: target register
+    // B: source register 1
+    // C: source register 2
+    LOP_IDIV,
+
+    // IDIVK compute floor division between the source register and a constant and put the result into target register
+    // A: target register
+    // B: source register
+    // C: constant table index (0..255)
+    LOP_IDIVK,
+
+    // Enum entry for number of opcodes, not a valid opcode by itself!
+    LOP__COUNT
+};
+
+// Bytecode instruction header: it's always a 32-bit integer, with low byte (first byte in little endian) containing the opcode
+// Some instruction types require more data and have more 32-bit integers following the header
+#define LUAU_INSN_OP(insn) ((insn) & 0xff)
+
+// ABC encoding: three 8-bit values, containing registers or small numbers
+#define LUAU_INSN_A(insn) (((insn) >> 8) & 0xff)
+#define LUAU_INSN_B(insn) (((insn) >> 16) & 0xff)
+#define LUAU_INSN_C(insn) (((insn) >> 24) & 0xff)
+
+// AD encoding: one 8-bit value, one signed 16-bit value
+#define LUAU_INSN_D(insn) (int32_t(insn) >> 16)
+
+// E encoding: one signed 24-bit value
+#define LUAU_INSN_E(insn) (int32_t(insn) >> 8)
+
+// Bytecode tags, used internally for bytecode encoded as a string
+enum LuauBytecodeTag
+{
+    // Bytecode version; runtime supports [MIN, MAX], compiler emits TARGET by default but may emit a higher version when flags are enabled
+    LBC_VERSION_MIN = 3,
+    LBC_VERSION_MAX = 5,
+    LBC_VERSION_TARGET = 4,
+    // Type encoding version
+    LBC_TYPE_VERSION = 1,
+    // Types of constant table entries
+    LBC_CONSTANT_NIL = 0,
+    LBC_CONSTANT_BOOLEAN,
+    LBC_CONSTANT_NUMBER,
+    LBC_CONSTANT_STRING,
+    LBC_CONSTANT_IMPORT,
+    LBC_CONSTANT_TABLE,
+    LBC_CONSTANT_CLOSURE,
+    LBC_CONSTANT_VECTOR,
+};
+
+// Type table tags
+enum LuauBytecodeType
+{
+    LBC_TYPE_NIL = 0,
+    LBC_TYPE_BOOLEAN,
+    LBC_TYPE_NUMBER,
+    LBC_TYPE_STRING,
+    LBC_TYPE_TABLE,
+    LBC_TYPE_FUNCTION,
+    LBC_TYPE_THREAD,
+    LBC_TYPE_USERDATA,
+    LBC_TYPE_VECTOR,
+    LBC_TYPE_BUFFER,
+
+    LBC_TYPE_ANY = 15,
+    LBC_TYPE_OPTIONAL_BIT = 1 << 7,
+
+    LBC_TYPE_INVALID = 256,
+};
+
+// Builtin function ids, used in LOP_FASTCALL
+enum LuauBuiltinFunction
+{
+    LBF_NONE = 0,
+
+    // assert()
+    LBF_ASSERT,
+
+    // math.
+    LBF_MATH_ABS,
+    LBF_MATH_ACOS,
+    LBF_MATH_ASIN,
+    LBF_MATH_ATAN2,
+    LBF_MATH_ATAN,
+    LBF_MATH_CEIL,
+    LBF_MATH_COSH,
+    LBF_MATH_COS,
+    LBF_MATH_DEG,
+    LBF_MATH_EXP,
+    LBF_MATH_FLOOR,
+    LBF_MATH_FMOD,
+    LBF_MATH_FREXP,
+    LBF_MATH_LDEXP,
+    LBF_MATH_LOG10,
+    LBF_MATH_LOG,
+    LBF_MATH_MAX,
+    LBF_MATH_MIN,
+    LBF_MATH_MODF,
+    LBF_MATH_POW,
+    LBF_MATH_RAD,
+    LBF_MATH_SINH,
+    LBF_MATH_SIN,
+    LBF_MATH_SQRT,
+    LBF_MATH_TANH,
+    LBF_MATH_TAN,
+
+    // bit32.
+    LBF_BIT32_ARSHIFT,
+    LBF_BIT32_BAND,
+    LBF_BIT32_BNOT,
+    LBF_BIT32_BOR,
+    LBF_BIT32_BXOR,
+    LBF_BIT32_BTEST,
+    LBF_BIT32_EXTRACT,
+    LBF_BIT32_LROTATE,
+    LBF_BIT32_LSHIFT,
+    LBF_BIT32_REPLACE,
+    LBF_BIT32_RROTATE,
+    LBF_BIT32_RSHIFT,
+
+    // type()
+    LBF_TYPE,
+
+    // string.
+    LBF_STRING_BYTE,
+    LBF_STRING_CHAR,
+    LBF_STRING_LEN,
+
+    // typeof()
+    LBF_TYPEOF,
+
+    // string.
+    LBF_STRING_SUB,
+
+    // math.
+    LBF_MATH_CLAMP,
+    LBF_MATH_SIGN,
+    LBF_MATH_ROUND,
+
+    // raw*
+    LBF_RAWSET,
+    LBF_RAWGET,
+    LBF_RAWEQUAL,
+
+    // table.
+    LBF_TABLE_INSERT,
+    LBF_TABLE_UNPACK,
+
+    // vector ctor
+    LBF_VECTOR,
+
+    // bit32.count
+    LBF_BIT32_COUNTLZ,
+    LBF_BIT32_COUNTRZ,
+
+    // select(_, ...)
+    LBF_SELECT_VARARG,
+
+    // rawlen
+    LBF_RAWLEN,
+
+    // bit32.extract(_, k, k)
+    LBF_BIT32_EXTRACTK,
+
+    // get/setmetatable
+    LBF_GETMETATABLE,
+    LBF_SETMETATABLE,
+
+    // tonumber/tostring
+    LBF_TONUMBER,
+    LBF_TOSTRING,
+
+    // bit32.byteswap(n)
+    LBF_BIT32_BYTESWAP,
+
+    // buffer.
+    LBF_BUFFER_READI8,
+    LBF_BUFFER_READU8,
+    LBF_BUFFER_WRITEU8,
+    LBF_BUFFER_READI16,
+    LBF_BUFFER_READU16,
+    LBF_BUFFER_WRITEU16,
+    LBF_BUFFER_READI32,
+    LBF_BUFFER_READU32,
+    LBF_BUFFER_WRITEU32,
+    LBF_BUFFER_READF32,
+    LBF_BUFFER_WRITEF32,
+    LBF_BUFFER_READF64,
+    LBF_BUFFER_WRITEF64,
+};
+
+// Capture type, used in LOP_CAPTURE
+enum LuauCaptureType
+{
+    LCT_VAL = 0,
+    LCT_REF,
+    LCT_UPVAL,
+};
+
+// Proto flag bitmask, stored in Proto::flags
+enum LuauProtoFlag
+{
+    // used to tag main proto for modules with --!native
+    LPF_NATIVE_MODULE = 1 << 0,
+    // used to tag individual protos as not profitable to compile natively
+    LPF_NATIVE_COLD = 1 << 1,
+};

--- a/lib/luau/Common/include/Luau/BytecodeUtils.h
+++ b/lib/luau/Common/include/Luau/BytecodeUtils.h
@@ -1,0 +1,42 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Bytecode.h"
+
+namespace Luau
+{
+
+inline int getOpLength(LuauOpcode op)
+{
+    switch (op)
+    {
+    case LOP_GETGLOBAL:
+    case LOP_SETGLOBAL:
+    case LOP_GETIMPORT:
+    case LOP_GETTABLEKS:
+    case LOP_SETTABLEKS:
+    case LOP_NAMECALL:
+    case LOP_JUMPIFEQ:
+    case LOP_JUMPIFLE:
+    case LOP_JUMPIFLT:
+    case LOP_JUMPIFNOTEQ:
+    case LOP_JUMPIFNOTLE:
+    case LOP_JUMPIFNOTLT:
+    case LOP_NEWTABLE:
+    case LOP_SETLIST:
+    case LOP_FORGLOOP:
+    case LOP_LOADKX:
+    case LOP_FASTCALL2:
+    case LOP_FASTCALL2K:
+    case LOP_JUMPXEQKNIL:
+    case LOP_JUMPXEQKB:
+    case LOP_JUMPXEQKN:
+    case LOP_JUMPXEQKS:
+        return 2;
+
+    default:
+        return 1;
+    }
+}
+
+} // namespace Luau

--- a/lib/luau/Common/include/Luau/Common.h
+++ b/lib/luau/Common/include/Luau/Common.h
@@ -1,0 +1,137 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+// Compiler codegen control macros
+#ifdef _MSC_VER
+#define LUAU_NORETURN __declspec(noreturn)
+#define LUAU_NOINLINE __declspec(noinline)
+#define LUAU_FORCEINLINE __forceinline
+#define LUAU_LIKELY(x) x
+#define LUAU_UNLIKELY(x) x
+#define LUAU_UNREACHABLE() __assume(false)
+#define LUAU_DEBUGBREAK() __debugbreak()
+#else
+#define LUAU_NORETURN __attribute__((__noreturn__))
+#define LUAU_NOINLINE __attribute__((noinline))
+#define LUAU_FORCEINLINE inline __attribute__((always_inline))
+#define LUAU_LIKELY(x) __builtin_expect(x, 1)
+#define LUAU_UNLIKELY(x) __builtin_expect(x, 0)
+#define LUAU_UNREACHABLE() __builtin_unreachable()
+#define LUAU_DEBUGBREAK() __builtin_trap()
+#endif
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define LUAU_BIG_ENDIAN
+#endif
+
+namespace Luau
+{
+
+using AssertHandler = int (*)(const char* expression, const char* file, int line, const char* function);
+
+inline AssertHandler& assertHandler()
+{
+    static AssertHandler handler = nullptr;
+    return handler;
+}
+
+// We want 'inline' to correctly link this function declared in the header
+// But we also want to prevent compiler from inlining this function when optimization and assertions are enabled together
+// Reason for that is that compilation times can increase significantly in such a configuration
+LUAU_NOINLINE inline int assertCallHandler(const char* expression, const char* file, int line, const char* function)
+{
+    if (AssertHandler handler = assertHandler())
+        return handler(expression, file, line, function);
+
+    return 1;
+}
+
+} // namespace Luau
+
+#if !defined(NDEBUG) || defined(LUAU_ENABLE_ASSERT)
+#define LUAU_ASSERT(expr) ((void)(!!(expr) || (Luau::assertCallHandler(#expr, __FILE__, __LINE__, __FUNCTION__) && (LUAU_DEBUGBREAK(), 0))))
+#define LUAU_ASSERTENABLED
+#else
+#define LUAU_ASSERT(expr) (void)sizeof(!!(expr))
+#endif
+
+namespace Luau
+{
+
+template<typename T>
+struct FValue
+{
+    static FValue* list;
+
+    T value;
+    bool dynamic;
+    const char* name;
+    FValue* next;
+
+    FValue(const char* name, T def, bool dynamic)
+        : value(def)
+        , dynamic(dynamic)
+        , name(name)
+        , next(list)
+    {
+        list = this;
+    }
+
+    operator T() const
+    {
+        return value;
+    }
+};
+
+template<typename T>
+FValue<T>* FValue<T>::list = nullptr;
+
+} // namespace Luau
+
+#define LUAU_FASTFLAG(flag) \
+    namespace FFlag \
+    { \
+    extern Luau::FValue<bool> flag; \
+    }
+#define LUAU_FASTFLAGVARIABLE(flag, def) \
+    namespace FFlag \
+    { \
+    Luau::FValue<bool> flag(#flag, def, false); \
+    }
+#define LUAU_FASTINT(flag) \
+    namespace FInt \
+    { \
+    extern Luau::FValue<int> flag; \
+    }
+#define LUAU_FASTINTVARIABLE(flag, def) \
+    namespace FInt \
+    { \
+    Luau::FValue<int> flag(#flag, def, false); \
+    }
+
+#define LUAU_DYNAMIC_FASTFLAG(flag) \
+    namespace DFFlag \
+    { \
+    extern Luau::FValue<bool> flag; \
+    }
+#define LUAU_DYNAMIC_FASTFLAGVARIABLE(flag, def) \
+    namespace DFFlag \
+    { \
+    Luau::FValue<bool> flag(#flag, def, true); \
+    }
+#define LUAU_DYNAMIC_FASTINT(flag) \
+    namespace DFInt \
+    { \
+    extern Luau::FValue<int> flag; \
+    }
+#define LUAU_DYNAMIC_FASTINTVARIABLE(flag, def) \
+    namespace DFInt \
+    { \
+    Luau::FValue<int> flag(#flag, def, true); \
+    }
+
+#if defined(__GNUC__)
+#define LUAU_PRINTF_ATTR(fmt, arg) __attribute__((format(printf, fmt, arg)))
+#else
+#define LUAU_PRINTF_ATTR(fmt, arg)
+#endif

--- a/lib/luau/Common/include/Luau/DenseHash.h
+++ b/lib/luau/Common/include/Luau/DenseHash.h
@@ -1,0 +1,666 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Common.h"
+
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <type_traits>
+#include <stdint.h>
+
+namespace Luau
+{
+
+struct DenseHashPointer
+{
+    size_t operator()(const void* key) const
+    {
+        return (uintptr_t(key) >> 4) ^ (uintptr_t(key) >> 9);
+    }
+};
+
+// Internal implementation of DenseHashSet and DenseHashMap
+namespace detail
+{
+
+template<typename T>
+using DenseHashDefault = std::conditional_t<std::is_pointer_v<T>, DenseHashPointer, std::hash<T>>;
+
+template<typename Key, typename Item, typename MutableItem, typename ItemInterface, typename Hash, typename Eq>
+class DenseHashTable
+{
+public:
+    class const_iterator;
+    class iterator;
+
+    explicit DenseHashTable(const Key& empty_key, size_t buckets = 0)
+        : data(nullptr)
+        , capacity(0)
+        , count(0)
+        , empty_key(empty_key)
+    {
+        // validate that equality operator is at least somewhat functional
+        LUAU_ASSERT(eq(empty_key, empty_key));
+        // buckets has to be power-of-two or zero
+        LUAU_ASSERT((buckets & (buckets - 1)) == 0);
+
+        if (buckets)
+        {
+            data = static_cast<Item*>(::operator new(sizeof(Item) * buckets));
+            capacity = buckets;
+
+            ItemInterface::fill(data, buckets, empty_key);
+        }
+    }
+
+    ~DenseHashTable()
+    {
+        if (data)
+            destroy();
+    }
+
+    DenseHashTable(const DenseHashTable& other)
+        : data(nullptr)
+        , capacity(0)
+        , count(other.count)
+        , empty_key(other.empty_key)
+    {
+        if (other.capacity)
+        {
+            data = static_cast<Item*>(::operator new(sizeof(Item) * other.capacity));
+
+            for (size_t i = 0; i < other.capacity; ++i)
+            {
+                new (&data[i]) Item(other.data[i]);
+                capacity = i + 1; // if Item copy throws, capacity will note the number of initialized objects for destroy() to clean up
+            }
+        }
+    }
+
+    DenseHashTable(DenseHashTable&& other)
+        : data(other.data)
+        , capacity(other.capacity)
+        , count(other.count)
+        , empty_key(other.empty_key)
+    {
+        other.data = nullptr;
+        other.capacity = 0;
+        other.count = 0;
+    }
+
+    DenseHashTable& operator=(DenseHashTable&& other)
+    {
+        if (this != &other)
+        {
+            if (data)
+                destroy();
+
+            data = other.data;
+            capacity = other.capacity;
+            count = other.count;
+            empty_key = other.empty_key;
+
+            other.data = nullptr;
+            other.capacity = 0;
+            other.count = 0;
+        }
+
+        return *this;
+    }
+
+    DenseHashTable& operator=(const DenseHashTable& other)
+    {
+        if (this != &other)
+        {
+            DenseHashTable copy(other);
+            *this = std::move(copy);
+        }
+
+        return *this;
+    }
+
+    void clear()
+    {
+        if (count == 0)
+            return;
+
+        if (capacity > 32)
+        {
+            destroy();
+        }
+        else
+        {
+            ItemInterface::destroy(data, capacity);
+            ItemInterface::fill(data, capacity, empty_key);
+        }
+
+        count = 0;
+    }
+
+    void destroy()
+    {
+        ItemInterface::destroy(data, capacity);
+
+        ::operator delete(data);
+        data = nullptr;
+
+        capacity = 0;
+    }
+
+    Item* insert_unsafe(const Key& key)
+    {
+        // It is invalid to insert empty_key into the table since it acts as a "entry does not exist" marker
+        LUAU_ASSERT(!eq(key, empty_key));
+
+        size_t hashmod = capacity - 1;
+        size_t bucket = hasher(key) & hashmod;
+
+        for (size_t probe = 0; probe <= hashmod; ++probe)
+        {
+            Item& probe_item = data[bucket];
+
+            // Element does not exist, insert here
+            if (eq(ItemInterface::getKey(probe_item), empty_key))
+            {
+                ItemInterface::setKey(probe_item, key);
+                count++;
+                return &probe_item;
+            }
+
+            // Element already exists
+            if (eq(ItemInterface::getKey(probe_item), key))
+            {
+                return &probe_item;
+            }
+
+            // Hash collision, quadratic probing
+            bucket = (bucket + probe + 1) & hashmod;
+        }
+
+        // Hash table is full - this should not happen
+        LUAU_ASSERT(false);
+        return NULL;
+    }
+
+    const Item* find(const Key& key) const
+    {
+        if (count == 0)
+            return 0;
+        if (eq(key, empty_key))
+            return 0;
+
+        size_t hashmod = capacity - 1;
+        size_t bucket = hasher(key) & hashmod;
+
+        for (size_t probe = 0; probe <= hashmod; ++probe)
+        {
+            const Item& probe_item = data[bucket];
+
+            // Element exists
+            if (eq(ItemInterface::getKey(probe_item), key))
+                return &probe_item;
+
+            // Element does not exist
+            if (eq(ItemInterface::getKey(probe_item), empty_key))
+                return NULL;
+
+            // Hash collision, quadratic probing
+            bucket = (bucket + probe + 1) & hashmod;
+        }
+
+        // Hash table is full - this should not happen
+        LUAU_ASSERT(false);
+        return NULL;
+    }
+
+    void rehash()
+    {
+        size_t newsize = capacity == 0 ? 16 : capacity * 2;
+
+        DenseHashTable newtable(empty_key, newsize);
+
+        for (size_t i = 0; i < capacity; ++i)
+        {
+            const Key& key = ItemInterface::getKey(data[i]);
+
+            if (!eq(key, empty_key))
+            {
+                Item* item = newtable.insert_unsafe(key);
+                *item = std::move(data[i]);
+            }
+        }
+
+        LUAU_ASSERT(count == newtable.count);
+
+        std::swap(data, newtable.data);
+        std::swap(capacity, newtable.capacity);
+    }
+
+    void rehash_if_full(const Key& key)
+    {
+        if (count >= capacity * 3 / 4 && !find(key))
+        {
+            rehash();
+        }
+    }
+
+    const_iterator begin() const
+    {
+        size_t start = 0;
+
+        while (start < capacity && eq(ItemInterface::getKey(data[start]), empty_key))
+            start++;
+
+        return const_iterator(this, start);
+    }
+
+    const_iterator end() const
+    {
+        return const_iterator(this, capacity);
+    }
+
+    iterator begin()
+    {
+        size_t start = 0;
+
+        while (start < capacity && eq(ItemInterface::getKey(data[start]), empty_key))
+            start++;
+
+        return iterator(this, start);
+    }
+
+    iterator end()
+    {
+        return iterator(this, capacity);
+    }
+
+    size_t size() const
+    {
+        return count;
+    }
+
+    class const_iterator
+    {
+    public:
+        using value_type = Item;
+        using reference = Item&;
+        using pointer = Item*;
+        using difference_type = ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        const_iterator()
+            : set(0)
+            , index(0)
+        {
+        }
+
+        const_iterator(const DenseHashTable<Key, Item, MutableItem, ItemInterface, Hash, Eq>* set, size_t index)
+            : set(set)
+            , index(index)
+        {
+        }
+
+        const Item& operator*() const
+        {
+            return set->data[index];
+        }
+
+        const Item* operator->() const
+        {
+            return &set->data[index];
+        }
+
+        bool operator==(const const_iterator& other) const
+        {
+            return set == other.set && index == other.index;
+        }
+
+        bool operator!=(const const_iterator& other) const
+        {
+            return set != other.set || index != other.index;
+        }
+
+        const_iterator& operator++()
+        {
+            size_t size = set->capacity;
+
+            do
+            {
+                index++;
+            } while (index < size && set->eq(ItemInterface::getKey(set->data[index]), set->empty_key));
+
+            return *this;
+        }
+
+        const_iterator operator++(int)
+        {
+            const_iterator res = *this;
+            ++*this;
+            return res;
+        }
+
+    private:
+        const DenseHashTable<Key, Item, MutableItem, ItemInterface, Hash, Eq>* set;
+        size_t index;
+    };
+
+    class iterator
+    {
+    public:
+        using value_type = MutableItem;
+        using reference = MutableItem&;
+        using pointer = MutableItem*;
+        using difference_type = ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        iterator()
+            : set(0)
+            , index(0)
+        {
+        }
+
+        iterator(DenseHashTable<Key, Item, MutableItem, ItemInterface, Hash, Eq>* set, size_t index)
+            : set(set)
+            , index(index)
+        {
+        }
+
+        MutableItem& operator*() const
+        {
+            return *reinterpret_cast<MutableItem*>(&set->data[index]);
+        }
+
+        MutableItem* operator->() const
+        {
+            return reinterpret_cast<MutableItem*>(&set->data[index]);
+        }
+
+        bool operator==(const iterator& other) const
+        {
+            return set == other.set && index == other.index;
+        }
+
+        bool operator!=(const iterator& other) const
+        {
+            return set != other.set || index != other.index;
+        }
+
+        iterator& operator++()
+        {
+            size_t size = set->capacity;
+
+            do
+            {
+                index++;
+            } while (index < size && set->eq(ItemInterface::getKey(set->data[index]), set->empty_key));
+
+            return *this;
+        }
+
+        iterator operator++(int)
+        {
+            iterator res = *this;
+            ++*this;
+            return res;
+        }
+
+    private:
+        DenseHashTable<Key, Item, MutableItem, ItemInterface, Hash, Eq>* set;
+        size_t index;
+    };
+
+private:
+    Item* data;
+    size_t capacity;
+    size_t count;
+    Key empty_key;
+    Hash hasher;
+    Eq eq;
+};
+
+template<typename Key>
+struct ItemInterfaceSet
+{
+    static const Key& getKey(const Key& item)
+    {
+        return item;
+    }
+
+    static void setKey(Key& item, const Key& key)
+    {
+        item = key;
+    }
+
+    static void fill(Key* data, size_t count, const Key& key)
+    {
+        for (size_t i = 0; i < count; ++i)
+            new (&data[i]) Key(key);
+    }
+
+    static void destroy(Key* data, size_t count)
+    {
+        for (size_t i = 0; i < count; ++i)
+            data[i].~Key();
+    }
+};
+
+template<typename Key, typename Value>
+struct ItemInterfaceMap
+{
+    static const Key& getKey(const std::pair<Key, Value>& item)
+    {
+        return item.first;
+    }
+
+    static void setKey(std::pair<Key, Value>& item, const Key& key)
+    {
+        item.first = key;
+    }
+
+    static void fill(std::pair<Key, Value>* data, size_t count, const Key& key)
+    {
+        for (size_t i = 0; i < count; ++i)
+        {
+            new (&data[i].first) Key(key);
+            new (&data[i].second) Value();
+        }
+    }
+
+    static void destroy(std::pair<Key, Value>* data, size_t count)
+    {
+        for (size_t i = 0; i < count; ++i)
+        {
+            data[i].first.~Key();
+            data[i].second.~Value();
+        }
+    }
+};
+
+} // namespace detail
+
+// This is a faster alternative of unordered_set, but it does not implement the same interface (i.e. it does not support erasing)
+template<typename Key, typename Hash = detail::DenseHashDefault<Key>, typename Eq = std::equal_to<Key>>
+class DenseHashSet
+{
+    typedef detail::DenseHashTable<Key, Key, Key, detail::ItemInterfaceSet<Key>, Hash, Eq> Impl;
+    Impl impl;
+
+public:
+    typedef typename Impl::const_iterator const_iterator;
+    typedef typename Impl::iterator iterator;
+
+    explicit DenseHashSet(const Key& empty_key, size_t buckets = 0)
+        : impl(empty_key, buckets)
+    {
+    }
+
+    void clear()
+    {
+        impl.clear();
+    }
+
+    const Key& insert(const Key& key)
+    {
+        impl.rehash_if_full(key);
+        return *impl.insert_unsafe(key);
+    }
+
+    const Key* find(const Key& key) const
+    {
+        return impl.find(key);
+    }
+
+    bool contains(const Key& key) const
+    {
+        return impl.find(key) != 0;
+    }
+
+    size_t size() const
+    {
+        return impl.size();
+    }
+
+    bool empty() const
+    {
+        return impl.size() == 0;
+    }
+
+    const_iterator begin() const
+    {
+        return impl.begin();
+    }
+
+    const_iterator end() const
+    {
+        return impl.end();
+    }
+
+    iterator begin()
+    {
+        return impl.begin();
+    }
+
+    iterator end()
+    {
+        return impl.end();
+    }
+
+    bool operator==(const DenseHashSet<Key, Hash, Eq>& other) const
+    {
+        if (size() != other.size())
+            return false;
+
+        for (const Key& k : *this)
+        {
+            if (!other.contains(k))
+                return false;
+        }
+
+        return true;
+    }
+
+    bool operator!=(const DenseHashSet<Key, Hash, Eq>& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+// This is a faster alternative of unordered_map, but it does not implement the same interface (i.e. it does not support erasing and has
+// contains() instead of find())
+template<typename Key, typename Value, typename Hash = detail::DenseHashDefault<Key>, typename Eq = std::equal_to<Key>>
+class DenseHashMap
+{
+    typedef detail::DenseHashTable<Key, std::pair<Key, Value>, std::pair<const Key, Value>, detail::ItemInterfaceMap<Key, Value>, Hash, Eq> Impl;
+    Impl impl;
+
+public:
+    typedef typename Impl::const_iterator const_iterator;
+    typedef typename Impl::iterator iterator;
+
+    explicit DenseHashMap(const Key& empty_key, size_t buckets = 0)
+        : impl(empty_key, buckets)
+    {
+    }
+
+    void clear()
+    {
+        impl.clear();
+    }
+
+    // Note: this reference is invalidated by any insert operation (i.e. operator[])
+    Value& operator[](const Key& key)
+    {
+        impl.rehash_if_full(key);
+        return impl.insert_unsafe(key)->second;
+    }
+
+    // Note: this pointer is invalidated by any insert operation (i.e. operator[])
+    const Value* find(const Key& key) const
+    {
+        const std::pair<Key, Value>* result = impl.find(key);
+
+        return result ? &result->second : NULL;
+    }
+
+    // Note: this pointer is invalidated by any insert operation (i.e. operator[])
+    Value* find(const Key& key)
+    {
+        const std::pair<Key, Value>* result = impl.find(key);
+
+        return result ? const_cast<Value*>(&result->second) : NULL;
+    }
+
+    bool contains(const Key& key) const
+    {
+        return impl.find(key) != 0;
+    }
+
+    std::pair<Value&, bool> try_insert(const Key& key, const Value& value)
+    {
+        impl.rehash_if_full(key);
+
+        size_t before = impl.size();
+        std::pair<Key, Value>* slot = impl.insert_unsafe(key);
+
+        // Value is fresh if container count has increased
+        bool fresh = impl.size() > before;
+
+        if (fresh)
+            slot->second = value;
+
+        return std::make_pair(std::ref(slot->second), fresh);
+    }
+
+    size_t size() const
+    {
+        return impl.size();
+    }
+
+    bool empty() const
+    {
+        return impl.size() == 0;
+    }
+
+    const_iterator begin() const
+    {
+        return impl.begin();
+    }
+
+    const_iterator end() const
+    {
+        return impl.end();
+    }
+
+    iterator begin()
+    {
+        return impl.begin();
+    }
+
+    iterator end()
+    {
+        return impl.end();
+    }
+};
+
+} // namespace Luau

--- a/lib/luau/Common/include/Luau/ExperimentalFlags.h
+++ b/lib/luau/Common/include/Luau/ExperimentalFlags.h
@@ -1,0 +1,29 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include <string.h>
+
+namespace Luau
+{
+
+inline bool isFlagExperimental(const char* flag)
+{
+    // Flags in this list are disabled by default in various command-line tools. They may have behavior that is not fully final,
+    // or critical bugs that are found after the code has been submitted.
+    static const char* const kList[] = {
+        "LuauInstantiateInSubtyping",  // requires some fixes to lua-apps code
+        "LuauTinyControlFlowAnalysis", // waiting for updates to packages depended by internal builtin plugins
+        "LuauFixIndexerSubtypingOrdering", // requires some small fixes to lua-apps code since this fixes a false negative
+        "LuauUpdatedRequireByStringSemantics", // requires some small fixes to fully implement some proposed changes
+        // makes sure we always have at least one entry
+        nullptr,
+    };
+
+    for (const char* item : kList)
+        if (item && strcmp(item, flag) == 0)
+            return true;
+
+    return false;
+}
+
+} // namespace Luau

--- a/lib/luau/Compiler/include/Luau/BytecodeBuilder.h
+++ b/lib/luau/Compiler/include/Luau/BytecodeBuilder.h
@@ -1,0 +1,292 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Bytecode.h"
+#include "Luau/DenseHash.h"
+#include "Luau/StringUtils.h"
+
+#include <string>
+
+namespace Luau
+{
+
+class BytecodeEncoder
+{
+public:
+    virtual ~BytecodeEncoder() {}
+
+    virtual void encode(uint32_t* data, size_t count) = 0;
+};
+
+class BytecodeBuilder
+{
+public:
+    // BytecodeBuilder does *not* copy the data passed via StringRef; instead, it keeps the ref around until finalize()
+    // Please be careful with the lifetime of the data that's being passed because of this.
+    // The safe and correct pattern is to only build StringRefs out of pieces of AST (AstName or AstArray<>) that are backed by AstAllocator.
+    // Note that you must finalize() the builder before the Allocator backing the Ast is destroyed.
+    struct StringRef
+    {
+        // To construct a StringRef, use sref() from Compiler.cpp.
+        const char* data = nullptr;
+        size_t length = 0;
+
+        bool operator==(const StringRef& other) const;
+    };
+
+    struct TableShape
+    {
+        static const unsigned int kMaxLength = 32;
+
+        int32_t keys[kMaxLength];
+        unsigned int length = 0;
+
+        bool operator==(const TableShape& other) const;
+    };
+
+    BytecodeBuilder(BytecodeEncoder* encoder = 0);
+
+    uint32_t beginFunction(uint8_t numparams, bool isvararg = false);
+    void endFunction(uint8_t maxstacksize, uint8_t numupvalues, uint8_t flags = 0);
+
+    void setMainFunction(uint32_t fid);
+
+    int32_t addConstantNil();
+    int32_t addConstantBoolean(bool value);
+    int32_t addConstantNumber(double value);
+    int32_t addConstantVector(float x, float y, float z, float w);
+    int32_t addConstantString(StringRef value);
+    int32_t addImport(uint32_t iid);
+    int32_t addConstantTable(const TableShape& shape);
+    int32_t addConstantClosure(uint32_t fid);
+
+    int16_t addChildFunction(uint32_t fid);
+
+    void emitABC(LuauOpcode op, uint8_t a, uint8_t b, uint8_t c);
+    void emitAD(LuauOpcode op, uint8_t a, int16_t d);
+    void emitE(LuauOpcode op, int32_t e);
+    void emitAux(uint32_t aux);
+
+    size_t emitLabel();
+
+    [[nodiscard]] bool patchJumpD(size_t jumpLabel, size_t targetLabel);
+    [[nodiscard]] bool patchSkipC(size_t jumpLabel, size_t targetLabel);
+
+    void foldJumps();
+    void expandJumps();
+
+    void setFunctionTypeInfo(std::string value);
+
+    void setDebugFunctionName(StringRef name);
+    void setDebugFunctionLineDefined(int line);
+    void setDebugLine(int line);
+    void pushDebugLocal(StringRef name, uint8_t reg, uint32_t startpc, uint32_t endpc);
+    void pushDebugUpval(StringRef name);
+
+    size_t getInstructionCount() const;
+    size_t getTotalInstructionCount() const;
+    uint32_t getDebugPC() const;
+
+    void addDebugRemark(const char* format, ...) LUAU_PRINTF_ATTR(2, 3);
+
+    void finalize();
+
+    enum DumpFlags
+    {
+        Dump_Code = 1 << 0,
+        Dump_Lines = 1 << 1,
+        Dump_Source = 1 << 2,
+        Dump_Locals = 1 << 3,
+        Dump_Remarks = 1 << 4,
+    };
+
+    void setDumpFlags(uint32_t flags)
+    {
+        dumpFlags = flags;
+        dumpFunctionPtr = &BytecodeBuilder::dumpCurrentFunction;
+    }
+
+    void setDumpSource(const std::string& source);
+
+    bool needsDebugRemarks() const
+    {
+        return (dumpFlags & Dump_Remarks) != 0;
+    }
+
+    const std::string& getBytecode() const
+    {
+        LUAU_ASSERT(!bytecode.empty()); // did you forget to call finalize?
+        return bytecode;
+    }
+
+    std::string dumpFunction(uint32_t id) const;
+    std::string dumpEverything() const;
+    std::string dumpSourceRemarks() const;
+    std::string dumpTypeInfo() const;
+
+    void annotateInstruction(std::string& result, uint32_t fid, uint32_t instpos) const;
+
+    static uint32_t getImportId(int32_t id0);
+    static uint32_t getImportId(int32_t id0, int32_t id1);
+    static uint32_t getImportId(int32_t id0, int32_t id1, int32_t id2);
+
+    static int decomposeImportId(uint32_t ids, int32_t& id0, int32_t& id1, int32_t& id2);
+
+    static uint32_t getStringHash(StringRef key);
+
+    static std::string getError(const std::string& message);
+
+    static uint8_t getVersion();
+    static uint8_t getTypeEncodingVersion();
+
+private:
+    struct Constant
+    {
+        enum Type
+        {
+            Type_Nil,
+            Type_Boolean,
+            Type_Number,
+            Type_Vector,
+            Type_String,
+            Type_Import,
+            Type_Table,
+            Type_Closure,
+        };
+
+        Type type;
+        union
+        {
+            bool valueBoolean;
+            double valueNumber;
+            float valueVector[4];
+            unsigned int valueString; // index into string table
+            uint32_t valueImport;     // 10-10-10-2 encoded import id
+            uint32_t valueTable;      // index into tableShapes[]
+            uint32_t valueClosure;    // index of function in global list
+        };
+    };
+
+    struct ConstantKey
+    {
+        Constant::Type type;
+        // Note: this stores value* from Constant; when type is Type_Number, this stores the same bits as double does but in uint64_t.
+        // For Type_Vector, x and y are stored in 'value' and z and w are stored in 'extra'.
+        uint64_t value;
+        uint64_t extra = 0;
+
+        bool operator==(const ConstantKey& key) const
+        {
+            return type == key.type && value == key.value && extra == key.extra;
+        }
+    };
+
+    struct Function
+    {
+        std::string data;
+
+        uint8_t maxstacksize = 0;
+        uint8_t numparams = 0;
+        uint8_t numupvalues = 0;
+        bool isvararg = false;
+
+        unsigned int debugname = 0;
+        int debuglinedefined = 0;
+
+        std::string dump;
+        std::string dumpname;
+        std::vector<int> dumpinstoffs;
+        std::string typeinfo;
+    };
+
+    struct DebugLocal
+    {
+        unsigned int name;
+
+        uint8_t reg;
+        uint32_t startpc;
+        uint32_t endpc;
+    };
+
+    struct DebugUpval
+    {
+        unsigned int name;
+    };
+
+    struct Jump
+    {
+        uint32_t source;
+        uint32_t target;
+    };
+
+    struct StringRefHash
+    {
+        size_t operator()(const StringRef& v) const;
+    };
+
+    struct ConstantKeyHash
+    {
+        size_t operator()(const ConstantKey& key) const;
+    };
+
+    struct TableShapeHash
+    {
+        size_t operator()(const TableShape& v) const;
+    };
+
+    std::vector<Function> functions;
+    uint32_t currentFunction = ~0u;
+    uint32_t mainFunction = ~0u;
+
+    size_t totalInstructionCount = 0;
+    std::vector<uint32_t> insns;
+    std::vector<int> lines;
+    std::vector<Constant> constants;
+    std::vector<uint32_t> protos;
+    std::vector<Jump> jumps;
+
+    std::vector<TableShape> tableShapes;
+
+    bool hasLongJumps = false;
+
+    DenseHashMap<ConstantKey, int32_t, ConstantKeyHash> constantMap;
+    DenseHashMap<TableShape, int32_t, TableShapeHash> tableShapeMap;
+    DenseHashMap<uint32_t, int16_t> protoMap;
+
+    int debugLine = 0;
+
+    std::vector<DebugLocal> debugLocals;
+    std::vector<DebugUpval> debugUpvals;
+
+    DenseHashMap<StringRef, unsigned int, StringRefHash> stringTable;
+    std::vector<StringRef> debugStrings;
+
+    std::vector<std::pair<uint32_t, uint32_t>> debugRemarks;
+    std::string debugRemarkBuffer;
+
+    BytecodeEncoder* encoder = nullptr;
+    std::string bytecode;
+
+    uint32_t dumpFlags = 0;
+    std::vector<std::string> dumpSource;
+    std::vector<std::pair<int, std::string>> dumpRemarks;
+
+    std::string (BytecodeBuilder::*dumpFunctionPtr)(std::vector<int>&) const = nullptr;
+
+    void validate() const;
+    void validateInstructions() const;
+    void validateVariadic() const;
+
+    std::string dumpCurrentFunction(std::vector<int>& dumpinstoffs) const;
+    void dumpConstant(std::string& result, int k) const;
+    void dumpInstruction(const uint32_t* opcode, std::string& output, int targetLabel) const;
+
+    void writeFunction(std::string& ss, uint32_t id, uint8_t flags) const;
+    void writeLineInfo(std::string& ss) const;
+    void writeStringTable(std::string& ss) const;
+
+    int32_t addConstant(const ConstantKey& key, const Constant& value);
+    unsigned int addStringTableEntry(StringRef value);
+};
+
+} // namespace Luau

--- a/lib/luau/Compiler/include/Luau/Compiler.h
+++ b/lib/luau/Compiler/include/Luau/Compiler.h
@@ -1,0 +1,71 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/ParseOptions.h"
+#include "Luau/Location.h"
+#include "Luau/StringUtils.h"
+#include "Luau/Common.h"
+
+namespace Luau
+{
+class AstNameTable;
+struct ParseResult;
+class BytecodeBuilder;
+class BytecodeEncoder;
+
+// Note: this structure is duplicated in luacode.h, don't forget to change these in sync!
+struct CompileOptions
+{
+    // 0 - no optimization
+    // 1 - baseline optimization level that doesn't prevent debuggability
+    // 2 - includes optimizations that harm debuggability such as inlining
+    int optimizationLevel = 1;
+
+    // 0 - no debugging support
+    // 1 - line info & function names only; sufficient for backtraces
+    // 2 - full debug info with local & upvalue names; necessary for debugger
+    int debugLevel = 1;
+
+    // 0 - no code coverage support
+    // 1 - statement coverage
+    // 2 - statement and expression coverage (verbose)
+    int coverageLevel = 0;
+
+    // global builtin to construct vectors; disabled by default
+    const char* vectorLib = nullptr;
+    const char* vectorCtor = nullptr;
+
+    // vector type name for type tables; disabled by default
+    const char* vectorType = nullptr;
+
+    // null-terminated array of globals that are mutable; disables the import optimization for fields accessed through these
+    const char* const* mutableGlobals = nullptr;
+};
+
+class CompileError : public std::exception
+{
+public:
+    CompileError(const Location& location, const std::string& message);
+
+    virtual ~CompileError() throw();
+
+    virtual const char* what() const throw();
+
+    const Location& getLocation() const;
+
+    static LUAU_NORETURN void raise(const Location& location, const char* format, ...) LUAU_PRINTF_ATTR(2, 3);
+
+private:
+    Location location;
+    std::string message;
+};
+
+// compiles bytecode into bytecode builder using either a pre-parsed AST or parsing it from source; throws on errors
+void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, const AstNameTable& names, const CompileOptions& options = {});
+void compileOrThrow(BytecodeBuilder& bytecode, const std::string& source, const CompileOptions& options = {}, const ParseOptions& parseOptions = {});
+
+// compiles bytecode into a bytecode blob, that either contains the valid bytecode or an encoded error that luau_load can decode
+std::string compile(
+    const std::string& source, const CompileOptions& options = {}, const ParseOptions& parseOptions = {}, BytecodeEncoder* encoder = nullptr);
+
+} // namespace Luau

--- a/lib/luau/Compiler/include/luacode.h
+++ b/lib/luau/Compiler/include/luacode.h
@@ -1,0 +1,42 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include <stddef.h>
+
+// Can be used to reconfigure visibility/exports for public APIs
+#ifndef LUACODE_API
+#define LUACODE_API extern
+#endif
+
+typedef struct lua_CompileOptions lua_CompileOptions;
+
+struct lua_CompileOptions
+{
+    // 0 - no optimization
+    // 1 - baseline optimization level that doesn't prevent debuggability
+    // 2 - includes optimizations that harm debuggability such as inlining
+    int optimizationLevel; // default=1
+
+    // 0 - no debugging support
+    // 1 - line info & function names only; sufficient for backtraces
+    // 2 - full debug info with local & upvalue names; necessary for debugger
+    int debugLevel; // default=1
+
+    // 0 - no code coverage support
+    // 1 - statement coverage
+    // 2 - statement and expression coverage (verbose)
+    int coverageLevel; // default=0
+
+    // global builtin to construct vectors; disabled by default
+    const char* vectorLib;
+    const char* vectorCtor;
+
+    // vector type name for type tables; disabled by default
+    const char* vectorType;
+
+    // null-terminated array of globals that are mutable; disables the import optimization for fields accessed through these
+    const char* const* mutableGlobals;
+};
+
+// compile source to bytecode; when source compilation fails, the resulting bytecode contains the encoded error. use free() to destroy
+LUACODE_API char* luau_compile(const char* source, size_t size, lua_CompileOptions* options, size_t* outsize);

--- a/lib/luau/Compiler/src/BuiltinFolding.cpp
+++ b/lib/luau/Compiler/src/BuiltinFolding.cpp
@@ -1,0 +1,502 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "BuiltinFolding.h"
+
+#include "Luau/Bytecode.h"
+
+#include <math.h>
+
+LUAU_FASTFLAGVARIABLE(LuauVectorLiterals, false)
+
+namespace Luau
+{
+namespace Compile
+{
+
+const double kPi = 3.14159265358979323846;
+const double kRadDeg = kPi / 180.0;
+
+static Constant cvar()
+{
+    return Constant();
+}
+
+static Constant cbool(bool v)
+{
+    Constant res = {Constant::Type_Boolean};
+    res.valueBoolean = v;
+    return res;
+}
+
+static Constant cnum(double v)
+{
+    Constant res = {Constant::Type_Number};
+    res.valueNumber = v;
+    return res;
+}
+
+static Constant cvector(double x, double y, double z, double w)
+{
+    Constant res = {Constant::Type_Vector};
+    res.valueVector[0] = (float)x;
+    res.valueVector[1] = (float)y;
+    res.valueVector[2] = (float)z;
+    res.valueVector[3] = (float)w;
+    return res;
+}
+
+static Constant cstring(const char* v)
+{
+    Constant res = {Constant::Type_String};
+    res.stringLength = unsigned(strlen(v));
+    res.valueString = v;
+    return res;
+}
+
+static Constant ctype(const Constant& c)
+{
+    LUAU_ASSERT(c.type != Constant::Type_Unknown);
+
+    switch (c.type)
+    {
+    case Constant::Type_Nil:
+        return cstring("nil");
+
+    case Constant::Type_Boolean:
+        return cstring("boolean");
+
+    case Constant::Type_Number:
+        return cstring("number");
+
+    case Constant::Type_Vector:
+        return cstring("vector");
+
+    case Constant::Type_String:
+        return cstring("string");
+
+    default:
+        LUAU_ASSERT(!"Unsupported constant type");
+        return cvar();
+    }
+}
+
+static uint32_t bit32(double v)
+{
+    // convert through signed 64-bit integer to match runtime behavior and gracefully truncate negative integers
+    return uint32_t(int64_t(v));
+}
+
+Constant foldBuiltin(int bfid, const Constant* args, size_t count)
+{
+    switch (bfid)
+    {
+    case LBF_MATH_ABS:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(fabs(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_ACOS:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(acos(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_ASIN:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(asin(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_ATAN2:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+            return cnum(atan2(args[0].valueNumber, args[1].valueNumber));
+        break;
+
+    case LBF_MATH_ATAN:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(atan(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_CEIL:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(ceil(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_COSH:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(cosh(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_COS:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(cos(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_DEG:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(args[0].valueNumber / kRadDeg);
+        break;
+
+    case LBF_MATH_EXP:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(exp(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_FLOOR:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(floor(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_FMOD:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+            return cnum(fmod(args[0].valueNumber, args[1].valueNumber));
+        break;
+
+        // Note: FREXP isn't folded since it returns multiple values
+
+    case LBF_MATH_LDEXP:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+            return cnum(ldexp(args[0].valueNumber, int(args[1].valueNumber)));
+        break;
+
+    case LBF_MATH_LOG10:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(log10(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_LOG:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(log(args[0].valueNumber));
+        else if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            if (args[1].valueNumber == 2.0)
+                return cnum(log2(args[0].valueNumber));
+            else if (args[1].valueNumber == 10.0)
+                return cnum(log10(args[0].valueNumber));
+            else
+                return cnum(log(args[0].valueNumber) / log(args[1].valueNumber));
+        }
+        break;
+
+    case LBF_MATH_MAX:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            double r = args[0].valueNumber;
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                double a = args[i].valueNumber;
+
+                r = (a > r) ? a : r;
+            }
+
+            return cnum(r);
+        }
+        break;
+
+    case LBF_MATH_MIN:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            double r = args[0].valueNumber;
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                double a = args[i].valueNumber;
+
+                r = (a < r) ? a : r;
+            }
+
+            return cnum(r);
+        }
+        break;
+
+        // Note: MODF isn't folded since it returns multiple values
+
+    case LBF_MATH_POW:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+            return cnum(pow(args[0].valueNumber, args[1].valueNumber));
+        break;
+
+    case LBF_MATH_RAD:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(args[0].valueNumber * kRadDeg);
+        break;
+
+    case LBF_MATH_SINH:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(sinh(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_SIN:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(sin(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_SQRT:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(sqrt(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_TANH:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(tanh(args[0].valueNumber));
+        break;
+
+    case LBF_MATH_TAN:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(tan(args[0].valueNumber));
+        break;
+
+    case LBF_BIT32_ARSHIFT:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int s = int(args[1].valueNumber);
+
+            if (unsigned(s) < 32)
+                return cnum(double(uint32_t(int32_t(u) >> s)));
+        }
+        break;
+
+    case LBF_BIT32_BAND:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            uint32_t r = bit32(args[0].valueNumber);
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                r &= bit32(args[i].valueNumber);
+            }
+
+            return cnum(double(r));
+        }
+        break;
+
+    case LBF_BIT32_BNOT:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(double(uint32_t(~bit32(args[0].valueNumber))));
+        break;
+
+    case LBF_BIT32_BOR:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            uint32_t r = bit32(args[0].valueNumber);
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                r |= bit32(args[i].valueNumber);
+            }
+
+            return cnum(double(r));
+        }
+        break;
+
+    case LBF_BIT32_BXOR:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            uint32_t r = bit32(args[0].valueNumber);
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                r ^= bit32(args[i].valueNumber);
+            }
+
+            return cnum(double(r));
+        }
+        break;
+
+    case LBF_BIT32_BTEST:
+        if (count >= 1 && args[0].type == Constant::Type_Number)
+        {
+            uint32_t r = bit32(args[0].valueNumber);
+
+            for (size_t i = 1; i < count; ++i)
+            {
+                if (args[i].type != Constant::Type_Number)
+                    return cvar();
+
+                r &= bit32(args[i].valueNumber);
+            }
+
+            return cbool(r != 0);
+        }
+        break;
+
+    case LBF_BIT32_EXTRACT:
+        if (count >= 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number &&
+            (count == 2 || args[2].type == Constant::Type_Number))
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int f = int(args[1].valueNumber);
+            int w = count == 2 ? 1 : int(args[2].valueNumber);
+
+            if (f >= 0 && w > 0 && f + w <= 32)
+            {
+                uint32_t m = ~(0xfffffffeu << (w - 1));
+
+                return cnum(double((u >> f) & m));
+            }
+        }
+        break;
+
+    case LBF_BIT32_LROTATE:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int s = int(args[1].valueNumber);
+
+            return cnum(double((u << (s & 31)) | (u >> ((32 - s) & 31))));
+        }
+        break;
+
+    case LBF_BIT32_LSHIFT:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int s = int(args[1].valueNumber);
+
+            if (unsigned(s) < 32)
+                return cnum(double(u << s));
+        }
+        break;
+
+    case LBF_BIT32_REPLACE:
+        if (count >= 3 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number && args[2].type == Constant::Type_Number &&
+            (count == 3 || args[3].type == Constant::Type_Number))
+        {
+            uint32_t n = bit32(args[0].valueNumber);
+            uint32_t v = bit32(args[1].valueNumber);
+            int f = int(args[2].valueNumber);
+            int w = count == 3 ? 1 : int(args[3].valueNumber);
+
+            if (f >= 0 && w > 0 && f + w <= 32)
+            {
+                uint32_t m = ~(0xfffffffeu << (w - 1));
+
+                return cnum(double((n & ~(m << f)) | ((v & m) << f)));
+            }
+        }
+        break;
+
+    case LBF_BIT32_RROTATE:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int s = int(args[1].valueNumber);
+
+            return cnum(double((u >> (s & 31)) | (u << ((32 - s) & 31))));
+        }
+        break;
+
+    case LBF_BIT32_RSHIFT:
+        if (count == 2 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number)
+        {
+            uint32_t u = bit32(args[0].valueNumber);
+            int s = int(args[1].valueNumber);
+
+            if (unsigned(s) < 32)
+                return cnum(double(u >> s));
+        }
+        break;
+
+    case LBF_TYPE:
+        if (count == 1 && args[0].type != Constant::Type_Unknown)
+            return ctype(args[0]);
+        break;
+
+    case LBF_STRING_BYTE:
+        if (count == 1 && args[0].type == Constant::Type_String)
+        {
+            if (args[0].stringLength > 0)
+                return cnum(double(uint8_t(args[0].valueString[0])));
+        }
+        else if (count == 2 && args[0].type == Constant::Type_String && args[1].type == Constant::Type_Number)
+        {
+            int i = int(args[1].valueNumber);
+
+            if (i > 0 && unsigned(i) <= args[0].stringLength)
+                return cnum(double(uint8_t(args[0].valueString[i - 1])));
+        }
+        break;
+
+    case LBF_STRING_LEN:
+        if (count == 1 && args[0].type == Constant::Type_String)
+            return cnum(double(args[0].stringLength));
+        break;
+
+    case LBF_TYPEOF:
+        if (count == 1 && args[0].type != Constant::Type_Unknown)
+            return ctype(args[0]);
+        break;
+
+    case LBF_MATH_CLAMP:
+        if (count == 3 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number && args[2].type == Constant::Type_Number)
+        {
+            double min = args[1].valueNumber;
+            double max = args[2].valueNumber;
+
+            if (min <= max)
+            {
+                double v = args[0].valueNumber;
+                v = v < min ? min : v;
+                v = v > max ? max : v;
+
+                return cnum(v);
+            }
+        }
+        break;
+
+    case LBF_MATH_SIGN:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+        {
+            double v = args[0].valueNumber;
+
+            return cnum(v > 0.0 ? 1.0 : v < 0.0 ? -1.0 : 0.0);
+        }
+        break;
+
+    case LBF_MATH_ROUND:
+        if (count == 1 && args[0].type == Constant::Type_Number)
+            return cnum(round(args[0].valueNumber));
+        break;
+
+    case LBF_VECTOR:
+        if (FFlag::LuauVectorLiterals && count >= 3 && args[0].type == Constant::Type_Number && args[1].type == Constant::Type_Number &&
+            args[2].type == Constant::Type_Number)
+        {
+            if (count == 3)
+                return cvector(args[0].valueNumber, args[1].valueNumber, args[2].valueNumber, 0.0);
+            else if (count == 4 && args[3].type == Constant::Type_Number)
+                return cvector(args[0].valueNumber, args[1].valueNumber, args[2].valueNumber, args[3].valueNumber);
+        }
+        break;
+    }
+
+    return cvar();
+}
+
+Constant foldBuiltinMath(AstName index)
+{
+    if (index == "pi")
+        return cnum(kPi);
+
+    if (index == "huge")
+        return cnum(HUGE_VAL);
+
+    return cvar();
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/BuiltinFolding.h
+++ b/lib/luau/Compiler/src/BuiltinFolding.h
@@ -1,0 +1,15 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "ConstantFolding.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+Constant foldBuiltin(int bfid, const Constant* args, size_t count);
+Constant foldBuiltinMath(AstName index);
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/Builtins.cpp
+++ b/lib/luau/Compiler/src/Builtins.cpp
@@ -1,0 +1,467 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Builtins.h"
+
+#include "Luau/Bytecode.h"
+#include "Luau/Compiler.h"
+
+LUAU_FASTFLAGVARIABLE(LuauBit32ByteswapBuiltin, false)
+
+LUAU_FASTFLAGVARIABLE(LuauBufferBuiltins, false)
+
+namespace Luau
+{
+namespace Compile
+{
+
+Builtin getBuiltin(AstExpr* node, const DenseHashMap<AstName, Global>& globals, const DenseHashMap<AstLocal*, Variable>& variables)
+{
+    if (AstExprLocal* expr = node->as<AstExprLocal>())
+    {
+        const Variable* v = variables.find(expr->local);
+
+        return v && !v->written && v->init ? getBuiltin(v->init, globals, variables) : Builtin();
+    }
+    else if (AstExprIndexName* expr = node->as<AstExprIndexName>())
+    {
+        if (AstExprGlobal* object = expr->expr->as<AstExprGlobal>())
+        {
+            return getGlobalState(globals, object->name) == Global::Default ? Builtin{object->name, expr->index} : Builtin();
+        }
+        else
+        {
+            return Builtin();
+        }
+    }
+    else if (AstExprGlobal* expr = node->as<AstExprGlobal>())
+    {
+        return getGlobalState(globals, expr->name) == Global::Default ? Builtin{AstName(), expr->name} : Builtin();
+    }
+    else
+    {
+        return Builtin();
+    }
+}
+
+static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& options)
+{
+    if (builtin.isGlobal("assert"))
+        return LBF_ASSERT;
+
+    if (builtin.isGlobal("type"))
+        return LBF_TYPE;
+
+    if (builtin.isGlobal("typeof"))
+        return LBF_TYPEOF;
+
+    if (builtin.isGlobal("rawset"))
+        return LBF_RAWSET;
+    if (builtin.isGlobal("rawget"))
+        return LBF_RAWGET;
+    if (builtin.isGlobal("rawequal"))
+        return LBF_RAWEQUAL;
+    if (builtin.isGlobal("rawlen"))
+        return LBF_RAWLEN;
+
+    if (builtin.isGlobal("unpack"))
+        return LBF_TABLE_UNPACK;
+
+    if (builtin.isGlobal("select"))
+        return LBF_SELECT_VARARG;
+
+    if (builtin.isGlobal("getmetatable"))
+        return LBF_GETMETATABLE;
+    if (builtin.isGlobal("setmetatable"))
+        return LBF_SETMETATABLE;
+
+    if (builtin.isGlobal("tonumber"))
+        return LBF_TONUMBER;
+    if (builtin.isGlobal("tostring"))
+        return LBF_TOSTRING;
+
+    if (builtin.object == "math")
+    {
+        if (builtin.method == "abs")
+            return LBF_MATH_ABS;
+        if (builtin.method == "acos")
+            return LBF_MATH_ACOS;
+        if (builtin.method == "asin")
+            return LBF_MATH_ASIN;
+        if (builtin.method == "atan2")
+            return LBF_MATH_ATAN2;
+        if (builtin.method == "atan")
+            return LBF_MATH_ATAN;
+        if (builtin.method == "ceil")
+            return LBF_MATH_CEIL;
+        if (builtin.method == "cosh")
+            return LBF_MATH_COSH;
+        if (builtin.method == "cos")
+            return LBF_MATH_COS;
+        if (builtin.method == "deg")
+            return LBF_MATH_DEG;
+        if (builtin.method == "exp")
+            return LBF_MATH_EXP;
+        if (builtin.method == "floor")
+            return LBF_MATH_FLOOR;
+        if (builtin.method == "fmod")
+            return LBF_MATH_FMOD;
+        if (builtin.method == "frexp")
+            return LBF_MATH_FREXP;
+        if (builtin.method == "ldexp")
+            return LBF_MATH_LDEXP;
+        if (builtin.method == "log10")
+            return LBF_MATH_LOG10;
+        if (builtin.method == "log")
+            return LBF_MATH_LOG;
+        if (builtin.method == "max")
+            return LBF_MATH_MAX;
+        if (builtin.method == "min")
+            return LBF_MATH_MIN;
+        if (builtin.method == "modf")
+            return LBF_MATH_MODF;
+        if (builtin.method == "pow")
+            return LBF_MATH_POW;
+        if (builtin.method == "rad")
+            return LBF_MATH_RAD;
+        if (builtin.method == "sinh")
+            return LBF_MATH_SINH;
+        if (builtin.method == "sin")
+            return LBF_MATH_SIN;
+        if (builtin.method == "sqrt")
+            return LBF_MATH_SQRT;
+        if (builtin.method == "tanh")
+            return LBF_MATH_TANH;
+        if (builtin.method == "tan")
+            return LBF_MATH_TAN;
+        if (builtin.method == "clamp")
+            return LBF_MATH_CLAMP;
+        if (builtin.method == "sign")
+            return LBF_MATH_SIGN;
+        if (builtin.method == "round")
+            return LBF_MATH_ROUND;
+    }
+
+    if (builtin.object == "bit32")
+    {
+        if (builtin.method == "arshift")
+            return LBF_BIT32_ARSHIFT;
+        if (builtin.method == "band")
+            return LBF_BIT32_BAND;
+        if (builtin.method == "bnot")
+            return LBF_BIT32_BNOT;
+        if (builtin.method == "bor")
+            return LBF_BIT32_BOR;
+        if (builtin.method == "bxor")
+            return LBF_BIT32_BXOR;
+        if (builtin.method == "btest")
+            return LBF_BIT32_BTEST;
+        if (builtin.method == "extract")
+            return LBF_BIT32_EXTRACT;
+        if (builtin.method == "lrotate")
+            return LBF_BIT32_LROTATE;
+        if (builtin.method == "lshift")
+            return LBF_BIT32_LSHIFT;
+        if (builtin.method == "replace")
+            return LBF_BIT32_REPLACE;
+        if (builtin.method == "rrotate")
+            return LBF_BIT32_RROTATE;
+        if (builtin.method == "rshift")
+            return LBF_BIT32_RSHIFT;
+        if (builtin.method == "countlz")
+            return LBF_BIT32_COUNTLZ;
+        if (builtin.method == "countrz")
+            return LBF_BIT32_COUNTRZ;
+        if (FFlag::LuauBit32ByteswapBuiltin && builtin.method == "byteswap")
+            return LBF_BIT32_BYTESWAP;
+    }
+
+    if (builtin.object == "string")
+    {
+        if (builtin.method == "byte")
+            return LBF_STRING_BYTE;
+        if (builtin.method == "char")
+            return LBF_STRING_CHAR;
+        if (builtin.method == "len")
+            return LBF_STRING_LEN;
+        if (builtin.method == "sub")
+            return LBF_STRING_SUB;
+    }
+
+    if (builtin.object == "table")
+    {
+        if (builtin.method == "insert")
+            return LBF_TABLE_INSERT;
+        if (builtin.method == "unpack")
+            return LBF_TABLE_UNPACK;
+    }
+
+    if (FFlag::LuauBufferBuiltins && builtin.object == "buffer")
+    {
+        if (builtin.method == "readi8")
+            return LBF_BUFFER_READI8;
+        if (builtin.method == "readu8")
+            return LBF_BUFFER_READU8;
+        if (builtin.method == "writei8" || builtin.method == "writeu8")
+            return LBF_BUFFER_WRITEU8;
+        if (builtin.method == "readi16")
+            return LBF_BUFFER_READI16;
+        if (builtin.method == "readu16")
+            return LBF_BUFFER_READU16;
+        if (builtin.method == "writei16" || builtin.method == "writeu16")
+            return LBF_BUFFER_WRITEU16;
+        if (builtin.method == "readi32")
+            return LBF_BUFFER_READI32;
+        if (builtin.method == "readu32")
+            return LBF_BUFFER_READU32;
+        if (builtin.method == "writei32" || builtin.method == "writeu32")
+            return LBF_BUFFER_WRITEU32;
+        if (builtin.method == "readf32")
+            return LBF_BUFFER_READF32;
+        if (builtin.method == "writef32")
+            return LBF_BUFFER_WRITEF32;
+        if (builtin.method == "readf64")
+            return LBF_BUFFER_READF64;
+        if (builtin.method == "writef64")
+            return LBF_BUFFER_WRITEF64;
+    }
+
+    if (options.vectorCtor)
+    {
+        if (options.vectorLib)
+        {
+            if (builtin.isMethod(options.vectorLib, options.vectorCtor))
+                return LBF_VECTOR;
+        }
+        else
+        {
+            if (builtin.isGlobal(options.vectorCtor))
+                return LBF_VECTOR;
+        }
+    }
+
+    return -1;
+}
+
+struct BuiltinVisitor : AstVisitor
+{
+    DenseHashMap<AstExprCall*, int>& result;
+
+    const DenseHashMap<AstName, Global>& globals;
+    const DenseHashMap<AstLocal*, Variable>& variables;
+
+    const CompileOptions& options;
+
+    BuiltinVisitor(DenseHashMap<AstExprCall*, int>& result, const DenseHashMap<AstName, Global>& globals,
+        const DenseHashMap<AstLocal*, Variable>& variables, const CompileOptions& options)
+        : result(result)
+        , globals(globals)
+        , variables(variables)
+        , options(options)
+    {
+    }
+
+    bool visit(AstExprCall* node) override
+    {
+        Builtin builtin = node->self ? Builtin() : getBuiltin(node->func, globals, variables);
+        if (builtin.empty())
+            return true;
+
+        int bfid = getBuiltinFunctionId(builtin, options);
+
+        // getBuiltinFunctionId optimistically assumes all select() calls are builtin but actually the second argument must be a vararg
+        if (bfid == LBF_SELECT_VARARG && !(node->args.size == 2 && node->args.data[1]->is<AstExprVarargs>()))
+            bfid = -1;
+
+        if (bfid >= 0)
+            result[node] = bfid;
+
+        return true; // propagate to nested calls
+    }
+};
+
+void analyzeBuiltins(DenseHashMap<AstExprCall*, int>& result, const DenseHashMap<AstName, Global>& globals,
+    const DenseHashMap<AstLocal*, Variable>& variables, const CompileOptions& options, AstNode* root)
+{
+    BuiltinVisitor visitor{result, globals, variables, options};
+    root->visit(&visitor);
+}
+
+BuiltinInfo getBuiltinInfo(int bfid)
+{
+    switch (LuauBuiltinFunction(bfid))
+    {
+    case LBF_NONE:
+        return {-1, -1};
+
+    case LBF_ASSERT:
+        return {-1, -1}; // assert() returns all values when first value is truthy
+
+    case LBF_MATH_ABS:
+    case LBF_MATH_ACOS:
+    case LBF_MATH_ASIN:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_ATAN2:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_ATAN:
+    case LBF_MATH_CEIL:
+    case LBF_MATH_COSH:
+    case LBF_MATH_COS:
+    case LBF_MATH_DEG:
+    case LBF_MATH_EXP:
+    case LBF_MATH_FLOOR:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_FMOD:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_FREXP:
+        return {1, 2, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_LDEXP:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_LOG10:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_LOG:
+        return {-1, 1}; // 1 or 2 parameters
+
+    case LBF_MATH_MAX:
+    case LBF_MATH_MIN:
+        return {-1, 1}; // variadic
+
+    case LBF_MATH_MODF:
+        return {1, 2, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_POW:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_RAD:
+    case LBF_MATH_SINH:
+    case LBF_MATH_SIN:
+    case LBF_MATH_SQRT:
+    case LBF_MATH_TANH:
+    case LBF_MATH_TAN:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BIT32_ARSHIFT:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BIT32_BAND:
+        return {-1, 1}; // variadic
+
+    case LBF_BIT32_BNOT:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BIT32_BOR:
+    case LBF_BIT32_BXOR:
+    case LBF_BIT32_BTEST:
+        return {-1, 1}; // variadic
+
+    case LBF_BIT32_EXTRACT:
+        return {-1, 1}; // 2 or 3 parameters
+
+    case LBF_BIT32_LROTATE:
+    case LBF_BIT32_LSHIFT:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BIT32_REPLACE:
+        return {-1, 1}; // 3 or 4 parameters
+
+    case LBF_BIT32_RROTATE:
+    case LBF_BIT32_RSHIFT:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_TYPE:
+        return {1, 1};
+
+    case LBF_STRING_BYTE:
+        return {-1, -1}; // 1, 2 or 3 parameters
+
+    case LBF_STRING_CHAR:
+        return {-1, 1}; // variadic
+
+    case LBF_STRING_LEN:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_TYPEOF:
+        return {1, 1};
+
+    case LBF_STRING_SUB:
+        return {-1, 1}; // 2 or 3 parameters
+
+    case LBF_MATH_CLAMP:
+        return {3, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_MATH_SIGN:
+    case LBF_MATH_ROUND:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_RAWSET:
+        return {3, 1};
+
+    case LBF_RAWGET:
+    case LBF_RAWEQUAL:
+        return {2, 1};
+
+    case LBF_TABLE_INSERT:
+        return {-1, 0}; // 2 or 3 parameters
+
+    case LBF_TABLE_UNPACK:
+        return {-1, -1}; // 1, 2 or 3 parameters
+
+    case LBF_VECTOR:
+        return {-1, 1}; // 3 or 4 parameters in some configurations
+
+    case LBF_BIT32_COUNTLZ:
+    case LBF_BIT32_COUNTRZ:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_SELECT_VARARG:
+        return {-1, -1}; // variadic
+
+    case LBF_RAWLEN:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BIT32_EXTRACTK:
+        return {3, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_GETMETATABLE:
+        return {1, 1};
+
+    case LBF_SETMETATABLE:
+        return {2, 1};
+
+    case LBF_TONUMBER:
+        return {-1, 1}; // 1 or 2 parameters
+
+    case LBF_TOSTRING:
+        return {1, 1};
+
+    case LBF_BIT32_BYTESWAP:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BUFFER_READI8:
+    case LBF_BUFFER_READU8:
+    case LBF_BUFFER_READI16:
+    case LBF_BUFFER_READU16:
+    case LBF_BUFFER_READI32:
+    case LBF_BUFFER_READU32:
+    case LBF_BUFFER_READF32:
+    case LBF_BUFFER_READF64:
+        return {2, 1, BuiltinInfo::Flag_NoneSafe};
+
+    case LBF_BUFFER_WRITEU8:
+    case LBF_BUFFER_WRITEU16:
+    case LBF_BUFFER_WRITEU32:
+    case LBF_BUFFER_WRITEF32:
+    case LBF_BUFFER_WRITEF64:
+        return {3, 0, BuiltinInfo::Flag_NoneSafe};
+    };
+
+    LUAU_UNREACHABLE();
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/Builtins.h
+++ b/lib/luau/Compiler/src/Builtins.h
@@ -1,0 +1,60 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "ValueTracking.h"
+
+namespace Luau
+{
+struct CompileOptions;
+}
+
+namespace Luau
+{
+namespace Compile
+{
+
+struct Builtin
+{
+    AstName object;
+    AstName method;
+
+    bool empty() const
+    {
+        return object == AstName() && method == AstName();
+    }
+
+    bool isGlobal(const char* name) const
+    {
+        return object == AstName() && method == name;
+    }
+
+    bool isMethod(const char* table, const char* name) const
+    {
+        return object == table && method == name;
+    }
+};
+
+Builtin getBuiltin(AstExpr* node, const DenseHashMap<AstName, Global>& globals, const DenseHashMap<AstLocal*, Variable>& variables);
+
+void analyzeBuiltins(DenseHashMap<AstExprCall*, int>& result, const DenseHashMap<AstName, Global>& globals,
+    const DenseHashMap<AstLocal*, Variable>& variables, const CompileOptions& options, AstNode* root);
+
+struct BuiltinInfo
+{
+    enum Flags
+    {
+        // none-safe builtins are builtins that have the same behavior for arguments that are nil or none
+        // this allows the compiler to compile calls to builtins more efficiently in certain cases
+        // for example, math.abs(x()) may compile x() as if it returns one value; if it returns no values, abs() will get nil instead of none
+        Flag_NoneSafe = 1 << 0,
+    };
+
+    int params;
+    int results;
+    unsigned int flags;
+};
+
+BuiltinInfo getBuiltinInfo(int bfid);
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/BytecodeBuilder.cpp
+++ b/lib/luau/Compiler/src/BytecodeBuilder.cpp
@@ -1,0 +1,2446 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/BytecodeBuilder.h"
+
+#include "Luau/BytecodeUtils.h"
+#include "Luau/StringUtils.h"
+
+#include <algorithm>
+#include <string.h>
+
+LUAU_FASTFLAG(LuauVectorLiterals)
+LUAU_FASTFLAG(LuauCompileRevK)
+
+namespace Luau
+{
+
+static_assert(LBC_VERSION_TARGET >= LBC_VERSION_MIN && LBC_VERSION_TARGET <= LBC_VERSION_MAX, "Invalid bytecode version setup");
+static_assert(LBC_VERSION_MAX <= 127, "Bytecode version should be 7-bit so that we can extend the serialization to use varint transparently");
+
+static const uint32_t kMaxConstantCount = 1 << 23;
+static const uint32_t kMaxClosureCount = 1 << 15;
+
+static const int kMaxJumpDistance = 1 << 23;
+
+static int log2(int v)
+{
+    LUAU_ASSERT(v);
+
+    int r = 0;
+
+    while (v >= (2 << r))
+        r++;
+
+    return r;
+}
+
+static void writeByte(std::string& ss, unsigned char value)
+{
+    ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+static void writeInt(std::string& ss, int value)
+{
+    ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+static void writeFloat(std::string& ss, float value)
+{
+    ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+static void writeDouble(std::string& ss, double value)
+{
+    ss.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+static void writeVarInt(std::string& ss, unsigned int value)
+{
+    do
+    {
+        writeByte(ss, (value & 127) | ((value > 127) << 7));
+        value >>= 7;
+    } while (value);
+}
+
+inline bool isJumpD(LuauOpcode op)
+{
+    switch (op)
+    {
+    case LOP_JUMP:
+    case LOP_JUMPIF:
+    case LOP_JUMPIFNOT:
+    case LOP_JUMPIFEQ:
+    case LOP_JUMPIFLE:
+    case LOP_JUMPIFLT:
+    case LOP_JUMPIFNOTEQ:
+    case LOP_JUMPIFNOTLE:
+    case LOP_JUMPIFNOTLT:
+    case LOP_FORNPREP:
+    case LOP_FORNLOOP:
+    case LOP_FORGPREP:
+    case LOP_FORGLOOP:
+    case LOP_FORGPREP_INEXT:
+    case LOP_FORGPREP_NEXT:
+    case LOP_JUMPBACK:
+    case LOP_JUMPXEQKNIL:
+    case LOP_JUMPXEQKB:
+    case LOP_JUMPXEQKN:
+    case LOP_JUMPXEQKS:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+inline bool isSkipC(LuauOpcode op)
+{
+    switch (op)
+    {
+    case LOP_LOADB:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+inline bool isFastCall(LuauOpcode op)
+{
+    switch (op)
+    {
+    case LOP_FASTCALL:
+    case LOP_FASTCALL1:
+    case LOP_FASTCALL2:
+    case LOP_FASTCALL2K:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+static int getJumpTarget(uint32_t insn, uint32_t pc)
+{
+    LuauOpcode op = LuauOpcode(LUAU_INSN_OP(insn));
+
+    if (isJumpD(op))
+        return int(pc + LUAU_INSN_D(insn) + 1);
+    else if (isFastCall(op))
+        return int(pc + LUAU_INSN_C(insn) + 2);
+    else if (isSkipC(op) && LUAU_INSN_C(insn))
+        return int(pc + LUAU_INSN_C(insn) + 1);
+    else if (op == LOP_JUMPX)
+        return int(pc + LUAU_INSN_E(insn) + 1);
+    else
+        return -1;
+}
+
+bool BytecodeBuilder::StringRef::operator==(const StringRef& other) const
+{
+    return (data && other.data) ? (length == other.length && memcmp(data, other.data, length) == 0) : (data == other.data);
+}
+
+bool BytecodeBuilder::TableShape::operator==(const TableShape& other) const
+{
+    return length == other.length && memcmp(keys, other.keys, length * sizeof(keys[0])) == 0;
+}
+
+size_t BytecodeBuilder::StringRefHash::operator()(const StringRef& v) const
+{
+    return hashRange(v.data, v.length);
+}
+
+size_t BytecodeBuilder::ConstantKeyHash::operator()(const ConstantKey& key) const
+{
+    if (key.type == Constant::Type_Vector)
+    {
+        uint32_t i[4];
+        static_assert(sizeof(key.value) + sizeof(key.extra) == sizeof(i), "Expecting vector to have four 32-bit components");
+        memcpy(i, &key.value, sizeof(i));
+
+        // scramble bits to make sure that integer coordinates have entropy in lower bits
+        i[0] ^= i[0] >> 17;
+        i[1] ^= i[1] >> 17;
+        i[2] ^= i[2] >> 17;
+        i[3] ^= i[3] >> 17;
+
+        // Optimized Spatial Hashing for Collision Detection of Deformable Objects
+        uint32_t h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791) ^ (i[3] * 39916801);
+
+        return size_t(h);
+    }
+    else
+    {
+        // finalizer from MurmurHash64B
+        const uint32_t m = 0x5bd1e995;
+
+        uint32_t h1 = uint32_t(key.value);
+        uint32_t h2 = uint32_t(key.value >> 32) ^ (key.type * m);
+
+        h1 ^= h2 >> 18;
+        h1 *= m;
+        h2 ^= h1 >> 22;
+        h2 *= m;
+        h1 ^= h2 >> 17;
+        h1 *= m;
+        h2 ^= h1 >> 19;
+        h2 *= m;
+
+        // ... truncated to 32-bit output (normally hash is equal to (uint64_t(h1) << 32) | h2, but we only really need the lower 32-bit half)
+        return size_t(h2);
+    }
+}
+
+size_t BytecodeBuilder::TableShapeHash::operator()(const TableShape& v) const
+{
+    // FNV-1a inspired hash (note that we feed integers instead of bytes)
+    uint32_t hash = 2166136261;
+
+    for (size_t i = 0; i < v.length; ++i)
+    {
+        hash ^= v.keys[i];
+        hash *= 16777619;
+    }
+
+    return hash;
+}
+
+BytecodeBuilder::BytecodeBuilder(BytecodeEncoder* encoder)
+    : constantMap({Constant::Type_Nil, ~0ull})
+    , tableShapeMap(TableShape())
+    , protoMap(~0u)
+    , stringTable({nullptr, 0})
+    , encoder(encoder)
+{
+    LUAU_ASSERT(stringTable.find(StringRef{"", 0}) == nullptr);
+
+    // preallocate some buffers that are very likely to grow anyway; this works around std::vector's inefficient growth policy for small arrays
+    insns.reserve(32);
+    lines.reserve(32);
+    constants.reserve(16);
+    protos.reserve(16);
+    functions.reserve(8);
+}
+
+uint32_t BytecodeBuilder::beginFunction(uint8_t numparams, bool isvararg)
+{
+    LUAU_ASSERT(currentFunction == ~0u);
+
+    uint32_t id = uint32_t(functions.size());
+
+    Function func;
+    func.numparams = numparams;
+    func.isvararg = isvararg;
+
+    functions.push_back(func);
+
+    currentFunction = id;
+
+    hasLongJumps = false;
+    debugLine = 0;
+
+    return id;
+}
+
+void BytecodeBuilder::endFunction(uint8_t maxstacksize, uint8_t numupvalues, uint8_t flags)
+{
+    LUAU_ASSERT(currentFunction != ~0u);
+
+    Function& func = functions[currentFunction];
+
+    func.maxstacksize = maxstacksize;
+    func.numupvalues = numupvalues;
+
+#ifdef LUAU_ASSERTENABLED
+    validate();
+#endif
+
+    // this call is indirect to make sure we only gain link time dependency on dumpCurrentFunction when needed
+    if (dumpFunctionPtr)
+        func.dump = (this->*dumpFunctionPtr)(func.dumpinstoffs);
+
+    // very approximate: 4 bytes per instruction for code, 1 byte for debug line, and 1-2 bytes for aux data like constants plus overhead
+    func.data.reserve(32 + insns.size() * 7);
+
+    if (encoder)
+        encoder->encode(insns.data(), insns.size());
+
+    writeFunction(func.data, currentFunction, flags);
+
+    currentFunction = ~0u;
+
+    totalInstructionCount += insns.size();
+    insns.clear();
+    lines.clear();
+    constants.clear();
+    protos.clear();
+    jumps.clear();
+    tableShapes.clear();
+
+    debugLocals.clear();
+    debugUpvals.clear();
+
+    constantMap.clear();
+    tableShapeMap.clear();
+    protoMap.clear();
+
+    debugRemarks.clear();
+    debugRemarkBuffer.clear();
+}
+
+void BytecodeBuilder::setMainFunction(uint32_t fid)
+{
+    LUAU_ASSERT(fid < functions.size());
+
+    mainFunction = fid;
+}
+
+int32_t BytecodeBuilder::addConstant(const ConstantKey& key, const Constant& value)
+{
+    if (int32_t* cache = constantMap.find(key))
+        return *cache;
+
+    uint32_t id = uint32_t(constants.size());
+
+    if (id >= kMaxConstantCount)
+        return -1;
+
+    constantMap[key] = int32_t(id);
+    constants.push_back(value);
+
+    return int32_t(id);
+}
+
+unsigned int BytecodeBuilder::addStringTableEntry(StringRef value)
+{
+    unsigned int& index = stringTable[value];
+
+    // note: bytecode serialization format uses 1-based table indices, 0 is reserved to mean nil
+    if (index == 0)
+    {
+        index = uint32_t(stringTable.size());
+
+        if ((dumpFlags & Dump_Code) != 0)
+            debugStrings.push_back(value);
+    }
+
+    return index;
+}
+
+int32_t BytecodeBuilder::addConstantNil()
+{
+    Constant c = {Constant::Type_Nil};
+
+    ConstantKey k = {Constant::Type_Nil};
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantBoolean(bool value)
+{
+    Constant c = {Constant::Type_Boolean};
+    c.valueBoolean = value;
+
+    ConstantKey k = {Constant::Type_Boolean, value};
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantNumber(double value)
+{
+    Constant c = {Constant::Type_Number};
+    c.valueNumber = value;
+
+    ConstantKey k = {Constant::Type_Number};
+    static_assert(sizeof(k.value) == sizeof(value), "Expecting double to be 64-bit");
+    memcpy(&k.value, &value, sizeof(value));
+
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantVector(float x, float y, float z, float w)
+{
+    Constant c = {Constant::Type_Vector};
+    c.valueVector[0] = x;
+    c.valueVector[1] = y;
+    c.valueVector[2] = z;
+    c.valueVector[3] = w;
+
+    ConstantKey k = {Constant::Type_Vector};
+    static_assert(
+        sizeof(k.value) == sizeof(x) + sizeof(y) && sizeof(k.extra) == sizeof(z) + sizeof(w), "Expecting vector to have four 32-bit components");
+    memcpy(&k.value, &x, sizeof(x));
+    memcpy((char*)&k.value + sizeof(x), &y, sizeof(y));
+    memcpy(&k.extra, &z, sizeof(z));
+    memcpy((char*)&k.extra + sizeof(z), &w, sizeof(w));
+
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantString(StringRef value)
+{
+    unsigned int index = addStringTableEntry(value);
+
+    Constant c = {Constant::Type_String};
+    c.valueString = index;
+
+    ConstantKey k = {Constant::Type_String, index};
+
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addImport(uint32_t iid)
+{
+    Constant c = {Constant::Type_Import};
+    c.valueImport = iid;
+
+    ConstantKey k = {Constant::Type_Import, iid};
+
+    return addConstant(k, c);
+}
+
+int32_t BytecodeBuilder::addConstantTable(const TableShape& shape)
+{
+    if (int32_t* cache = tableShapeMap.find(shape))
+        return *cache;
+
+    uint32_t id = uint32_t(constants.size());
+
+    if (id >= kMaxConstantCount)
+        return -1;
+
+    Constant value = {Constant::Type_Table};
+    value.valueTable = uint32_t(tableShapes.size());
+
+    tableShapeMap[shape] = int32_t(id);
+    tableShapes.push_back(shape);
+    constants.push_back(value);
+
+    return int32_t(id);
+}
+
+int32_t BytecodeBuilder::addConstantClosure(uint32_t fid)
+{
+    Constant c = {Constant::Type_Closure};
+    c.valueClosure = fid;
+
+    ConstantKey k = {Constant::Type_Closure, fid};
+
+    return addConstant(k, c);
+}
+
+int16_t BytecodeBuilder::addChildFunction(uint32_t fid)
+{
+    if (int16_t* cache = protoMap.find(fid))
+        return *cache;
+
+    uint32_t id = uint32_t(protos.size());
+
+    if (id >= kMaxClosureCount)
+        return -1;
+
+    protoMap[fid] = int16_t(id);
+    protos.push_back(fid);
+
+    return int16_t(id);
+}
+
+void BytecodeBuilder::emitABC(LuauOpcode op, uint8_t a, uint8_t b, uint8_t c)
+{
+    uint32_t insn = uint32_t(op) | (a << 8) | (b << 16) | (c << 24);
+
+    insns.push_back(insn);
+    lines.push_back(debugLine);
+}
+
+void BytecodeBuilder::emitAD(LuauOpcode op, uint8_t a, int16_t d)
+{
+    uint32_t insn = uint32_t(op) | (a << 8) | (uint16_t(d) << 16);
+
+    insns.push_back(insn);
+    lines.push_back(debugLine);
+}
+
+void BytecodeBuilder::emitE(LuauOpcode op, int32_t e)
+{
+    uint32_t insn = uint32_t(op) | (uint32_t(e) << 8);
+
+    insns.push_back(insn);
+    lines.push_back(debugLine);
+}
+
+void BytecodeBuilder::emitAux(uint32_t aux)
+{
+    insns.push_back(aux);
+    lines.push_back(debugLine);
+}
+
+size_t BytecodeBuilder::emitLabel()
+{
+    return insns.size();
+}
+
+bool BytecodeBuilder::patchJumpD(size_t jumpLabel, size_t targetLabel)
+{
+    LUAU_ASSERT(jumpLabel < insns.size());
+
+    unsigned int jumpInsn = insns[jumpLabel];
+    (void)jumpInsn;
+
+    LUAU_ASSERT(isJumpD(LuauOpcode(LUAU_INSN_OP(jumpInsn))));
+    LUAU_ASSERT(LUAU_INSN_D(jumpInsn) == 0);
+
+    LUAU_ASSERT(targetLabel <= insns.size());
+
+    int offset = int(targetLabel) - int(jumpLabel) - 1;
+
+    if (int16_t(offset) == offset)
+    {
+        insns[jumpLabel] |= uint16_t(offset) << 16;
+    }
+    else if (abs(offset) < kMaxJumpDistance)
+    {
+        // our jump doesn't fit into 16 bits; we will need to repatch the bytecode sequence with jump trampolines, see expandJumps
+        hasLongJumps = true;
+    }
+    else
+    {
+        return false;
+    }
+
+    jumps.push_back({uint32_t(jumpLabel), uint32_t(targetLabel)});
+    return true;
+}
+
+bool BytecodeBuilder::patchSkipC(size_t jumpLabel, size_t targetLabel)
+{
+    LUAU_ASSERT(jumpLabel < insns.size());
+
+    unsigned int jumpInsn = insns[jumpLabel];
+    (void)jumpInsn;
+
+    LUAU_ASSERT(isSkipC(LuauOpcode(LUAU_INSN_OP(jumpInsn))) || isFastCall(LuauOpcode(LUAU_INSN_OP(jumpInsn))));
+    LUAU_ASSERT(LUAU_INSN_C(jumpInsn) == 0);
+
+    int offset = int(targetLabel) - int(jumpLabel) - 1;
+
+    if (uint8_t(offset) != offset)
+    {
+        return false;
+    }
+
+    insns[jumpLabel] |= offset << 24;
+    return true;
+}
+
+void BytecodeBuilder::setFunctionTypeInfo(std::string value)
+{
+    functions[currentFunction].typeinfo = std::move(value);
+}
+
+void BytecodeBuilder::setDebugFunctionName(StringRef name)
+{
+    unsigned int index = addStringTableEntry(name);
+
+    functions[currentFunction].debugname = index;
+
+    if (dumpFunctionPtr)
+        functions[currentFunction].dumpname = std::string(name.data, name.length);
+}
+
+void BytecodeBuilder::setDebugFunctionLineDefined(int line)
+{
+    functions[currentFunction].debuglinedefined = line;
+}
+
+void BytecodeBuilder::setDebugLine(int line)
+{
+    debugLine = line;
+}
+
+void BytecodeBuilder::pushDebugLocal(StringRef name, uint8_t reg, uint32_t startpc, uint32_t endpc)
+{
+    unsigned int index = addStringTableEntry(name);
+
+    DebugLocal local;
+    local.name = index;
+    local.reg = reg;
+    local.startpc = startpc;
+    local.endpc = endpc;
+
+    debugLocals.push_back(local);
+}
+
+void BytecodeBuilder::pushDebugUpval(StringRef name)
+{
+    unsigned int index = addStringTableEntry(name);
+
+    DebugUpval upval;
+    upval.name = index;
+
+    debugUpvals.push_back(upval);
+}
+
+size_t BytecodeBuilder::getInstructionCount() const
+{
+    return insns.size();
+}
+
+size_t BytecodeBuilder::getTotalInstructionCount() const
+{
+    return totalInstructionCount;
+}
+
+uint32_t BytecodeBuilder::getDebugPC() const
+{
+    return uint32_t(insns.size());
+}
+
+void BytecodeBuilder::addDebugRemark(const char* format, ...)
+{
+    if ((dumpFlags & Dump_Remarks) == 0)
+        return;
+
+    size_t offset = debugRemarkBuffer.size();
+
+    va_list args;
+    va_start(args, format);
+    vformatAppend(debugRemarkBuffer, format, args);
+    va_end(args);
+
+    // we null-terminate all remarks to avoid storing remark length
+    debugRemarkBuffer += '\0';
+
+    debugRemarks.emplace_back(uint32_t(insns.size()), uint32_t(offset));
+    dumpRemarks.emplace_back(debugLine, debugRemarkBuffer.c_str() + offset);
+}
+
+void BytecodeBuilder::finalize()
+{
+    LUAU_ASSERT(bytecode.empty());
+
+    // preallocate space for bytecode blob
+    size_t capacity = 16;
+
+    for (auto& p : stringTable)
+        capacity += p.first.length + 2;
+
+    for (const Function& func : functions)
+        capacity += func.data.size();
+
+    bytecode.reserve(capacity);
+
+    // assemble final bytecode blob
+    uint8_t version = getVersion();
+    LUAU_ASSERT(version >= LBC_VERSION_MIN && version <= LBC_VERSION_MAX);
+
+    bytecode = char(version);
+
+    uint8_t typesversion = getTypeEncodingVersion();
+    LUAU_ASSERT(typesversion == 1);
+    writeByte(bytecode, typesversion);
+
+    writeStringTable(bytecode);
+
+    writeVarInt(bytecode, uint32_t(functions.size()));
+
+    for (const Function& func : functions)
+        bytecode += func.data;
+
+    LUAU_ASSERT(mainFunction < functions.size());
+    writeVarInt(bytecode, mainFunction);
+}
+
+void BytecodeBuilder::writeFunction(std::string& ss, uint32_t id, uint8_t flags) const
+{
+    LUAU_ASSERT(id < functions.size());
+    const Function& func = functions[id];
+
+    // header
+    writeByte(ss, func.maxstacksize);
+    writeByte(ss, func.numparams);
+    writeByte(ss, func.numupvalues);
+    writeByte(ss, func.isvararg);
+
+    writeByte(ss, flags);
+
+    writeVarInt(ss, uint32_t(func.typeinfo.size()));
+    ss.append(func.typeinfo);
+
+    // instructions
+    writeVarInt(ss, uint32_t(insns.size()));
+
+    for (uint32_t insn : insns)
+        writeInt(ss, insn);
+
+    // constants
+    writeVarInt(ss, uint32_t(constants.size()));
+
+    for (const Constant& c : constants)
+    {
+        switch (c.type)
+        {
+        case Constant::Type_Nil:
+            writeByte(ss, LBC_CONSTANT_NIL);
+            break;
+
+        case Constant::Type_Boolean:
+            writeByte(ss, LBC_CONSTANT_BOOLEAN);
+            writeByte(ss, c.valueBoolean);
+            break;
+
+        case Constant::Type_Number:
+            writeByte(ss, LBC_CONSTANT_NUMBER);
+            writeDouble(ss, c.valueNumber);
+            break;
+
+        case Constant::Type_Vector:
+            writeByte(ss, LBC_CONSTANT_VECTOR);
+            writeFloat(ss, c.valueVector[0]);
+            writeFloat(ss, c.valueVector[1]);
+            writeFloat(ss, c.valueVector[2]);
+            writeFloat(ss, c.valueVector[3]);
+            break;
+
+        case Constant::Type_String:
+            writeByte(ss, LBC_CONSTANT_STRING);
+            writeVarInt(ss, c.valueString);
+            break;
+
+        case Constant::Type_Import:
+            writeByte(ss, LBC_CONSTANT_IMPORT);
+            writeInt(ss, c.valueImport);
+            break;
+
+        case Constant::Type_Table:
+        {
+            const TableShape& shape = tableShapes[c.valueTable];
+            writeByte(ss, LBC_CONSTANT_TABLE);
+            writeVarInt(ss, uint32_t(shape.length));
+            for (unsigned int i = 0; i < shape.length; ++i)
+                writeVarInt(ss, shape.keys[i]);
+            break;
+        }
+
+        case Constant::Type_Closure:
+            writeByte(ss, LBC_CONSTANT_CLOSURE);
+            writeVarInt(ss, c.valueClosure);
+            break;
+
+        default:
+            LUAU_ASSERT(!"Unsupported constant type");
+        }
+    }
+
+    // child protos
+    writeVarInt(ss, uint32_t(protos.size()));
+
+    for (uint32_t child : protos)
+        writeVarInt(ss, child);
+
+    // debug info
+    writeVarInt(ss, func.debuglinedefined);
+    writeVarInt(ss, func.debugname);
+
+    bool hasLines = true;
+
+    for (int line : lines)
+        if (line == 0)
+        {
+            hasLines = false;
+            break;
+        }
+
+    if (hasLines)
+    {
+        writeByte(ss, 1);
+
+        writeLineInfo(ss);
+    }
+    else
+    {
+        writeByte(ss, 0);
+    }
+
+    bool hasDebug = !debugLocals.empty() || !debugUpvals.empty();
+
+    if (hasDebug)
+    {
+        writeByte(ss, 1);
+
+        writeVarInt(ss, uint32_t(debugLocals.size()));
+
+        for (const DebugLocal& l : debugLocals)
+        {
+            writeVarInt(ss, l.name);
+            writeVarInt(ss, l.startpc);
+            writeVarInt(ss, l.endpc);
+            writeByte(ss, l.reg);
+        }
+
+        writeVarInt(ss, uint32_t(debugUpvals.size()));
+
+        for (const DebugUpval& l : debugUpvals)
+        {
+            writeVarInt(ss, l.name);
+        }
+    }
+    else
+    {
+        writeByte(ss, 0);
+    }
+}
+
+void BytecodeBuilder::writeLineInfo(std::string& ss) const
+{
+    LUAU_ASSERT(!lines.empty());
+
+    // this function encodes lines inside each span as a 8-bit delta to span baseline
+    // span is always a power of two; depending on the line info input, it may need to be as low as 1
+    int span = 1 << 24;
+
+    // first pass: determine span length
+    for (size_t offset = 0; offset < lines.size(); offset += span)
+    {
+        size_t next = offset;
+
+        int min = lines[offset];
+        int max = lines[offset];
+
+        for (; next < lines.size() && next < offset + span; ++next)
+        {
+            min = std::min(min, lines[next]);
+            max = std::max(max, lines[next]);
+
+            if (max - min > 255)
+                break;
+        }
+
+        if (next < lines.size() && next - offset < size_t(span))
+        {
+            // since not all lines in the range fit in 8b delta, we need to shrink the span
+            // next iteration will need to reprocess some lines again since span changed
+            span = 1 << log2(int(next - offset));
+        }
+    }
+
+    // second pass: compute span base
+    int baselineOne = 0;
+    std::vector<int> baselineScratch;
+    int* baseline = &baselineOne;
+    size_t baselineSize = (lines.size() - 1) / span + 1;
+
+    if (baselineSize > 1)
+    {
+        // avoid heap allocation for single-element baseline which is most functions (<256 lines)
+        baselineScratch.resize(baselineSize);
+        baseline = baselineScratch.data();
+    }
+
+    for (size_t offset = 0; offset < lines.size(); offset += span)
+    {
+        size_t next = offset;
+
+        int min = lines[offset];
+
+        for (; next < lines.size() && next < offset + span; ++next)
+            min = std::min(min, lines[next]);
+
+        baseline[offset / span] = min;
+    }
+
+    // third pass: write resulting data
+    int logspan = log2(span);
+
+    writeByte(ss, uint8_t(logspan));
+
+    uint8_t lastOffset = 0;
+
+    for (size_t i = 0; i < lines.size(); ++i)
+    {
+        int delta = lines[i] - baseline[i >> logspan];
+        LUAU_ASSERT(delta >= 0 && delta <= 255);
+
+        writeByte(ss, uint8_t(delta) - lastOffset);
+        lastOffset = uint8_t(delta);
+    }
+
+    int lastLine = 0;
+
+    for (size_t i = 0; i < baselineSize; ++i)
+    {
+        writeInt(ss, baseline[i] - lastLine);
+        lastLine = baseline[i];
+    }
+}
+
+void BytecodeBuilder::writeStringTable(std::string& ss) const
+{
+    std::vector<StringRef> strings(stringTable.size());
+
+    for (auto& p : stringTable)
+    {
+        LUAU_ASSERT(p.second > 0 && p.second <= strings.size());
+        strings[p.second - 1] = p.first;
+    }
+
+    writeVarInt(ss, uint32_t(strings.size()));
+
+    for (auto& s : strings)
+    {
+        writeVarInt(ss, uint32_t(s.length));
+        ss.append(s.data, s.length);
+    }
+}
+
+uint32_t BytecodeBuilder::getImportId(int32_t id0)
+{
+    LUAU_ASSERT(unsigned(id0) < 1024);
+
+    return (1u << 30) | (id0 << 20);
+}
+
+uint32_t BytecodeBuilder::getImportId(int32_t id0, int32_t id1)
+{
+    LUAU_ASSERT(unsigned(id0 | id1) < 1024);
+
+    return (2u << 30) | (id0 << 20) | (id1 << 10);
+}
+
+uint32_t BytecodeBuilder::getImportId(int32_t id0, int32_t id1, int32_t id2)
+{
+    LUAU_ASSERT(unsigned(id0 | id1 | id2) < 1024);
+
+    return (3u << 30) | (id0 << 20) | (id1 << 10) | id2;
+}
+
+int BytecodeBuilder::decomposeImportId(uint32_t ids, int32_t& id0, int32_t& id1, int32_t& id2)
+{
+    int count = ids >> 30;
+    id0 = count > 0 ? int(ids >> 20) & 1023 : -1;
+    id1 = count > 1 ? int(ids >> 10) & 1023 : -1;
+    id2 = count > 2 ? int(ids) & 1023 : -1;
+    return count;
+}
+
+uint32_t BytecodeBuilder::getStringHash(StringRef key)
+{
+    // This hashing algorithm should match luaS_hash defined in VM/lstring.cpp for short inputs; we can't use that code directly to keep compiler and
+    // VM independent in terms of compilation/linking. The resulting string hashes are embedded into bytecode binary and result in a better initial
+    // guess for the field hashes which improves performance during initial code execution. We omit the long string processing here for simplicity, as
+    // it doesn't really matter on long identifiers.
+    const char* str = key.data;
+    size_t len = key.length;
+
+    unsigned int h = unsigned(len);
+
+    // original Lua 5.1 hash for compatibility (exact match when len<32)
+    for (size_t i = len; i > 0; --i)
+        h ^= (h << 5) + (h >> 2) + (uint8_t)str[i - 1];
+
+    return h;
+}
+
+void BytecodeBuilder::foldJumps()
+{
+    // if our function has long jumps, some processing below can make jump instructions not-jumps (e.g. JUMP->RETURN)
+    // it's safer to skip this processing
+    if (hasLongJumps)
+        return;
+
+    for (Jump& jump : jumps)
+    {
+        uint32_t jumpLabel = jump.source;
+
+        uint32_t jumpInsn = insns[jumpLabel];
+
+        // follow jump target through forward unconditional jumps
+        // we only follow forward jumps to make sure the process terminates
+        uint32_t targetLabel = jumpLabel + 1 + LUAU_INSN_D(jumpInsn);
+        LUAU_ASSERT(targetLabel < insns.size());
+        uint32_t targetInsn = insns[targetLabel];
+
+        while (LUAU_INSN_OP(targetInsn) == LOP_JUMP && LUAU_INSN_D(targetInsn) >= 0)
+        {
+            targetLabel = targetLabel + 1 + LUAU_INSN_D(targetInsn);
+            LUAU_ASSERT(targetLabel < insns.size());
+            targetInsn = insns[targetLabel];
+        }
+
+        int offset = int(targetLabel) - int(jumpLabel) - 1;
+
+        // for unconditional jumps to RETURN, we can replace JUMP with RETURN
+        if (LUAU_INSN_OP(jumpInsn) == LOP_JUMP && LUAU_INSN_OP(targetInsn) == LOP_RETURN)
+        {
+            insns[jumpLabel] = targetInsn;
+            lines[jumpLabel] = lines[targetLabel];
+        }
+        else if (int16_t(offset) == offset)
+        {
+            insns[jumpLabel] &= 0xffff;
+            insns[jumpLabel] |= uint16_t(offset) << 16;
+        }
+
+        jump.target = targetLabel;
+    }
+}
+
+void BytecodeBuilder::expandJumps()
+{
+    if (!hasLongJumps)
+        return;
+
+    // we have some jump instructions that couldn't be patched which means their offset didn't fit into 16 bits
+    // our strategy for replacing instructions is as follows: instead of
+    //   OP jumpoffset
+    // we will synthesize a jump trampoline before our instruction (note that jump offsets are relative to next instruction):
+    //   JUMP +1
+    //   JUMPX jumpoffset
+    //   OP -2
+    // the idea is that during forward execution, we will jump over JUMPX into OP; if OP decides to jump, it will jump to JUMPX
+    // JUMPX can carry a 24-bit jump offset
+
+    // jump trampolines expand the code size, which can increase existing jump distances.
+    // because of this, we may need to expand jumps that previously fit into 16-bit just fine.
+    // the worst-case expansion is 3x, so to be conservative we will repatch all jumps that have an offset >= 32767/3
+    const int kMaxJumpDistanceConservative = 32767 / 3;
+
+    // we will need to process jumps in order
+    std::sort(jumps.begin(), jumps.end(), [](const Jump& lhs, const Jump& rhs) {
+        return lhs.source < rhs.source;
+    });
+
+    // first, let's add jump thunks for every jump with a distance that's too big
+    // we will create new instruction buffers, with remap table keeping track of the moves: remap[oldpc] = newpc
+    std::vector<uint32_t> remap(insns.size());
+
+    std::vector<uint32_t> newinsns;
+    std::vector<int> newlines;
+
+    LUAU_ASSERT(insns.size() == lines.size());
+    newinsns.reserve(insns.size());
+    newlines.reserve(insns.size());
+
+    size_t currentJump = 0;
+    size_t pendingTrampolines = 0;
+
+    for (size_t i = 0; i < insns.size();)
+    {
+        uint8_t op = LUAU_INSN_OP(insns[i]);
+        LUAU_ASSERT(op < LOP__COUNT);
+
+        if (currentJump < jumps.size() && jumps[currentJump].source == i)
+        {
+            int offset = int(jumps[currentJump].target) - int(jumps[currentJump].source) - 1;
+
+            if (abs(offset) > kMaxJumpDistanceConservative)
+            {
+                // insert jump trampoline as described above; we keep JUMPX offset uninitialized in this pass
+                newinsns.push_back(LOP_JUMP | (1 << 16));
+                newinsns.push_back(LOP_JUMPX);
+
+                newlines.push_back(lines[i]);
+                newlines.push_back(lines[i]);
+
+                pendingTrampolines++;
+            }
+
+            currentJump++;
+        }
+
+        int oplen = getOpLength(LuauOpcode(op));
+
+        // copy instruction and line info to the new stream
+        for (int j = 0; j < oplen; ++j)
+        {
+            remap[i] = uint32_t(newinsns.size());
+
+            newinsns.push_back(insns[i]);
+            newlines.push_back(lines[i]);
+
+            i++;
+        }
+    }
+
+    LUAU_ASSERT(currentJump == jumps.size());
+    LUAU_ASSERT(pendingTrampolines > 0);
+
+    // now we need to recompute offsets for jump instructions - we could not do this in the first pass because the offsets are between *target*
+    // instructions
+    for (Jump& jump : jumps)
+    {
+        int offset = int(jump.target) - int(jump.source) - 1;
+        int newoffset = int(remap[jump.target]) - int(remap[jump.source]) - 1;
+
+        if (abs(offset) > kMaxJumpDistanceConservative)
+        {
+            // fix up jump trampoline
+            uint32_t& insnt = newinsns[remap[jump.source] - 1];
+            uint32_t& insnj = newinsns[remap[jump.source]];
+
+            LUAU_ASSERT(LUAU_INSN_OP(insnt) == LOP_JUMPX);
+
+            // patch JUMPX to JUMPX to target location; note that newoffset is the offset of the jump *relative to OP*, so we need to add 1 to make it
+            // relative to JUMPX
+            insnt &= 0xff;
+            insnt |= uint32_t(newoffset + 1) << 8;
+
+            // patch OP to OP -2
+            insnj &= 0xffff;
+            insnj |= uint16_t(-2) << 16;
+
+            pendingTrampolines--;
+        }
+        else
+        {
+            uint32_t& insn = newinsns[remap[jump.source]];
+
+            // make sure jump instruction had the correct offset before we started
+            LUAU_ASSERT(LUAU_INSN_D(insn) == offset);
+
+            // patch instruction with the new offset
+            LUAU_ASSERT(int16_t(newoffset) == newoffset);
+
+            insn &= 0xffff;
+            insn |= uint16_t(newoffset) << 16;
+        }
+    }
+
+    LUAU_ASSERT(pendingTrampolines == 0);
+
+    // this was hard, but we're done.
+    insns.swap(newinsns);
+    lines.swap(newlines);
+}
+
+std::string BytecodeBuilder::getError(const std::string& message)
+{
+    // 0 acts as a special marker for error bytecode (it's equal to LBC_VERSION_TARGET for valid bytecode blobs)
+    std::string result;
+    result += char(0);
+    result += message;
+
+    return result;
+}
+
+uint8_t BytecodeBuilder::getVersion()
+{
+    // This function usually returns LBC_VERSION_TARGET but may sometimes return a higher number (within LBC_VERSION_MIN/MAX) under fast flags
+    return (FFlag::LuauVectorLiterals || FFlag::LuauCompileRevK) ? 5 : LBC_VERSION_TARGET;
+}
+
+uint8_t BytecodeBuilder::getTypeEncodingVersion()
+{
+    return LBC_TYPE_VERSION;
+}
+
+#ifdef LUAU_ASSERTENABLED
+void BytecodeBuilder::validate() const
+{
+    validateInstructions();
+    validateVariadic();
+}
+
+void BytecodeBuilder::validateInstructions() const
+{
+#define VREG(v) LUAU_ASSERT(unsigned(v) < func.maxstacksize)
+#define VREGRANGE(v, count) LUAU_ASSERT(unsigned(v + (count < 0 ? 0 : count)) <= func.maxstacksize)
+#define VUPVAL(v) LUAU_ASSERT(unsigned(v) < func.numupvalues)
+#define VCONST(v, kind) LUAU_ASSERT(unsigned(v) < constants.size() && constants[v].type == Constant::Type_##kind)
+#define VCONSTANY(v) LUAU_ASSERT(unsigned(v) < constants.size())
+#define VJUMP(v) LUAU_ASSERT(size_t(i + 1 + v) < insns.size() && insnvalid[i + 1 + v])
+
+    LUAU_ASSERT(currentFunction != ~0u);
+
+    const Function& func = functions[currentFunction];
+
+    // tag instruction offsets so that we can validate jumps
+    std::vector<uint8_t> insnvalid(insns.size(), 0);
+
+    for (size_t i = 0; i < insns.size();)
+    {
+        uint32_t insn = insns[i];
+        LuauOpcode op = LuauOpcode(LUAU_INSN_OP(insn));
+
+        insnvalid[i] = true;
+
+        i += getOpLength(op);
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    std::vector<uint8_t> openCaptures;
+
+    // validate individual instructions
+    for (size_t i = 0; i < insns.size();)
+    {
+        uint32_t insn = insns[i];
+        LuauOpcode op = LuauOpcode(LUAU_INSN_OP(insn));
+
+        switch (op)
+        {
+        case LOP_LOADNIL:
+            VREG(LUAU_INSN_A(insn));
+            break;
+
+        case LOP_LOADB:
+            VREG(LUAU_INSN_A(insn));
+            LUAU_ASSERT(LUAU_INSN_B(insn) == 0 || LUAU_INSN_B(insn) == 1);
+            VJUMP(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_LOADN:
+            VREG(LUAU_INSN_A(insn));
+            break;
+
+        case LOP_LOADK:
+            VREG(LUAU_INSN_A(insn));
+            VCONSTANY(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_MOVE:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            break;
+
+        case LOP_GETGLOBAL:
+        case LOP_SETGLOBAL:
+            VREG(LUAU_INSN_A(insn));
+            VCONST(insns[i + 1], String);
+            break;
+
+        case LOP_GETUPVAL:
+        case LOP_SETUPVAL:
+            VREG(LUAU_INSN_A(insn));
+            VUPVAL(LUAU_INSN_B(insn));
+            break;
+
+        case LOP_CLOSEUPVALS:
+            VREG(LUAU_INSN_A(insn));
+            while (openCaptures.size() && openCaptures.back() >= LUAU_INSN_A(insn))
+                openCaptures.pop_back();
+            break;
+
+        case LOP_GETIMPORT:
+        {
+            VREG(LUAU_INSN_A(insn));
+            VCONST(LUAU_INSN_D(insn), Import);
+            uint32_t id = insns[i + 1];
+            LUAU_ASSERT((id >> 30) != 0); // import chain with length 1-3
+            for (unsigned int j = 0; j < (id >> 30); ++j)
+                VCONST((id >> (20 - 10 * j)) & 1023, String);
+        }
+        break;
+
+        case LOP_GETTABLE:
+        case LOP_SETTABLE:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VREG(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_GETTABLEKS:
+        case LOP_SETTABLEKS:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VCONST(insns[i + 1], String);
+            break;
+
+        case LOP_GETTABLEN:
+        case LOP_SETTABLEN:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            break;
+
+        case LOP_NEWCLOSURE:
+        {
+            VREG(LUAU_INSN_A(insn));
+            LUAU_ASSERT(unsigned(LUAU_INSN_D(insn)) < protos.size());
+            LUAU_ASSERT(protos[LUAU_INSN_D(insn)] < functions.size());
+            unsigned int numupvalues = functions[protos[LUAU_INSN_D(insn)]].numupvalues;
+
+            for (unsigned int j = 0; j < numupvalues; ++j)
+            {
+                LUAU_ASSERT(i + 1 + j < insns.size());
+                uint32_t cinsn = insns[i + 1 + j];
+                LUAU_ASSERT(LUAU_INSN_OP(cinsn) == LOP_CAPTURE);
+            }
+        }
+        break;
+
+        case LOP_NAMECALL:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VCONST(insns[i + 1], String);
+            LUAU_ASSERT(LUAU_INSN_OP(insns[i + 2]) == LOP_CALL);
+            break;
+
+        case LOP_CALL:
+        {
+            int nparams = LUAU_INSN_B(insn) - 1;
+            int nresults = LUAU_INSN_C(insn) - 1;
+            VREG(LUAU_INSN_A(insn));
+            VREGRANGE(LUAU_INSN_A(insn) + 1, nparams); // 1..nparams
+            VREGRANGE(LUAU_INSN_A(insn), nresults);    // 1..nresults
+        }
+        break;
+
+        case LOP_RETURN:
+        {
+            int nresults = LUAU_INSN_B(insn) - 1;
+            VREGRANGE(LUAU_INSN_A(insn), nresults); // 0..nresults-1
+        }
+        break;
+
+        case LOP_JUMP:
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_JUMPIF:
+        case LOP_JUMPIFNOT:
+            VREG(LUAU_INSN_A(insn));
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_JUMPIFEQ:
+        case LOP_JUMPIFLE:
+        case LOP_JUMPIFLT:
+        case LOP_JUMPIFNOTEQ:
+        case LOP_JUMPIFNOTLE:
+        case LOP_JUMPIFNOTLT:
+            VREG(LUAU_INSN_A(insn));
+            VREG(insns[i + 1]);
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_JUMPXEQKNIL:
+        case LOP_JUMPXEQKB:
+            VREG(LUAU_INSN_A(insn));
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_JUMPXEQKN:
+            VREG(LUAU_INSN_A(insn));
+            VCONST(insns[i + 1] & 0xffffff, Number);
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_JUMPXEQKS:
+            VREG(LUAU_INSN_A(insn));
+            VCONST(insns[i + 1] & 0xffffff, String);
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_ADD:
+        case LOP_SUB:
+        case LOP_MUL:
+        case LOP_DIV:
+        case LOP_IDIV:
+        case LOP_MOD:
+        case LOP_POW:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VREG(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_ADDK:
+        case LOP_SUBK:
+        case LOP_MULK:
+        case LOP_DIVK:
+        case LOP_IDIVK:
+        case LOP_MODK:
+        case LOP_POWK:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VCONST(LUAU_INSN_C(insn), Number);
+            break;
+
+        case LOP_SUBRK:
+        case LOP_DIVRK:
+            VREG(LUAU_INSN_A(insn));
+            VCONST(LUAU_INSN_B(insn), Number);
+            VREG(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_AND:
+        case LOP_OR:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VREG(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_ANDK:
+        case LOP_ORK:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VCONSTANY(LUAU_INSN_C(insn));
+            break;
+
+        case LOP_CONCAT:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            VREG(LUAU_INSN_C(insn));
+            LUAU_ASSERT(LUAU_INSN_B(insn) <= LUAU_INSN_C(insn));
+            break;
+
+        case LOP_NOT:
+        case LOP_MINUS:
+        case LOP_LENGTH:
+            VREG(LUAU_INSN_A(insn));
+            VREG(LUAU_INSN_B(insn));
+            break;
+
+        case LOP_NEWTABLE:
+            VREG(LUAU_INSN_A(insn));
+            break;
+
+        case LOP_DUPTABLE:
+            VREG(LUAU_INSN_A(insn));
+            VCONST(LUAU_INSN_D(insn), Table);
+            break;
+
+        case LOP_SETLIST:
+        {
+            int count = LUAU_INSN_C(insn) - 1;
+            VREG(LUAU_INSN_A(insn));
+            VREGRANGE(LUAU_INSN_B(insn), count);
+        }
+        break;
+
+        case LOP_FORNPREP:
+        case LOP_FORNLOOP:
+            // for loop protocol: A, A+1, A+2 are used for iteration
+            VREG(LUAU_INSN_A(insn) + 2);
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_FORGPREP:
+            // forg loop protocol: A, A+1, A+2 are used for iteration protocol; A+3, ... are loop variables
+            VREG(LUAU_INSN_A(insn) + 2 + 1);
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_FORGLOOP:
+            // forg loop protocol: A, A+1, A+2 are used for iteration protocol; A+3, ... are loop variables
+            VREG(LUAU_INSN_A(insn) + 2 + uint8_t(insns[i + 1]));
+            VJUMP(LUAU_INSN_D(insn));
+            LUAU_ASSERT(uint8_t(insns[i + 1]) >= 1);
+            break;
+
+        case LOP_FORGPREP_INEXT:
+        case LOP_FORGPREP_NEXT:
+            VREG(LUAU_INSN_A(insn) + 4); // forg loop protocol: A, A+1, A+2 are used for iteration protocol; A+3, A+4 are loop variables
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_GETVARARGS:
+        {
+            int nresults = LUAU_INSN_B(insn) - 1;
+            VREGRANGE(LUAU_INSN_A(insn), nresults); // 0..nresults-1
+        }
+        break;
+
+        case LOP_DUPCLOSURE:
+        {
+            VREG(LUAU_INSN_A(insn));
+            VCONST(LUAU_INSN_D(insn), Closure);
+            unsigned int proto = constants[LUAU_INSN_D(insn)].valueClosure;
+            LUAU_ASSERT(proto < functions.size());
+            unsigned int numupvalues = functions[proto].numupvalues;
+
+            for (unsigned int j = 0; j < numupvalues; ++j)
+            {
+                LUAU_ASSERT(i + 1 + j < insns.size());
+                uint32_t cinsn = insns[i + 1 + j];
+                LUAU_ASSERT(LUAU_INSN_OP(cinsn) == LOP_CAPTURE);
+                LUAU_ASSERT(LUAU_INSN_A(cinsn) == LCT_VAL || LUAU_INSN_A(cinsn) == LCT_UPVAL);
+            }
+        }
+        break;
+
+        case LOP_PREPVARARGS:
+            LUAU_ASSERT(LUAU_INSN_A(insn) == func.numparams);
+            LUAU_ASSERT(func.isvararg);
+            break;
+
+        case LOP_BREAK:
+            break;
+
+        case LOP_JUMPBACK:
+            VJUMP(LUAU_INSN_D(insn));
+            break;
+
+        case LOP_LOADKX:
+            VREG(LUAU_INSN_A(insn));
+            VCONSTANY(insns[i + 1]);
+            break;
+
+        case LOP_JUMPX:
+            VJUMP(LUAU_INSN_E(insn));
+            break;
+
+        case LOP_FASTCALL:
+            VJUMP(LUAU_INSN_C(insn));
+            LUAU_ASSERT(LUAU_INSN_OP(insns[i + 1 + LUAU_INSN_C(insn)]) == LOP_CALL);
+            break;
+
+        case LOP_FASTCALL1:
+            VREG(LUAU_INSN_B(insn));
+            VJUMP(LUAU_INSN_C(insn));
+            LUAU_ASSERT(LUAU_INSN_OP(insns[i + 1 + LUAU_INSN_C(insn)]) == LOP_CALL);
+            break;
+
+        case LOP_FASTCALL2:
+            VREG(LUAU_INSN_B(insn));
+            VJUMP(LUAU_INSN_C(insn));
+            LUAU_ASSERT(LUAU_INSN_OP(insns[i + 1 + LUAU_INSN_C(insn)]) == LOP_CALL);
+            VREG(insns[i + 1]);
+            break;
+
+        case LOP_FASTCALL2K:
+            VREG(LUAU_INSN_B(insn));
+            VJUMP(LUAU_INSN_C(insn));
+            LUAU_ASSERT(LUAU_INSN_OP(insns[i + 1 + LUAU_INSN_C(insn)]) == LOP_CALL);
+            VCONSTANY(insns[i + 1]);
+            break;
+
+        case LOP_COVERAGE:
+            break;
+
+        case LOP_CAPTURE:
+            switch (LUAU_INSN_A(insn))
+            {
+            case LCT_VAL:
+                VREG(LUAU_INSN_B(insn));
+                break;
+
+            case LCT_REF:
+                VREG(LUAU_INSN_B(insn));
+                openCaptures.push_back(LUAU_INSN_B(insn));
+                break;
+
+            case LCT_UPVAL:
+                VUPVAL(LUAU_INSN_B(insn));
+                break;
+
+            default:
+                LUAU_ASSERT(!"Unsupported capture type");
+            }
+            break;
+
+        default:
+            LUAU_ASSERT(!"Unsupported opcode");
+        }
+
+        i += getOpLength(op);
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    // all CAPTURE REF instructions must have a CLOSEUPVALS instruction after them in the bytecode stream
+    // this doesn't guarantee safety as it doesn't perform basic block based analysis, but if this fails
+    // then the bytecode is definitely unsafe to run since the compiler won't generate backwards branches
+    // except for loop edges
+    LUAU_ASSERT(openCaptures.empty());
+
+#undef VREG
+#undef VREGEND
+#undef VUPVAL
+#undef VCONST
+#undef VCONSTANY
+#undef VJUMP
+}
+
+void BytecodeBuilder::validateVariadic() const
+{
+    // validate MULTRET sequences: instructions that produce a variadic sequence and consume one must come in pairs
+    // we classify instructions into four groups: producers, consumers, neutral and others
+    // any producer (an instruction that produces more than one value) must be followed by 0 or more neutral instructions
+    // and a consumer (that consumes more than one value); these form a variadic sequence.
+    // except for producer, no instruction in the variadic sequence may be a jump target.
+    // from the execution perspective, producer adjusts L->top to point to one past the last result, neutral instructions
+    // leave L->top unmodified, and consumer adjusts L->top back to the stack frame end.
+    // consumers invalidate all values after L->top after they execute (which we currently don't validate)
+    bool variadicSeq = false;
+
+    std::vector<uint8_t> insntargets(insns.size(), 0);
+
+    for (size_t i = 0; i < insns.size();)
+    {
+        uint32_t insn = insns[i];
+        LuauOpcode op = LuauOpcode(LUAU_INSN_OP(insn));
+
+        int target = getJumpTarget(insn, uint32_t(i));
+
+        if (target >= 0 && !isFastCall(op))
+        {
+            LUAU_ASSERT(unsigned(target) < insns.size());
+
+            insntargets[target] = true;
+        }
+
+        i += getOpLength(op);
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    for (size_t i = 0; i < insns.size();)
+    {
+        uint32_t insn = insns[i];
+        LuauOpcode op = LuauOpcode(LUAU_INSN_OP(insn));
+
+        if (variadicSeq)
+        {
+            // no instruction inside the sequence, including the consumer, may be a jump target
+            // this guarantees uninterrupted L->top adjustment flow
+            LUAU_ASSERT(!insntargets[i]);
+        }
+
+        if (op == LOP_CALL)
+        {
+            // note: calls may end one variadic sequence and start a new one
+
+            if (LUAU_INSN_B(insn) == 0)
+            {
+                // consumer instruction ens a variadic sequence
+                LUAU_ASSERT(variadicSeq);
+                variadicSeq = false;
+            }
+            else
+            {
+                // CALL is not a neutral instruction so it can't be present in a variadic sequence unless it's a consumer
+                LUAU_ASSERT(!variadicSeq);
+            }
+
+            if (LUAU_INSN_C(insn) == 0)
+            {
+                // producer instruction starts a variadic sequence
+                LUAU_ASSERT(!variadicSeq);
+                variadicSeq = true;
+            }
+        }
+        else if (op == LOP_GETVARARGS && LUAU_INSN_B(insn) == 0)
+        {
+            // producer instruction starts a variadic sequence
+            LUAU_ASSERT(!variadicSeq);
+            variadicSeq = true;
+        }
+        else if ((op == LOP_RETURN && LUAU_INSN_B(insn) == 0) || (op == LOP_SETLIST && LUAU_INSN_C(insn) == 0))
+        {
+            // consumer instruction ends a variadic sequence
+            LUAU_ASSERT(variadicSeq);
+            variadicSeq = false;
+        }
+        else if (op == LOP_FASTCALL)
+        {
+            int callTarget = int(i + LUAU_INSN_C(insn) + 1);
+            LUAU_ASSERT(unsigned(callTarget) < insns.size() && LUAU_INSN_OP(insns[callTarget]) == LOP_CALL);
+
+            if (LUAU_INSN_B(insns[callTarget]) == 0)
+            {
+                // consumer instruction ends a variadic sequence; however, we can't terminate it yet because future analysis of CALL will do it
+                // during FASTCALL fallback, the instructions between this and CALL consumer are going to be executed before L->top so they must
+                // be neutral; as such, we will defer termination of variadic sequence until CALL analysis
+                LUAU_ASSERT(variadicSeq);
+            }
+            else
+            {
+                // FASTCALL is not a neutral instruction so it can't be present in a variadic sequence unless it's linked to CALL consumer
+                LUAU_ASSERT(!variadicSeq);
+            }
+
+            // note: if FASTCALL is linked to a CALL producer, the instructions between FASTCALL and CALL are technically not part of an executed
+            // variadic sequence since they are never executed if FASTCALL does anything, so it's okay to skip their validation until CALL
+            // (we can't simply start a variadic sequence here because that would trigger assertions during linked CALL validation)
+        }
+        else if (op == LOP_CLOSEUPVALS || op == LOP_NAMECALL || op == LOP_GETIMPORT || op == LOP_MOVE || op == LOP_GETUPVAL || op == LOP_GETGLOBAL ||
+                 op == LOP_GETTABLEKS || op == LOP_COVERAGE)
+        {
+            // instructions inside a variadic sequence must be neutral (can't change L->top)
+            // while there are many neutral instructions like this, here we check that the instruction is one of the few
+            // that we'd expect to exist in FASTCALL fallback sequences or between consecutive CALLs for encoding reasons
+        }
+        else
+        {
+            LUAU_ASSERT(!variadicSeq);
+        }
+
+        i += getOpLength(op);
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    LUAU_ASSERT(!variadicSeq);
+}
+#endif
+
+static bool printableStringConstant(const char* str, size_t len)
+{
+    for (size_t i = 0; i < len; ++i)
+    {
+        if (unsigned(str[i]) < ' ')
+            return false;
+    }
+
+    return true;
+}
+
+void BytecodeBuilder::dumpConstant(std::string& result, int k) const
+{
+    LUAU_ASSERT(unsigned(k) < constants.size());
+    const Constant& data = constants[k];
+
+    switch (data.type)
+    {
+    case Constant::Type_Nil:
+        formatAppend(result, "nil");
+        break;
+    case Constant::Type_Boolean:
+        formatAppend(result, "%s", data.valueBoolean ? "true" : "false");
+        break;
+    case Constant::Type_Number:
+        formatAppend(result, "%.17g", data.valueNumber);
+        break;
+    case Constant::Type_Vector:
+        // 3-vectors is the most common configuration, so truncate to three components if possible
+        if (data.valueVector[3] == 0.0)
+            formatAppend(result, "%.9g, %.9g, %.9g", data.valueVector[0], data.valueVector[1], data.valueVector[2]);
+        else
+            formatAppend(result, "%.9g, %.9g, %.9g, %.9g", data.valueVector[0], data.valueVector[1], data.valueVector[2], data.valueVector[3]);
+        break;
+    case Constant::Type_String:
+    {
+        const StringRef& str = debugStrings[data.valueString - 1];
+
+        if (printableStringConstant(str.data, str.length))
+        {
+            if (str.length < 32)
+                formatAppend(result, "'%.*s'", int(str.length), str.data);
+            else
+                formatAppend(result, "'%.*s'...", 32, str.data);
+        }
+        break;
+    }
+    case Constant::Type_Import:
+    {
+        int id0 = -1, id1 = -1, id2 = -1;
+        if (int count = decomposeImportId(data.valueImport, id0, id1, id2))
+        {
+            {
+                const Constant& id = constants[id0];
+                LUAU_ASSERT(id.type == Constant::Type_String && id.valueString <= debugStrings.size());
+
+                const StringRef& str = debugStrings[id.valueString - 1];
+                formatAppend(result, "%.*s", int(str.length), str.data);
+            }
+
+            if (count > 1)
+            {
+                const Constant& id = constants[id1];
+                LUAU_ASSERT(id.type == Constant::Type_String && id.valueString <= debugStrings.size());
+
+                const StringRef& str = debugStrings[id.valueString - 1];
+                formatAppend(result, ".%.*s", int(str.length), str.data);
+            }
+
+            if (count > 2)
+            {
+                const Constant& id = constants[id2];
+                LUAU_ASSERT(id.type == Constant::Type_String && id.valueString <= debugStrings.size());
+
+                const StringRef& str = debugStrings[id.valueString - 1];
+                formatAppend(result, ".%.*s", int(str.length), str.data);
+            }
+        }
+        break;
+    }
+    case Constant::Type_Table:
+        formatAppend(result, "{...}");
+        break;
+    case Constant::Type_Closure:
+    {
+        const Function& func = functions[data.valueClosure];
+
+        if (!func.dumpname.empty())
+            formatAppend(result, "'%s'", func.dumpname.c_str());
+        break;
+    }
+    }
+}
+
+void BytecodeBuilder::dumpInstruction(const uint32_t* code, std::string& result, int targetLabel) const
+{
+    uint32_t insn = *code++;
+
+    switch (LUAU_INSN_OP(insn))
+    {
+    case LOP_LOADNIL:
+        formatAppend(result, "LOADNIL R%d\n", LUAU_INSN_A(insn));
+        break;
+
+    case LOP_LOADB:
+        if (LUAU_INSN_C(insn))
+            formatAppend(result, "LOADB R%d %d +%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        else
+            formatAppend(result, "LOADB R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_LOADN:
+        formatAppend(result, "LOADN R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        break;
+
+    case LOP_LOADK:
+        formatAppend(result, "LOADK R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        dumpConstant(result, LUAU_INSN_D(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_MOVE:
+        formatAppend(result, "MOVE R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_GETGLOBAL:
+        formatAppend(result, "GETGLOBAL R%d K%d [", LUAU_INSN_A(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_SETGLOBAL:
+        formatAppend(result, "SETGLOBAL R%d K%d [", LUAU_INSN_A(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_GETUPVAL:
+        formatAppend(result, "GETUPVAL R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_SETUPVAL:
+        formatAppend(result, "SETUPVAL R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_CLOSEUPVALS:
+        formatAppend(result, "CLOSEUPVALS R%d\n", LUAU_INSN_A(insn));
+        break;
+
+    case LOP_GETIMPORT:
+        formatAppend(result, "GETIMPORT R%d %d [", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        dumpConstant(result, LUAU_INSN_D(insn));
+        result.append("]\n");
+        code++; // AUX
+        break;
+
+    case LOP_GETTABLE:
+        formatAppend(result, "GETTABLE R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_SETTABLE:
+        formatAppend(result, "SETTABLE R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_GETTABLEKS:
+        formatAppend(result, "GETTABLEKS R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_SETTABLEKS:
+        formatAppend(result, "SETTABLEKS R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_GETTABLEN:
+        formatAppend(result, "GETTABLEN R%d R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn) + 1);
+        break;
+
+    case LOP_SETTABLEN:
+        formatAppend(result, "SETTABLEN R%d R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn) + 1);
+        break;
+
+    case LOP_NEWCLOSURE:
+        formatAppend(result, "NEWCLOSURE R%d P%d\n", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        break;
+
+    case LOP_NAMECALL:
+        formatAppend(result, "NAMECALL R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_CALL:
+        formatAppend(result, "CALL R%d %d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn) - 1, LUAU_INSN_C(insn) - 1);
+        break;
+
+    case LOP_RETURN:
+        formatAppend(result, "RETURN R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn) - 1);
+        break;
+
+    case LOP_JUMP:
+        formatAppend(result, "JUMP L%d\n", targetLabel);
+        break;
+
+    case LOP_JUMPIF:
+        formatAppend(result, "JUMPIF R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_JUMPIFNOT:
+        formatAppend(result, "JUMPIFNOT R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_JUMPIFEQ:
+        formatAppend(result, "JUMPIFEQ R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_JUMPIFLE:
+        formatAppend(result, "JUMPIFLE R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_JUMPIFLT:
+        formatAppend(result, "JUMPIFLT R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_JUMPIFNOTEQ:
+        formatAppend(result, "JUMPIFNOTEQ R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_JUMPIFNOTLE:
+        formatAppend(result, "JUMPIFNOTLE R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_JUMPIFNOTLT:
+        formatAppend(result, "JUMPIFNOTLT R%d R%d L%d\n", LUAU_INSN_A(insn), *code++, targetLabel);
+        break;
+
+    case LOP_ADD:
+        formatAppend(result, "ADD R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_SUB:
+        formatAppend(result, "SUB R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_MUL:
+        formatAppend(result, "MUL R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_DIV:
+        formatAppend(result, "DIV R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_IDIV:
+        formatAppend(result, "IDIV R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_MOD:
+        formatAppend(result, "MOD R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_POW:
+        formatAppend(result, "POW R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_ADDK:
+        formatAppend(result, "ADDK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_SUBK:
+        formatAppend(result, "SUBK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_MULK:
+        formatAppend(result, "MULK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_DIVK:
+        formatAppend(result, "DIVK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_IDIVK:
+        formatAppend(result, "IDIVK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_MODK:
+        formatAppend(result, "MODK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_POWK:
+        formatAppend(result, "POWK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_SUBRK:
+        formatAppend(result, "SUBRK R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        dumpConstant(result, LUAU_INSN_B(insn));
+        formatAppend(result, "] R%d\n", LUAU_INSN_C(insn));
+        break;
+
+    case LOP_DIVRK:
+        formatAppend(result, "DIVRK R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        dumpConstant(result, LUAU_INSN_B(insn));
+        formatAppend(result, "] R%d\n", LUAU_INSN_C(insn));
+        break;
+
+    case LOP_AND:
+        formatAppend(result, "AND R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_OR:
+        formatAppend(result, "OR R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_ANDK:
+        formatAppend(result, "ANDK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_ORK:
+        formatAppend(result, "ORK R%d R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        dumpConstant(result, LUAU_INSN_C(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_CONCAT:
+        formatAppend(result, "CONCAT R%d R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn));
+        break;
+
+    case LOP_NOT:
+        formatAppend(result, "NOT R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_MINUS:
+        formatAppend(result, "MINUS R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_LENGTH:
+        formatAppend(result, "LENGTH R%d R%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn));
+        break;
+
+    case LOP_NEWTABLE:
+        formatAppend(result, "NEWTABLE R%d %d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn) == 0 ? 0 : 1 << (LUAU_INSN_B(insn) - 1), *code++);
+        break;
+
+    case LOP_DUPTABLE:
+        formatAppend(result, "DUPTABLE R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        break;
+
+    case LOP_SETLIST:
+        formatAppend(result, "SETLIST R%d R%d %d [%d]\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), LUAU_INSN_C(insn) - 1, *code++);
+        break;
+
+    case LOP_FORNPREP:
+        formatAppend(result, "FORNPREP R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_FORNLOOP:
+        formatAppend(result, "FORNLOOP R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_FORGPREP:
+        formatAppend(result, "FORGPREP R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_FORGLOOP:
+        formatAppend(result, "FORGLOOP R%d L%d %d%s\n", LUAU_INSN_A(insn), targetLabel, uint8_t(*code), int(*code) < 0 ? " [inext]" : "");
+        code++;
+        break;
+
+    case LOP_FORGPREP_INEXT:
+        formatAppend(result, "FORGPREP_INEXT R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_FORGPREP_NEXT:
+        formatAppend(result, "FORGPREP_NEXT R%d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_GETVARARGS:
+        formatAppend(result, "GETVARARGS R%d %d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn) - 1);
+        break;
+
+    case LOP_DUPCLOSURE:
+        formatAppend(result, "DUPCLOSURE R%d K%d [", LUAU_INSN_A(insn), LUAU_INSN_D(insn));
+        dumpConstant(result, LUAU_INSN_D(insn));
+        result.append("]\n");
+        break;
+
+    case LOP_BREAK:
+        formatAppend(result, "BREAK\n");
+        break;
+
+    case LOP_JUMPBACK:
+        formatAppend(result, "JUMPBACK L%d\n", targetLabel);
+        break;
+
+    case LOP_LOADKX:
+        formatAppend(result, "LOADKX R%d K%d [", LUAU_INSN_A(insn), *code);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_JUMPX:
+        formatAppend(result, "JUMPX L%d\n", targetLabel);
+        break;
+
+    case LOP_FASTCALL:
+        formatAppend(result, "FASTCALL %d L%d\n", LUAU_INSN_A(insn), targetLabel);
+        break;
+
+    case LOP_FASTCALL1:
+        formatAppend(result, "FASTCALL1 %d R%d L%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), targetLabel);
+        break;
+
+    case LOP_FASTCALL2:
+        formatAppend(result, "FASTCALL2 %d R%d R%d L%d\n", LUAU_INSN_A(insn), LUAU_INSN_B(insn), *code, targetLabel);
+        code++;
+        break;
+
+    case LOP_FASTCALL2K:
+        formatAppend(result, "FASTCALL2K %d R%d K%d L%d [", LUAU_INSN_A(insn), LUAU_INSN_B(insn), *code, targetLabel);
+        dumpConstant(result, *code);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_COVERAGE:
+        formatAppend(result, "COVERAGE\n");
+        break;
+
+    case LOP_CAPTURE:
+        formatAppend(result, "CAPTURE %s %c%d\n",
+            LUAU_INSN_A(insn) == LCT_UPVAL ? "UPVAL"
+            : LUAU_INSN_A(insn) == LCT_REF ? "REF"
+            : LUAU_INSN_A(insn) == LCT_VAL ? "VAL"
+                                           : "",
+            LUAU_INSN_A(insn) == LCT_UPVAL ? 'U' : 'R', LUAU_INSN_B(insn));
+        break;
+
+    case LOP_JUMPXEQKNIL:
+        formatAppend(result, "JUMPXEQKNIL R%d L%d%s\n", LUAU_INSN_A(insn), targetLabel, *code >> 31 ? " NOT" : "");
+        code++;
+        break;
+
+    case LOP_JUMPXEQKB:
+        formatAppend(result, "JUMPXEQKB R%d %d L%d%s\n", LUAU_INSN_A(insn), *code & 1, targetLabel, *code >> 31 ? " NOT" : "");
+        code++;
+        break;
+
+    case LOP_JUMPXEQKN:
+        formatAppend(result, "JUMPXEQKN R%d K%d L%d%s [", LUAU_INSN_A(insn), *code & 0xffffff, targetLabel, *code >> 31 ? " NOT" : "");
+        dumpConstant(result, *code & 0xffffff);
+        result.append("]\n");
+        code++;
+        break;
+
+    case LOP_JUMPXEQKS:
+        formatAppend(result, "JUMPXEQKS R%d K%d L%d%s [", LUAU_INSN_A(insn), *code & 0xffffff, targetLabel, *code >> 31 ? " NOT" : "");
+        dumpConstant(result, *code & 0xffffff);
+        result.append("]\n");
+        code++;
+        break;
+
+    default:
+        LUAU_ASSERT(!"Unsupported opcode");
+    }
+}
+
+std::string BytecodeBuilder::dumpCurrentFunction(std::vector<int>& dumpinstoffs) const
+{
+    if ((dumpFlags & Dump_Code) == 0)
+        return std::string();
+
+    int lastLine = -1;
+    size_t nextRemark = 0;
+
+    std::string result;
+
+    if (dumpFlags & Dump_Locals)
+    {
+        for (size_t i = 0; i < debugLocals.size(); ++i)
+        {
+            const DebugLocal& l = debugLocals[i];
+
+            LUAU_ASSERT(l.startpc < l.endpc);
+            LUAU_ASSERT(l.startpc < lines.size());
+            LUAU_ASSERT(l.endpc <= lines.size()); // endpc is exclusive in the debug info, but it's more intuitive to print inclusive data
+
+            // it would be nice to emit name as well but it requires reverse lookup through stringtable
+            formatAppend(result, "local %d: reg %d, start pc %d line %d, end pc %d line %d\n", int(i), l.reg, l.startpc, lines[l.startpc],
+                l.endpc - 1, lines[l.endpc - 1]);
+        }
+    }
+
+    std::vector<int> labels(insns.size(), -1);
+
+    // annotate valid jump targets with 0
+    for (size_t i = 0; i < insns.size();)
+    {
+        int target = getJumpTarget(insns[i], uint32_t(i));
+
+        if (target >= 0)
+        {
+            LUAU_ASSERT(size_t(target) < insns.size());
+            labels[target] = 0;
+        }
+
+        i += getOpLength(LuauOpcode(LUAU_INSN_OP(insns[i])));
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    int nextLabel = 0;
+
+    // compute label ids (sequential integers for all jump targets)
+    for (size_t i = 0; i < labels.size(); ++i)
+        if (labels[i] == 0)
+            labels[i] = nextLabel++;
+
+    dumpinstoffs.resize(insns.size() + 1, -1);
+
+    for (size_t i = 0; i < insns.size();)
+    {
+        const uint32_t* code = &insns[i];
+        uint8_t op = LUAU_INSN_OP(*code);
+
+        dumpinstoffs[i] = int(result.size());
+
+        if (op == LOP_PREPVARARGS)
+        {
+            // Don't emit function header in bytecode - it's used for call dispatching and doesn't contain "interesting" information
+            i++;
+            continue;
+        }
+
+        if (dumpFlags & Dump_Remarks)
+        {
+            while (nextRemark < debugRemarks.size() && debugRemarks[nextRemark].first == i)
+            {
+                formatAppend(result, "REMARK %s\n", debugRemarkBuffer.c_str() + debugRemarks[nextRemark].second);
+                nextRemark++;
+            }
+        }
+
+        if (dumpFlags & Dump_Source)
+        {
+            int line = lines[i];
+
+            if (line > 0 && line != lastLine)
+            {
+                LUAU_ASSERT(size_t(line - 1) < dumpSource.size());
+                formatAppend(result, "%5d: %s\n", line, dumpSource[line - 1].c_str());
+                lastLine = line;
+            }
+        }
+
+        if (dumpFlags & Dump_Lines)
+            formatAppend(result, "%d: ", lines[i]);
+
+        if (labels[i] != -1)
+            formatAppend(result, "L%d: ", labels[i]);
+
+        int target = getJumpTarget(*code, uint32_t(i));
+
+        dumpInstruction(code, result, target >= 0 ? labels[target] : -1);
+
+        i += getOpLength(LuauOpcode(op));
+        LUAU_ASSERT(i <= insns.size());
+    }
+
+    dumpinstoffs[insns.size()] = int(result.size());
+
+    return result;
+}
+
+void BytecodeBuilder::setDumpSource(const std::string& source)
+{
+    dumpSource.clear();
+
+    size_t pos = 0;
+
+    while (pos != std::string::npos)
+    {
+        size_t next = source.find('\n', pos);
+
+        if (next == std::string::npos)
+        {
+            dumpSource.push_back(source.substr(pos));
+            pos = next;
+        }
+        else
+        {
+            dumpSource.push_back(source.substr(pos, next - pos));
+            pos = next + 1;
+        }
+
+        if (!dumpSource.back().empty() && dumpSource.back().back() == '\r')
+            dumpSource.back().pop_back();
+    }
+}
+
+std::string BytecodeBuilder::dumpFunction(uint32_t id) const
+{
+    LUAU_ASSERT(id < functions.size());
+
+    return functions[id].dump;
+}
+
+std::string BytecodeBuilder::dumpEverything() const
+{
+    std::string result;
+
+    for (size_t i = 0; i < functions.size(); ++i)
+    {
+        std::string debugname = functions[i].dumpname.empty() ? "??" : functions[i].dumpname;
+
+        formatAppend(result, "Function %d (%s):\n", int(i), debugname.c_str());
+
+        result += functions[i].dump;
+        result += "\n";
+    }
+
+    return result;
+}
+
+std::string BytecodeBuilder::dumpSourceRemarks() const
+{
+    std::string result;
+
+    size_t nextRemark = 0;
+
+    std::vector<std::pair<int, std::string>> remarks = dumpRemarks;
+    std::sort(remarks.begin(), remarks.end());
+
+    for (size_t i = 0; i < dumpSource.size(); ++i)
+    {
+        const std::string& line = dumpSource[i];
+
+        size_t indent = 0;
+        while (indent < line.length() && (line[indent] == ' ' || line[indent] == '\t'))
+            indent++;
+
+        while (nextRemark < remarks.size() && remarks[nextRemark].first == int(i + 1))
+        {
+            formatAppend(result, "%.*s-- remark: %s\n", int(indent), line.c_str(), remarks[nextRemark].second.c_str());
+            nextRemark++;
+
+            // skip duplicate remarks (due to inlining/unrolling)
+            while (nextRemark < remarks.size() && remarks[nextRemark] == remarks[nextRemark - 1])
+                nextRemark++;
+        }
+
+        result += line;
+
+        if (i + 1 < dumpSource.size())
+            result += '\n';
+    }
+
+    return result;
+}
+
+static const char* getBaseTypeString(uint8_t type)
+{
+    uint8_t tag = type & ~LBC_TYPE_OPTIONAL_BIT;
+    switch (tag)
+    {
+    case LBC_TYPE_NIL:
+        return "nil";
+    case LBC_TYPE_BOOLEAN:
+        return "boolean";
+    case LBC_TYPE_NUMBER:
+        return "number";
+    case LBC_TYPE_STRING:
+        return "string";
+    case LBC_TYPE_TABLE:
+        return "table";
+    case LBC_TYPE_FUNCTION:
+        return "function";
+    case LBC_TYPE_THREAD:
+        return "thread";
+    case LBC_TYPE_USERDATA:
+        return "userdata";
+    case LBC_TYPE_VECTOR:
+        return "vector";
+    case LBC_TYPE_BUFFER:
+        return "buffer";
+    case LBC_TYPE_ANY:
+        return "any";
+    }
+
+    LUAU_ASSERT(!"Unhandled type in getBaseTypeString");
+    return nullptr;
+}
+
+std::string BytecodeBuilder::dumpTypeInfo() const
+{
+    std::string result;
+
+    for (size_t i = 0; i < functions.size(); ++i)
+    {
+        const std::string& typeinfo = functions[i].typeinfo;
+        if (typeinfo.empty())
+            continue;
+
+        uint8_t encodedType = typeinfo[0];
+
+        LUAU_ASSERT(encodedType == LBC_TYPE_FUNCTION);
+
+        formatAppend(result, "%zu: function(", i);
+
+        LUAU_ASSERT(typeinfo.size() >= 2);
+
+        uint8_t numparams = typeinfo[1];
+
+        LUAU_ASSERT(size_t(1 + numparams - 1) < typeinfo.size());
+
+        for (uint8_t i = 0; i < numparams; ++i)
+        {
+            uint8_t et = typeinfo[2 + i];
+            const char* optional = (et & LBC_TYPE_OPTIONAL_BIT) ? "?" : "";
+            formatAppend(result, "%s%s", getBaseTypeString(et), optional);
+
+            if (i + 1 != numparams)
+                formatAppend(result, ", ");
+        }
+
+        formatAppend(result, ")\n");
+    }
+
+    return result;
+}
+
+void BytecodeBuilder::annotateInstruction(std::string& result, uint32_t fid, uint32_t instpos) const
+{
+    if ((dumpFlags & Dump_Code) == 0)
+        return;
+
+    LUAU_ASSERT(fid < functions.size());
+
+    const Function& function = functions[fid];
+    const std::string& dump = function.dump;
+    const std::vector<int>& dumpinstoffs = function.dumpinstoffs;
+
+    uint32_t next = instpos + 1;
+
+    LUAU_ASSERT(next < dumpinstoffs.size());
+
+    // Skip locations of multi-dword instructions
+    while (next < dumpinstoffs.size() && dumpinstoffs[next] == -1)
+        next++;
+
+    formatAppend(result, "%.*s", dumpinstoffs[next] - dumpinstoffs[instpos], dump.data() + dumpinstoffs[instpos]);
+}
+
+} // namespace Luau

--- a/lib/luau/Compiler/src/Compiler.cpp
+++ b/lib/luau/Compiler/src/Compiler.cpp
@@ -1,0 +1,4103 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Compiler.h"
+
+#include "Luau/Parser.h"
+#include "Luau/BytecodeBuilder.h"
+#include "Luau/Common.h"
+#include "Luau/TimeTrace.h"
+
+#include "Builtins.h"
+#include "ConstantFolding.h"
+#include "CostModel.h"
+#include "TableShape.h"
+#include "Types.h"
+#include "ValueTracking.h"
+
+#include <algorithm>
+#include <bitset>
+#include <memory>
+
+#include <math.h>
+
+LUAU_FASTINTVARIABLE(LuauCompileLoopUnrollThreshold, 25)
+LUAU_FASTINTVARIABLE(LuauCompileLoopUnrollThresholdMaxBoost, 300)
+
+LUAU_FASTINTVARIABLE(LuauCompileInlineThreshold, 25)
+LUAU_FASTINTVARIABLE(LuauCompileInlineThresholdMaxBoost, 300)
+LUAU_FASTINTVARIABLE(LuauCompileInlineDepth, 5)
+
+LUAU_FASTFLAGVARIABLE(LuauCompileRevK, false)
+
+namespace Luau
+{
+
+using namespace Luau::Compile;
+
+static const uint32_t kMaxRegisterCount = 255;
+static const uint32_t kMaxUpvalueCount = 200;
+static const uint32_t kMaxLocalCount = 200;
+static const uint32_t kMaxInstructionCount = 1'000'000'000;
+
+static const uint8_t kInvalidReg = 255;
+
+CompileError::CompileError(const Location& location, const std::string& message)
+    : location(location)
+    , message(message)
+{
+}
+
+CompileError::~CompileError() throw() {}
+
+const char* CompileError::what() const throw()
+{
+    return message.c_str();
+}
+
+const Location& CompileError::getLocation() const
+{
+    return location;
+}
+
+// NOINLINE is used to limit the stack cost of this function due to std::string object / exception plumbing
+LUAU_NOINLINE void CompileError::raise(const Location& location, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    std::string message = vformat(format, args);
+    va_end(args);
+
+    throw CompileError(location, message);
+}
+
+static BytecodeBuilder::StringRef sref(AstName name)
+{
+    LUAU_ASSERT(name.value);
+    return {name.value, strlen(name.value)};
+}
+
+static BytecodeBuilder::StringRef sref(AstArray<char> data)
+{
+    LUAU_ASSERT(data.data);
+    return {data.data, data.size};
+}
+
+static BytecodeBuilder::StringRef sref(AstArray<const char> data)
+{
+    LUAU_ASSERT(data.data);
+    return {data.data, data.size};
+}
+
+struct Compiler
+{
+    struct RegScope;
+
+    Compiler(BytecodeBuilder& bytecode, const CompileOptions& options)
+        : bytecode(bytecode)
+        , options(options)
+        , functions(nullptr)
+        , locals(nullptr)
+        , globals(AstName())
+        , variables(nullptr)
+        , constants(nullptr)
+        , locstants(nullptr)
+        , tableShapes(nullptr)
+        , builtins(nullptr)
+        , typeMap(nullptr)
+    {
+        // preallocate some buffers that are very likely to grow anyway; this works around std::vector's inefficient growth policy for small arrays
+        localStack.reserve(16);
+        upvals.reserve(16);
+    }
+
+    int getLocalReg(AstLocal* local)
+    {
+        Local* l = locals.find(local);
+
+        return l && l->allocated ? l->reg : -1;
+    }
+
+    uint8_t getUpval(AstLocal* local)
+    {
+        for (size_t uid = 0; uid < upvals.size(); ++uid)
+            if (upvals[uid] == local)
+                return uint8_t(uid);
+
+        if (upvals.size() >= kMaxUpvalueCount)
+            CompileError::raise(
+                local->location, "Out of upvalue registers when trying to allocate %s: exceeded limit %d", local->name.value, kMaxUpvalueCount);
+
+        // mark local as captured so that closeLocals emits LOP_CLOSEUPVALS accordingly
+        Variable* v = variables.find(local);
+
+        if (v && v->written)
+            locals[local].captured = true;
+
+        upvals.push_back(local);
+
+        return uint8_t(upvals.size() - 1);
+    }
+
+    // true iff all execution paths through node subtree result in return/break/continue
+    // note: because this function doesn't visit loop nodes, it (correctly) only detects break/continue that refer to the outer control flow
+    bool alwaysTerminates(AstStat* node)
+    {
+        if (AstStatBlock* stat = node->as<AstStatBlock>())
+            return stat->body.size > 0 && alwaysTerminates(stat->body.data[stat->body.size - 1]);
+        else if (node->is<AstStatReturn>())
+            return true;
+        else if (node->is<AstStatBreak>() || node->is<AstStatContinue>())
+            return true;
+        else if (AstStatIf* stat = node->as<AstStatIf>())
+            return stat->elsebody && alwaysTerminates(stat->thenbody) && alwaysTerminates(stat->elsebody);
+        else
+            return false;
+    }
+
+    void emitLoadK(uint8_t target, int32_t cid)
+    {
+        LUAU_ASSERT(cid >= 0);
+
+        if (cid < 32768)
+        {
+            bytecode.emitAD(LOP_LOADK, target, int16_t(cid));
+        }
+        else
+        {
+            bytecode.emitAD(LOP_LOADKX, target, 0);
+            bytecode.emitAux(cid);
+        }
+    }
+
+    AstExprFunction* getFunctionExpr(AstExpr* node)
+    {
+        if (AstExprLocal* expr = node->as<AstExprLocal>())
+        {
+            Variable* lv = variables.find(expr->local);
+
+            if (!lv || lv->written || !lv->init)
+                return nullptr;
+
+            return getFunctionExpr(lv->init);
+        }
+        else if (AstExprGroup* expr = node->as<AstExprGroup>())
+            return getFunctionExpr(expr->expr);
+        else if (AstExprTypeAssertion* expr = node->as<AstExprTypeAssertion>())
+            return getFunctionExpr(expr->expr);
+        else
+            return node->as<AstExprFunction>();
+    }
+
+    uint32_t compileFunction(AstExprFunction* func, uint8_t protoflags)
+    {
+        LUAU_TIMETRACE_SCOPE("Compiler::compileFunction", "Compiler");
+
+        if (func->debugname.value)
+            LUAU_TIMETRACE_ARGUMENT("name", func->debugname.value);
+
+        LUAU_ASSERT(!functions.contains(func));
+        LUAU_ASSERT(regTop == 0 && stackSize == 0 && localStack.empty() && upvals.empty());
+
+        RegScope rs(this);
+
+        bool self = func->self != 0;
+        uint32_t fid = bytecode.beginFunction(uint8_t(self + func->args.size), func->vararg);
+
+        setDebugLine(func);
+
+        // note: we move types out of typeMap which is safe because compileFunction is only called once per function
+        if (std::string* funcType = typeMap.find(func))
+            bytecode.setFunctionTypeInfo(std::move(*funcType));
+
+        if (func->vararg)
+            bytecode.emitABC(LOP_PREPVARARGS, uint8_t(self + func->args.size), 0, 0);
+
+        uint8_t args = allocReg(func, self + unsigned(func->args.size));
+
+        if (func->self)
+            pushLocal(func->self, args);
+
+        for (size_t i = 0; i < func->args.size; ++i)
+            pushLocal(func->args.data[i], uint8_t(args + self + i));
+
+        AstStatBlock* stat = func->body;
+
+        for (size_t i = 0; i < stat->body.size; ++i)
+            compileStat(stat->body.data[i]);
+
+        // valid function bytecode must always end with RETURN
+        // we elide this if we're guaranteed to hit a RETURN statement regardless of the control flow
+        if (!alwaysTerminates(stat))
+        {
+            setDebugLineEnd(stat);
+            closeLocals(0);
+
+            bytecode.emitABC(LOP_RETURN, 0, 1, 0);
+        }
+
+        // constant folding may remove some upvalue refs from bytecode, so this puts them back
+        if (options.optimizationLevel >= 1 && options.debugLevel >= 2)
+            gatherConstUpvals(func);
+
+        bytecode.setDebugFunctionLineDefined(func->location.begin.line + 1);
+
+        if (options.debugLevel >= 1 && func->debugname.value)
+            bytecode.setDebugFunctionName(sref(func->debugname));
+
+        if (options.debugLevel >= 2 && !upvals.empty())
+        {
+            for (AstLocal* l : upvals)
+                bytecode.pushDebugUpval(sref(l->name));
+        }
+
+        if (options.optimizationLevel >= 1)
+            bytecode.foldJumps();
+
+        bytecode.expandJumps();
+
+        popLocals(0);
+
+        if (bytecode.getInstructionCount() > kMaxInstructionCount)
+            CompileError::raise(func->location, "Exceeded function instruction limit; split the function into parts to compile");
+
+        // top-level code only executes once so it can be marked as cold if it has no loops; code with loops might be profitable to compile natively
+        if (func->functionDepth == 0 && !hasLoops)
+            protoflags |= LPF_NATIVE_COLD;
+
+        bytecode.endFunction(uint8_t(stackSize), uint8_t(upvals.size()), protoflags);
+
+        Function& f = functions[func];
+        f.id = fid;
+        f.upvals = upvals;
+
+        // record information for inlining
+        if (options.optimizationLevel >= 2 && !func->vararg && !func->self && !getfenvUsed && !setfenvUsed)
+        {
+            f.canInline = true;
+            f.stackSize = stackSize;
+            f.costModel = modelCost(func->body, func->args.data, func->args.size, builtins);
+
+            // track functions that only ever return a single value so that we can convert multret calls to fixedret calls
+            if (alwaysTerminates(func->body))
+            {
+                ReturnVisitor returnVisitor(this);
+                stat->visit(&returnVisitor);
+                f.returnsOne = returnVisitor.returnsOne;
+            }
+        }
+
+        upvals.clear(); // note: instead of std::move above, we copy & clear to preserve capacity for future pushes
+        stackSize = 0;
+        hasLoops = false;
+
+        return fid;
+    }
+
+    // returns true if node can return multiple values; may conservatively return true even if expr is known to return just a single value
+    bool isExprMultRet(AstExpr* node)
+    {
+        AstExprCall* expr = node->as<AstExprCall>();
+        if (!expr)
+            return node->is<AstExprVarargs>();
+
+        // conservative version, optimized for compilation throughput
+        if (options.optimizationLevel <= 1)
+            return true;
+
+        // handles builtin calls that can be constant-folded
+        // without this we may omit some optimizations eg compiling fast calls without use of FASTCALL2K
+        if (isConstant(expr))
+            return false;
+
+        // handles builtin calls that can't be constant-folded but are known to return one value
+        // note: optimizationLevel check is technically redundant but it's important that we never optimize based on builtins in O1
+        if (options.optimizationLevel >= 2)
+            if (int* bfid = builtins.find(expr))
+                return getBuiltinInfo(*bfid).results != 1;
+
+        // handles local function calls where we know only one argument is returned
+        AstExprFunction* func = getFunctionExpr(expr->func);
+        Function* fi = func ? functions.find(func) : nullptr;
+
+        if (fi && fi->returnsOne)
+            return false;
+
+        // unrecognized call, so we conservatively assume multret
+        return true;
+    }
+
+    // note: this doesn't just clobber target (assuming it's temp), but also clobbers *all* allocated registers >= target!
+    // this is important to be able to support "multret" semantics due to Lua call frame structure
+    bool compileExprTempMultRet(AstExpr* node, uint8_t target)
+    {
+        if (AstExprCall* expr = node->as<AstExprCall>())
+        {
+            // Optimization: convert multret calls that always return one value to fixedret calls; this facilitates inlining/constant folding
+            if (options.optimizationLevel >= 2 && !isExprMultRet(node))
+            {
+                compileExprTemp(node, target);
+                return false;
+            }
+
+            // We temporarily swap out regTop to have targetTop work correctly...
+            // This is a crude hack but it's necessary for correctness :(
+            RegScope rs(this, target);
+            compileExprCall(expr, target, /* targetCount= */ 0, /* targetTop= */ true, /* multRet= */ true);
+            return true;
+        }
+        else if (AstExprVarargs* expr = node->as<AstExprVarargs>())
+        {
+            // We temporarily swap out regTop to have targetTop work correctly...
+            // This is a crude hack but it's necessary for correctness :(
+            RegScope rs(this, target);
+            compileExprVarargs(expr, target, /* targetCount= */ 0, /* multRet= */ true);
+            return true;
+        }
+        else
+        {
+            compileExprTemp(node, target);
+            return false;
+        }
+    }
+
+    // note: this doesn't just clobber target (assuming it's temp), but also clobbers *all* allocated registers >= target!
+    // this is important to be able to emit code that takes fewer registers and runs faster
+    void compileExprTempTop(AstExpr* node, uint8_t target)
+    {
+        // We temporarily swap out regTop to have targetTop work correctly...
+        // This is a crude hack but it's necessary for performance :(
+        // It makes sure that nested call expressions can use targetTop optimization and don't need to have too many registers
+        RegScope rs(this, target + 1);
+        compileExprTemp(node, target);
+    }
+
+    void compileExprVarargs(AstExprVarargs* expr, uint8_t target, uint8_t targetCount, bool multRet = false)
+    {
+        LUAU_ASSERT(!multRet || unsigned(target + targetCount) == regTop);
+
+        setDebugLine(expr); // normally compileExpr sets up line info, but compileExprVarargs can be called directly
+
+        bytecode.emitABC(LOP_GETVARARGS, target, multRet ? 0 : uint8_t(targetCount + 1), 0);
+    }
+
+    void compileExprSelectVararg(AstExprCall* expr, uint8_t target, uint8_t targetCount, bool targetTop, bool multRet, uint8_t regs)
+    {
+        LUAU_ASSERT(targetCount == 1);
+        LUAU_ASSERT(!expr->self);
+        LUAU_ASSERT(expr->args.size == 2 && expr->args.data[1]->is<AstExprVarargs>());
+
+        AstExpr* arg = expr->args.data[0];
+
+        uint8_t argreg;
+
+        if (int reg = getExprLocalReg(arg); reg >= 0)
+            argreg = uint8_t(reg);
+        else
+        {
+            argreg = uint8_t(regs + 1);
+            compileExprTempTop(arg, argreg);
+        }
+
+        size_t fastcallLabel = bytecode.emitLabel();
+
+        bytecode.emitABC(LOP_FASTCALL1, LBF_SELECT_VARARG, argreg, 0);
+
+        // note, these instructions are normally not executed and are used as a fallback for FASTCALL
+        // we can't use TempTop variant here because we need to make sure the arguments we already computed aren't overwritten
+        compileExprTemp(expr->func, regs);
+
+        if (argreg != regs + 1)
+            bytecode.emitABC(LOP_MOVE, uint8_t(regs + 1), argreg, 0);
+
+        bytecode.emitABC(LOP_GETVARARGS, uint8_t(regs + 2), 0, 0);
+
+        size_t callLabel = bytecode.emitLabel();
+        if (!bytecode.patchSkipC(fastcallLabel, callLabel))
+            CompileError::raise(expr->func->location, "Exceeded jump distance limit; simplify the code to compile");
+
+        // note, this is always multCall (last argument is variadic)
+        bytecode.emitABC(LOP_CALL, regs, 0, multRet ? 0 : uint8_t(targetCount + 1));
+
+        // if we didn't output results directly to target, we need to move them
+        if (!targetTop)
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                bytecode.emitABC(LOP_MOVE, uint8_t(target + i), uint8_t(regs + i), 0);
+        }
+    }
+
+    void compileExprFastcallN(
+        AstExprCall* expr, uint8_t target, uint8_t targetCount, bool targetTop, bool multRet, uint8_t regs, int bfid, int bfK = -1)
+    {
+        LUAU_ASSERT(!expr->self);
+        LUAU_ASSERT(expr->args.size >= 1);
+        LUAU_ASSERT(expr->args.size <= 2 || (bfid == LBF_BIT32_EXTRACTK && expr->args.size == 3));
+        LUAU_ASSERT(bfid == LBF_BIT32_EXTRACTK ? bfK >= 0 : bfK < 0);
+
+        LuauOpcode opc = expr->args.size == 1 ? LOP_FASTCALL1 : (bfK >= 0 || isConstant(expr->args.data[1])) ? LOP_FASTCALL2K : LOP_FASTCALL2;
+
+        uint32_t args[3] = {};
+
+        for (size_t i = 0; i < expr->args.size; ++i)
+        {
+            if (i > 0 && opc == LOP_FASTCALL2K)
+            {
+                int32_t cid = getConstantIndex(expr->args.data[i]);
+                if (cid < 0)
+                    CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+                args[i] = cid;
+            }
+            else if (int reg = getExprLocalReg(expr->args.data[i]); reg >= 0)
+            {
+                args[i] = uint8_t(reg);
+            }
+            else
+            {
+                args[i] = uint8_t(regs + 1 + i);
+                compileExprTempTop(expr->args.data[i], uint8_t(args[i]));
+            }
+        }
+
+        size_t fastcallLabel = bytecode.emitLabel();
+
+        bytecode.emitABC(opc, uint8_t(bfid), uint8_t(args[0]), 0);
+        if (opc != LOP_FASTCALL1)
+            bytecode.emitAux(bfK >= 0 ? bfK : args[1]);
+
+        // Set up a traditional Lua stack for the subsequent LOP_CALL.
+        // Note, as with other instructions that immediately follow FASTCALL, these are normally not executed and are used as a fallback for
+        // these FASTCALL variants.
+        for (size_t i = 0; i < expr->args.size; ++i)
+        {
+            if (i > 0 && opc == LOP_FASTCALL2K)
+                emitLoadK(uint8_t(regs + 1 + i), args[i]);
+            else if (args[i] != regs + 1 + i)
+                bytecode.emitABC(LOP_MOVE, uint8_t(regs + 1 + i), uint8_t(args[i]), 0);
+        }
+
+        // note, these instructions are normally not executed and are used as a fallback for FASTCALL
+        // we can't use TempTop variant here because we need to make sure the arguments we already computed aren't overwritten
+        compileExprTemp(expr->func, regs);
+
+        size_t callLabel = bytecode.emitLabel();
+
+        // FASTCALL will skip over the instructions needed to compute function and jump over CALL which must immediately follow the instruction
+        // sequence after FASTCALL
+        if (!bytecode.patchSkipC(fastcallLabel, callLabel))
+            CompileError::raise(expr->func->location, "Exceeded jump distance limit; simplify the code to compile");
+
+        bytecode.emitABC(LOP_CALL, regs, uint8_t(expr->args.size + 1), multRet ? 0 : uint8_t(targetCount + 1));
+
+        // if we didn't output results directly to target, we need to move them
+        if (!targetTop)
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                bytecode.emitABC(LOP_MOVE, uint8_t(target + i), uint8_t(regs + i), 0);
+        }
+    }
+
+    bool tryCompileInlinedCall(AstExprCall* expr, AstExprFunction* func, uint8_t target, uint8_t targetCount, bool multRet, int thresholdBase,
+        int thresholdMaxBoost, int depthLimit)
+    {
+        Function* fi = functions.find(func);
+        LUAU_ASSERT(fi);
+
+        // make sure we have enough register space
+        if (regTop > 128 || fi->stackSize > 32)
+        {
+            bytecode.addDebugRemark("inlining failed: high register pressure");
+            return false;
+        }
+
+        // we should ideally aggregate the costs during recursive inlining, but for now simply limit the depth
+        if (int(inlineFrames.size()) >= depthLimit)
+        {
+            bytecode.addDebugRemark("inlining failed: too many inlined frames");
+            return false;
+        }
+
+        // compiling recursive inlining is difficult because we share constant/variable state but need to bind variables to different registers
+        for (InlineFrame& frame : inlineFrames)
+            if (frame.func == func)
+            {
+                bytecode.addDebugRemark("inlining failed: can't inline recursive calls");
+                return false;
+            }
+
+        // we can't inline multret functions because the caller expects L->top to be adjusted:
+        // - inlined return compiles to a JUMP, and we don't have an instruction that adjusts L->top arbitrarily
+        // - even if we did, right now all L->top adjustments are immediately consumed by the next instruction, and for now we want to preserve that
+        // - additionally, we can't easily compile multret expressions into designated target as computed call arguments will get clobbered
+        if (multRet)
+        {
+            bytecode.addDebugRemark("inlining failed: can't convert fixed returns to multret");
+            return false;
+        }
+
+        // compute constant bitvector for all arguments to feed the cost model
+        bool varc[8] = {};
+        for (size_t i = 0; i < func->args.size && i < expr->args.size && i < 8; ++i)
+            varc[i] = isConstant(expr->args.data[i]);
+
+        // if the last argument only returns a single value, all following arguments are nil
+        if (expr->args.size != 0 && !isExprMultRet(expr->args.data[expr->args.size - 1]))
+            for (size_t i = expr->args.size; i < func->args.size && i < 8; ++i)
+                varc[i] = true;
+
+        // we use a dynamic cost threshold that's based on the fixed limit boosted by the cost advantage we gain due to inlining
+        int inlinedCost = computeCost(fi->costModel, varc, std::min(int(func->args.size), 8));
+        int baselineCost = computeCost(fi->costModel, nullptr, 0) + 3;
+        int inlineProfit = (inlinedCost == 0) ? thresholdMaxBoost : std::min(thresholdMaxBoost, 100 * baselineCost / inlinedCost);
+
+        int threshold = thresholdBase * inlineProfit / 100;
+
+        if (inlinedCost > threshold)
+        {
+            bytecode.addDebugRemark("inlining failed: too expensive (cost %d, profit %.2fx)", inlinedCost, double(inlineProfit) / 100);
+            return false;
+        }
+
+        bytecode.addDebugRemark(
+            "inlining succeeded (cost %d, profit %.2fx, depth %d)", inlinedCost, double(inlineProfit) / 100, int(inlineFrames.size()));
+
+        compileInlinedCall(expr, func, target, targetCount);
+        return true;
+    }
+
+    void compileInlinedCall(AstExprCall* expr, AstExprFunction* func, uint8_t target, uint8_t targetCount)
+    {
+        RegScope rs(this);
+
+        size_t oldLocals = localStack.size();
+
+        std::vector<InlineArg> args;
+        args.reserve(func->args.size);
+
+        // evaluate all arguments; note that we don't emit code for constant arguments (relying on constant folding)
+        // note that compiler state (variable registers/values) does not change here - we defer that to a separate loop below to handle nested calls
+        for (size_t i = 0; i < func->args.size; ++i)
+        {
+            AstLocal* var = func->args.data[i];
+            AstExpr* arg = i < expr->args.size ? expr->args.data[i] : nullptr;
+
+            if (i + 1 == expr->args.size && func->args.size > expr->args.size && isExprMultRet(arg))
+            {
+                // if the last argument can return multiple values, we need to compute all of them into the remaining arguments
+                unsigned int tail = unsigned(func->args.size - expr->args.size) + 1;
+                uint8_t reg = allocReg(arg, tail);
+
+                if (AstExprCall* expr = arg->as<AstExprCall>())
+                    compileExprCall(expr, reg, tail, /* targetTop= */ true);
+                else if (AstExprVarargs* expr = arg->as<AstExprVarargs>())
+                    compileExprVarargs(expr, reg, tail);
+                else
+                    LUAU_ASSERT(!"Unexpected expression type");
+
+                for (size_t j = i; j < func->args.size; ++j)
+                    args.push_back({func->args.data[j], uint8_t(reg + (j - i))});
+
+                // all remaining function arguments have been allocated and assigned to
+                break;
+            }
+            else if (Variable* vv = variables.find(var); vv && vv->written)
+            {
+                // if the argument is mutated, we need to allocate a fresh register even if it's a constant
+                uint8_t reg = allocReg(arg, 1);
+
+                if (arg)
+                    compileExprTemp(arg, reg);
+                else
+                    bytecode.emitABC(LOP_LOADNIL, reg, 0, 0);
+
+                args.push_back({var, reg});
+            }
+            else if (arg == nullptr)
+            {
+                // since the argument is not mutated, we can simply fold the value into the expressions that need it
+                args.push_back({var, kInvalidReg, {Constant::Type_Nil}});
+            }
+            else if (const Constant* cv = constants.find(arg); cv && cv->type != Constant::Type_Unknown)
+            {
+                // since the argument is not mutated, we can simply fold the value into the expressions that need it
+                args.push_back({var, kInvalidReg, *cv});
+            }
+            else
+            {
+                AstExprLocal* le = getExprLocal(arg);
+                Variable* lv = le ? variables.find(le->local) : nullptr;
+
+                // if the argument is a local that isn't mutated, we will simply reuse the existing register
+                if (int reg = le ? getExprLocalReg(le) : -1; reg >= 0 && (!lv || !lv->written))
+                {
+                    args.push_back({var, uint8_t(reg)});
+                }
+                else
+                {
+                    uint8_t temp = allocReg(arg, 1);
+                    compileExprTemp(arg, temp);
+
+                    args.push_back({var, temp});
+                }
+            }
+        }
+
+        // evaluate extra expressions for side effects
+        for (size_t i = func->args.size; i < expr->args.size; ++i)
+            compileExprSide(expr->args.data[i]);
+
+        // apply all evaluated arguments to the compiler state
+        // note: locals use current startpc for debug info, although some of them have been computed earlier; this is similar to compileStatLocal
+        for (InlineArg& arg : args)
+        {
+            if (arg.value.type == Constant::Type_Unknown)
+            {
+                pushLocal(arg.local, arg.reg);
+            }
+            else
+            {
+                locstants[arg.local] = arg.value;
+            }
+        }
+
+        // the inline frame will be used to compile return statements as well as to reject recursive inlining attempts
+        inlineFrames.push_back({func, oldLocals, target, targetCount});
+
+        // fold constant values updated above into expressions in the function body
+        foldConstants(constants, variables, locstants, builtinsFold, builtinsFoldMathK, func->body);
+
+        bool usedFallthrough = false;
+
+        for (size_t i = 0; i < func->body->body.size; ++i)
+        {
+            AstStat* stat = func->body->body.data[i];
+
+            if (AstStatReturn* ret = stat->as<AstStatReturn>())
+            {
+                // Optimization: use fallthrough when compiling return at the end of the function to avoid an extra JUMP
+                compileInlineReturn(ret, /* fallthrough= */ true);
+                // TODO: This doesn't work when return is part of control flow; ideally we would track the state somehow and generalize this
+                usedFallthrough = true;
+                break;
+            }
+            else
+                compileStat(stat);
+        }
+
+        // for the fallthrough path we need to ensure we clear out target registers
+        if (!usedFallthrough && !alwaysTerminates(func->body))
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                bytecode.emitABC(LOP_LOADNIL, uint8_t(target + i), 0, 0);
+
+            closeLocals(oldLocals);
+        }
+
+        popLocals(oldLocals);
+
+        size_t returnLabel = bytecode.emitLabel();
+        patchJumps(expr, inlineFrames.back().returnJumps, returnLabel);
+
+        inlineFrames.pop_back();
+
+        // clean up constant state for future inlining attempts
+        for (size_t i = 0; i < func->args.size; ++i)
+        {
+            AstLocal* local = func->args.data[i];
+
+            if (Constant* var = locstants.find(local))
+                var->type = Constant::Type_Unknown;
+        }
+
+        foldConstants(constants, variables, locstants, builtinsFold, builtinsFoldMathK, func->body);
+    }
+
+    void compileExprCall(AstExprCall* expr, uint8_t target, uint8_t targetCount, bool targetTop = false, bool multRet = false)
+    {
+        LUAU_ASSERT(!targetTop || unsigned(target + targetCount) == regTop);
+
+        setDebugLine(expr); // normally compileExpr sets up line info, but compileExprCall can be called directly
+
+        // try inlining the function
+        if (options.optimizationLevel >= 2 && !expr->self)
+        {
+            AstExprFunction* func = getFunctionExpr(expr->func);
+            Function* fi = func ? functions.find(func) : nullptr;
+
+            if (fi && fi->canInline &&
+                tryCompileInlinedCall(expr, func, target, targetCount, multRet, FInt::LuauCompileInlineThreshold,
+                    FInt::LuauCompileInlineThresholdMaxBoost, FInt::LuauCompileInlineDepth))
+                return;
+
+            // add a debug remark for cases when we didn't even call tryCompileInlinedCall
+            if (func && !(fi && fi->canInline))
+            {
+                if (func->vararg)
+                    bytecode.addDebugRemark("inlining failed: function is variadic");
+                else if (!fi)
+                    bytecode.addDebugRemark("inlining failed: can't inline recursive calls");
+                else if (getfenvUsed || setfenvUsed)
+                    bytecode.addDebugRemark("inlining failed: module uses getfenv/setfenv");
+            }
+        }
+
+        RegScope rs(this);
+
+        unsigned int regCount = std::max(unsigned(1 + expr->self + expr->args.size), unsigned(targetCount));
+
+        // Optimization: if target points to the top of the stack, we can start the call at oldTop - 1 and won't need MOVE at the end
+        uint8_t regs = targetTop ? allocReg(expr, regCount - targetCount) - targetCount : allocReg(expr, regCount);
+
+        uint8_t selfreg = 0;
+
+        int bfid = -1;
+
+        if (options.optimizationLevel >= 1 && !expr->self)
+            if (const int* id = builtins.find(expr))
+                bfid = *id;
+
+        if (bfid >= 0 && bytecode.needsDebugRemarks())
+        {
+            Builtin builtin = getBuiltin(expr->func, globals, variables);
+            bool lastMult = expr->args.size > 0 && isExprMultRet(expr->args.data[expr->args.size - 1]);
+
+            if (builtin.object.value)
+                bytecode.addDebugRemark("builtin %s.%s/%d%s", builtin.object.value, builtin.method.value, int(expr->args.size), lastMult ? "+" : "");
+            else if (builtin.method.value)
+                bytecode.addDebugRemark("builtin %s/%d%s", builtin.method.value, int(expr->args.size), lastMult ? "+" : "");
+        }
+
+        if (bfid == LBF_SELECT_VARARG)
+        {
+            // Optimization: compile select(_, ...) as FASTCALL1; the builtin will read variadic arguments directly
+            // note: for now we restrict this to single-return expressions since our runtime code doesn't deal with general cases
+            if (multRet == false && targetCount == 1)
+                return compileExprSelectVararg(expr, target, targetCount, targetTop, multRet, regs);
+            else
+                bfid = -1;
+        }
+
+        // Optimization: for bit32.extract with constant in-range f/w we compile using FASTCALL2K and a special builtin
+        if (bfid == LBF_BIT32_EXTRACT && expr->args.size == 3 && isConstant(expr->args.data[1]) && isConstant(expr->args.data[2]))
+        {
+            Constant fc = getConstant(expr->args.data[1]);
+            Constant wc = getConstant(expr->args.data[2]);
+
+            int fi = fc.type == Constant::Type_Number ? int(fc.valueNumber) : -1;
+            int wi = wc.type == Constant::Type_Number ? int(wc.valueNumber) : -1;
+
+            if (fi >= 0 && wi > 0 && fi + wi <= 32)
+            {
+                int fwp = fi | ((wi - 1) << 5);
+                int32_t cid = bytecode.addConstantNumber(fwp);
+                if (cid < 0)
+                    CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+                return compileExprFastcallN(expr, target, targetCount, targetTop, multRet, regs, LBF_BIT32_EXTRACTK, cid);
+            }
+        }
+
+        // Optimization: for 1/2 argument fast calls use specialized opcodes
+        if (bfid >= 0 && expr->args.size >= 1 && expr->args.size <= 2)
+        {
+            if (!isExprMultRet(expr->args.data[expr->args.size - 1]))
+                return compileExprFastcallN(expr, target, targetCount, targetTop, multRet, regs, bfid);
+            else if (options.optimizationLevel >= 2)
+            {
+                // when a builtin is none-safe with matching arity, even if the last expression returns 0 or >1 arguments,
+                // we can rely on the behavior of the function being the same (none-safe means nil and none are interchangeable)
+                BuiltinInfo info = getBuiltinInfo(bfid);
+                if (int(expr->args.size) == info.params && (info.flags & BuiltinInfo::Flag_NoneSafe) != 0)
+                    return compileExprFastcallN(expr, target, targetCount, targetTop, multRet, regs, bfid);
+            }
+        }
+
+        if (expr->self)
+        {
+            AstExprIndexName* fi = expr->func->as<AstExprIndexName>();
+            LUAU_ASSERT(fi);
+
+            // Optimization: use local register directly in NAMECALL if possible
+            if (int reg = getExprLocalReg(fi->expr); reg >= 0)
+            {
+                selfreg = uint8_t(reg);
+            }
+            else
+            {
+                // Note: to be able to compile very deeply nested self call chains (obj:method1():method2():...), we need to be able to do this in
+                // finite stack space NAMECALL will happily move object from regs to regs+1 but we need to compute it into regs so that
+                // compileExprTempTop doesn't increase stack usage for every recursive call
+                selfreg = regs;
+
+                compileExprTempTop(fi->expr, selfreg);
+            }
+        }
+        else if (bfid < 0)
+        {
+            compileExprTempTop(expr->func, regs);
+        }
+
+        bool multCall = false;
+
+        for (size_t i = 0; i < expr->args.size; ++i)
+            if (i + 1 == expr->args.size)
+                multCall = compileExprTempMultRet(expr->args.data[i], uint8_t(regs + 1 + expr->self + i));
+            else
+                compileExprTempTop(expr->args.data[i], uint8_t(regs + 1 + expr->self + i));
+
+        setDebugLineEnd(expr->func);
+
+        if (expr->self)
+        {
+            AstExprIndexName* fi = expr->func->as<AstExprIndexName>();
+            LUAU_ASSERT(fi);
+
+            setDebugLine(fi->indexLocation);
+
+            BytecodeBuilder::StringRef iname = sref(fi->index);
+            int32_t cid = bytecode.addConstantString(iname);
+            if (cid < 0)
+                CompileError::raise(fi->location, "Exceeded constant limit; simplify the code to compile");
+
+            bytecode.emitABC(LOP_NAMECALL, regs, selfreg, uint8_t(BytecodeBuilder::getStringHash(iname)));
+            bytecode.emitAux(cid);
+        }
+        else if (bfid >= 0)
+        {
+            size_t fastcallLabel = bytecode.emitLabel();
+            bytecode.emitABC(LOP_FASTCALL, uint8_t(bfid), 0, 0);
+
+            // note, these instructions are normally not executed and are used as a fallback for FASTCALL
+            // we can't use TempTop variant here because we need to make sure the arguments we already computed aren't overwritten
+            compileExprTemp(expr->func, regs);
+
+            size_t callLabel = bytecode.emitLabel();
+
+            // FASTCALL will skip over the instructions needed to compute function and jump over CALL which must immediately follow the instruction
+            // sequence after FASTCALL
+            if (!bytecode.patchSkipC(fastcallLabel, callLabel))
+                CompileError::raise(expr->func->location, "Exceeded jump distance limit; simplify the code to compile");
+        }
+
+        bytecode.emitABC(LOP_CALL, regs, multCall ? 0 : uint8_t(expr->self + expr->args.size + 1), multRet ? 0 : uint8_t(targetCount + 1));
+
+        // if we didn't output results directly to target, we need to move them
+        if (!targetTop)
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                bytecode.emitABC(LOP_MOVE, uint8_t(target + i), uint8_t(regs + i), 0);
+        }
+    }
+
+    bool shouldShareClosure(AstExprFunction* func)
+    {
+        const Function* f = functions.find(func);
+        if (!f)
+            return false;
+
+        for (AstLocal* uv : f->upvals)
+        {
+            Variable* ul = variables.find(uv);
+
+            if (!ul)
+                return false;
+
+            if (ul->written)
+                return false;
+
+            // it's technically safe to share closures whenever all upvalues are immutable
+            // this is because of a runtime equality check in DUPCLOSURE.
+            // however, this results in frequent deoptimization and increases the set of reachable objects, making some temporary objects permanent
+            // instead we apply a heuristic: we share closures if they refer to top-level upvalues, or closures that refer to top-level upvalues
+            // this will only deoptimize (outside of fenv changes) if top level code is executed twice with different results.
+            if (uv->functionDepth != 0 || uv->loopDepth != 0)
+            {
+                AstExprFunction* uf = ul->init ? ul->init->as<AstExprFunction>() : nullptr;
+                if (!uf)
+                    return false;
+
+                if (uf != func && !shouldShareClosure(uf))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    void compileExprFunction(AstExprFunction* expr, uint8_t target)
+    {
+        RegScope rs(this);
+
+        const Function* f = functions.find(expr);
+        LUAU_ASSERT(f);
+
+        // when the closure has upvalues we'll use this to create the closure at runtime
+        // when the closure has no upvalues, we use constant closures that technically don't rely on the child function list
+        // however, it's still important to add the child function because debugger relies on the function hierarchy when setting breakpoints
+        int16_t pid = bytecode.addChildFunction(f->id);
+        if (pid < 0)
+            CompileError::raise(expr->location, "Exceeded closure limit; simplify the code to compile");
+
+        // we use a scratch vector to reduce allocations; this is safe since compileExprFunction is not reentrant
+        captures.clear();
+        captures.reserve(f->upvals.size());
+
+        for (AstLocal* uv : f->upvals)
+        {
+            LUAU_ASSERT(uv->functionDepth < expr->functionDepth);
+
+            if (int reg = getLocalReg(uv); reg >= 0)
+            {
+                // note: we can't check if uv is an upvalue in the current frame because inlining can migrate from upvalues to locals
+                Variable* ul = variables.find(uv);
+                bool immutable = !ul || !ul->written;
+
+                captures.push_back({immutable ? LCT_VAL : LCT_REF, uint8_t(reg)});
+            }
+            else if (const Constant* uc = locstants.find(uv); uc && uc->type != Constant::Type_Unknown)
+            {
+                // inlining can result in an upvalue capture of a constant, in which case we can't capture without a temporary register
+                uint8_t reg = allocReg(expr, 1);
+                compileExprConstant(expr, uc, reg);
+
+                captures.push_back({LCT_VAL, reg});
+            }
+            else
+            {
+                LUAU_ASSERT(uv->functionDepth < expr->functionDepth - 1);
+
+                // get upvalue from parent frame
+                // note: this will add uv to the current upvalue list if necessary
+                uint8_t uid = getUpval(uv);
+
+                captures.push_back({LCT_UPVAL, uid});
+            }
+        }
+
+        // Optimization: when closure has no upvalues, or upvalues are safe to share, instead of allocating it every time we can share closure
+        // objects (this breaks assumptions about function identity which can lead to setfenv not working as expected, so we disable this when it
+        // is used)
+        int16_t shared = -1;
+
+        if (options.optimizationLevel >= 1 && shouldShareClosure(expr) && !setfenvUsed)
+        {
+            int32_t cid = bytecode.addConstantClosure(f->id);
+
+            if (cid >= 0 && cid < 32768)
+                shared = int16_t(cid);
+        }
+
+        if (shared < 0)
+            bytecode.addDebugRemark("allocation: closure with %d upvalues", int(captures.size()));
+
+        if (shared >= 0)
+            bytecode.emitAD(LOP_DUPCLOSURE, target, shared);
+        else
+            bytecode.emitAD(LOP_NEWCLOSURE, target, pid);
+
+        for (const Capture& c : captures)
+            bytecode.emitABC(LOP_CAPTURE, uint8_t(c.type), c.data, 0);
+    }
+
+    LuauOpcode getUnaryOp(AstExprUnary::Op op)
+    {
+        switch (op)
+        {
+        case AstExprUnary::Not:
+            return LOP_NOT;
+
+        case AstExprUnary::Minus:
+            return LOP_MINUS;
+
+        case AstExprUnary::Len:
+            return LOP_LENGTH;
+
+        default:
+            LUAU_ASSERT(!"Unexpected unary operation");
+            return LOP_NOP;
+        }
+    }
+
+    LuauOpcode getBinaryOpArith(AstExprBinary::Op op, bool k = false)
+    {
+        switch (op)
+        {
+        case AstExprBinary::Add:
+            return k ? LOP_ADDK : LOP_ADD;
+
+        case AstExprBinary::Sub:
+            return k ? LOP_SUBK : LOP_SUB;
+
+        case AstExprBinary::Mul:
+            return k ? LOP_MULK : LOP_MUL;
+
+        case AstExprBinary::Div:
+            return k ? LOP_DIVK : LOP_DIV;
+
+        case AstExprBinary::FloorDiv:
+            return k ? LOP_IDIVK : LOP_IDIV;
+
+        case AstExprBinary::Mod:
+            return k ? LOP_MODK : LOP_MOD;
+
+        case AstExprBinary::Pow:
+            return k ? LOP_POWK : LOP_POW;
+
+        default:
+            LUAU_ASSERT(!"Unexpected binary operation");
+            return LOP_NOP;
+        }
+    }
+
+    LuauOpcode getJumpOpCompare(AstExprBinary::Op op, bool not_ = false)
+    {
+        switch (op)
+        {
+        case AstExprBinary::CompareNe:
+            return not_ ? LOP_JUMPIFEQ : LOP_JUMPIFNOTEQ;
+
+        case AstExprBinary::CompareEq:
+            return not_ ? LOP_JUMPIFNOTEQ : LOP_JUMPIFEQ;
+
+        case AstExprBinary::CompareLt:
+        case AstExprBinary::CompareGt:
+            return not_ ? LOP_JUMPIFNOTLT : LOP_JUMPIFLT;
+
+        case AstExprBinary::CompareLe:
+        case AstExprBinary::CompareGe:
+            return not_ ? LOP_JUMPIFNOTLE : LOP_JUMPIFLE;
+
+        default:
+            LUAU_ASSERT(!"Unexpected binary operation");
+            return LOP_NOP;
+        }
+    }
+
+    bool isConstant(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        return cv && cv->type != Constant::Type_Unknown;
+    }
+
+    bool isConstantTrue(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        return cv && cv->type != Constant::Type_Unknown && cv->isTruthful();
+    }
+
+    bool isConstantFalse(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        return cv && cv->type != Constant::Type_Unknown && !cv->isTruthful();
+    }
+
+    bool isConstantVector(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        return cv && cv->type == Constant::Type_Vector;
+    }
+
+    Constant getConstant(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        return cv ? *cv : Constant{Constant::Type_Unknown};
+    }
+
+    size_t compileCompareJump(AstExprBinary* expr, bool not_ = false)
+    {
+        RegScope rs(this);
+
+        bool isEq = (expr->op == AstExprBinary::CompareEq || expr->op == AstExprBinary::CompareNe);
+        AstExpr* left = expr->left;
+        AstExpr* right = expr->right;
+
+        bool operandIsConstant = isConstant(right);
+        if (isEq && !operandIsConstant)
+        {
+            operandIsConstant = isConstant(left);
+            if (operandIsConstant)
+                std::swap(left, right);
+        }
+
+        // disable fast path for vectors because supporting it would require a new opcode
+        if (operandIsConstant && isConstantVector(right))
+            operandIsConstant = false;
+
+        uint8_t rl = compileExprAuto(left, rs);
+
+        if (isEq && operandIsConstant)
+        {
+            const Constant* cv = constants.find(right);
+            LUAU_ASSERT(cv && cv->type != Constant::Type_Unknown);
+
+            LuauOpcode opc = LOP_NOP;
+            int32_t cid = -1;
+            uint32_t flip = (expr->op == AstExprBinary::CompareEq) == not_ ? 0x80000000 : 0;
+
+            switch (cv->type)
+            {
+            case Constant::Type_Nil:
+                opc = LOP_JUMPXEQKNIL;
+                cid = 0;
+                break;
+
+            case Constant::Type_Boolean:
+                opc = LOP_JUMPXEQKB;
+                cid = cv->valueBoolean;
+                break;
+
+            case Constant::Type_Number:
+                opc = LOP_JUMPXEQKN;
+                cid = getConstantIndex(right);
+                break;
+
+            case Constant::Type_String:
+                opc = LOP_JUMPXEQKS;
+                cid = getConstantIndex(right);
+                break;
+
+            default:
+                LUAU_ASSERT(!"Unexpected constant type");
+            }
+
+            if (cid < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            size_t jumpLabel = bytecode.emitLabel();
+
+            bytecode.emitAD(opc, rl, 0);
+            bytecode.emitAux(cid | flip);
+
+            return jumpLabel;
+        }
+        else
+        {
+            LuauOpcode opc = getJumpOpCompare(expr->op, not_);
+
+            uint8_t rr = compileExprAuto(right, rs);
+
+            size_t jumpLabel = bytecode.emitLabel();
+
+            if (expr->op == AstExprBinary::CompareGt || expr->op == AstExprBinary::CompareGe)
+            {
+                bytecode.emitAD(opc, rr, 0);
+                bytecode.emitAux(rl);
+            }
+            else
+            {
+                bytecode.emitAD(opc, rl, 0);
+                bytecode.emitAux(rr);
+            }
+
+            return jumpLabel;
+        }
+    }
+
+    int32_t getConstantNumber(AstExpr* node)
+    {
+        const Constant* c = constants.find(node);
+
+        if (c && c->type == Constant::Type_Number)
+        {
+            int cid = bytecode.addConstantNumber(c->valueNumber);
+            if (cid < 0)
+                CompileError::raise(node->location, "Exceeded constant limit; simplify the code to compile");
+
+            return cid;
+        }
+
+        return -1;
+    }
+
+    int32_t getConstantIndex(AstExpr* node)
+    {
+        const Constant* c = constants.find(node);
+
+        if (!c || c->type == Constant::Type_Unknown)
+            return -1;
+
+        int cid = -1;
+
+        switch (c->type)
+        {
+        case Constant::Type_Nil:
+            cid = bytecode.addConstantNil();
+            break;
+
+        case Constant::Type_Boolean:
+            cid = bytecode.addConstantBoolean(c->valueBoolean);
+            break;
+
+        case Constant::Type_Number:
+            cid = bytecode.addConstantNumber(c->valueNumber);
+            break;
+
+        case Constant::Type_Vector:
+            cid = bytecode.addConstantVector(c->valueVector[0], c->valueVector[1], c->valueVector[2], c->valueVector[3]);
+            break;
+
+        case Constant::Type_String:
+            cid = bytecode.addConstantString(sref(c->getString()));
+            break;
+
+        default:
+            LUAU_ASSERT(!"Unexpected constant type");
+            return -1;
+        }
+
+        if (cid < 0)
+            CompileError::raise(node->location, "Exceeded constant limit; simplify the code to compile");
+
+        return cid;
+    }
+
+    // compile expr to target temp register
+    // if the expr (or not expr if onlyTruth is false) is truthy, jump via skipJump
+    // if the expr (or not expr if onlyTruth is false) is falsy, fall through (target isn't guaranteed to be updated in this case)
+    // if target is omitted, then the jump behavior is the same - skipJump or fallthrough depending on the truthiness of the expression
+    void compileConditionValue(AstExpr* node, const uint8_t* target, std::vector<size_t>& skipJump, bool onlyTruth)
+    {
+        // Optimization: we don't need to compute constant values
+        if (const Constant* cv = constants.find(node); cv && cv->type != Constant::Type_Unknown)
+        {
+            // note that we only need to compute the value if it's truthy; otherwise we cal fall through
+            if (cv->isTruthful() == onlyTruth)
+            {
+                if (target)
+                    compileExprTemp(node, *target);
+
+                skipJump.push_back(bytecode.emitLabel());
+                bytecode.emitAD(LOP_JUMP, 0, 0);
+            }
+            return;
+        }
+
+        if (AstExprBinary* expr = node->as<AstExprBinary>())
+        {
+            switch (expr->op)
+            {
+            case AstExprBinary::And:
+            case AstExprBinary::Or:
+            {
+                // disambiguation: there's 4 cases (we only need truthy or falsy results based on onlyTruth)
+                // onlyTruth = 1: a and b transforms to a ? b : dontcare
+                // onlyTruth = 1: a or b transforms to a ? a : b
+                // onlyTruth = 0: a and b transforms to !a ? a : b
+                // onlyTruth = 0: a or b transforms to !a ? b : dontcare
+                if (onlyTruth == (expr->op == AstExprBinary::And))
+                {
+                    // we need to compile the left hand side, and skip to "dontcare" (aka fallthrough of the entire statement) if it's not the same as
+                    // onlyTruth if it's the same then the result of the expression is the right hand side because of this, we *never* care about the
+                    // result of the left hand side
+                    std::vector<size_t> elseJump;
+                    compileConditionValue(expr->left, nullptr, elseJump, !onlyTruth);
+
+                    // fallthrough indicates that we need to compute & return the right hand side
+                    // we use compileConditionValue again to process any extra and/or statements directly
+                    compileConditionValue(expr->right, target, skipJump, onlyTruth);
+
+                    size_t elseLabel = bytecode.emitLabel();
+
+                    patchJumps(expr, elseJump, elseLabel);
+                }
+                else
+                {
+                    // we need to compute the left hand side first; note that we will jump to skipJump if we know the answer
+                    compileConditionValue(expr->left, target, skipJump, onlyTruth);
+
+                    // we will fall through if computing the left hand didn't give us an "interesting" result
+                    // we still use compileConditionValue to recursively optimize any and/or/compare statements
+                    compileConditionValue(expr->right, target, skipJump, onlyTruth);
+                }
+                return;
+            }
+            break;
+
+            case AstExprBinary::CompareNe:
+            case AstExprBinary::CompareEq:
+            case AstExprBinary::CompareLt:
+            case AstExprBinary::CompareLe:
+            case AstExprBinary::CompareGt:
+            case AstExprBinary::CompareGe:
+            {
+                if (target)
+                {
+                    // since target is a temp register, we'll initialize it to 1, and then jump if the comparison is true
+                    // if the comparison is false, we'll fallthrough and target will still be 1 but target has unspecified value for falsy results
+                    // when we only care about falsy values instead of truthy values, the process is the same but with flipped conditionals
+                    bytecode.emitABC(LOP_LOADB, *target, onlyTruth ? 1 : 0, 0);
+                }
+
+                size_t jumpLabel = compileCompareJump(expr, /* not= */ !onlyTruth);
+
+                skipJump.push_back(jumpLabel);
+                return;
+            }
+            break;
+
+            // fall-through to default path below
+            default:;
+            }
+        }
+
+        if (AstExprUnary* expr = node->as<AstExprUnary>())
+        {
+            // if we *do* need to compute the target, we'd have to inject "not" ops on every return path
+            // this is possible but cumbersome; so for now we only optimize not expression when we *don't* need the value
+            if (!target && expr->op == AstExprUnary::Not)
+            {
+                compileConditionValue(expr->expr, target, skipJump, !onlyTruth);
+                return;
+            }
+        }
+
+        if (AstExprGroup* expr = node->as<AstExprGroup>())
+        {
+            compileConditionValue(expr->expr, target, skipJump, onlyTruth);
+            return;
+        }
+
+        RegScope rs(this);
+        uint8_t reg;
+
+        if (target)
+        {
+            reg = *target;
+            compileExprTemp(node, reg);
+        }
+        else
+        {
+            reg = compileExprAuto(node, rs);
+        }
+
+        skipJump.push_back(bytecode.emitLabel());
+        bytecode.emitAD(onlyTruth ? LOP_JUMPIF : LOP_JUMPIFNOT, reg, 0);
+    }
+
+    // checks if compiling the expression as a condition value generates code that's faster than using compileExpr
+    bool isConditionFast(AstExpr* node)
+    {
+        const Constant* cv = constants.find(node);
+
+        if (cv && cv->type != Constant::Type_Unknown)
+            return true;
+
+        if (AstExprBinary* expr = node->as<AstExprBinary>())
+        {
+            switch (expr->op)
+            {
+            case AstExprBinary::And:
+            case AstExprBinary::Or:
+                return true;
+
+            case AstExprBinary::CompareNe:
+            case AstExprBinary::CompareEq:
+            case AstExprBinary::CompareLt:
+            case AstExprBinary::CompareLe:
+            case AstExprBinary::CompareGt:
+            case AstExprBinary::CompareGe:
+                return true;
+
+            default:
+                return false;
+            }
+        }
+
+        if (AstExprGroup* expr = node->as<AstExprGroup>())
+            return isConditionFast(expr->expr);
+
+        return false;
+    }
+
+    void compileExprAndOr(AstExprBinary* expr, uint8_t target, bool targetTemp)
+    {
+        bool and_ = (expr->op == AstExprBinary::And);
+
+        RegScope rs(this);
+
+        // Optimization: when left hand side is a constant, we can emit left hand side or right hand side
+        if (const Constant* cl = constants.find(expr->left); cl && cl->type != Constant::Type_Unknown)
+        {
+            compileExpr(and_ == cl->isTruthful() ? expr->right : expr->left, target, targetTemp);
+            return;
+        }
+
+        // Note: two optimizations below can lead to inefficient codegen when the left hand side is a condition
+        if (!isConditionFast(expr->left))
+        {
+            // Optimization: when right hand side is a local variable, we can use AND/OR
+            if (int reg = getExprLocalReg(expr->right); reg >= 0)
+            {
+                uint8_t lr = compileExprAuto(expr->left, rs);
+                uint8_t rr = uint8_t(reg);
+
+                bytecode.emitABC(and_ ? LOP_AND : LOP_OR, target, lr, rr);
+                return;
+            }
+
+            // Optimization: when right hand side is a constant, we can use ANDK/ORK
+            int32_t cid = getConstantIndex(expr->right);
+
+            if (cid >= 0 && cid <= 255)
+            {
+                uint8_t lr = compileExprAuto(expr->left, rs);
+
+                bytecode.emitABC(and_ ? LOP_ANDK : LOP_ORK, target, lr, uint8_t(cid));
+                return;
+            }
+        }
+
+        // Optimization: if target is a temp register, we can clobber it which allows us to compute the result directly into it
+        // If it's not a temp register, then something like `a = a > 1 or a + 2` may clobber `a` while evaluating left hand side, and `a+2` will break
+        uint8_t reg = targetTemp ? target : allocReg(expr, 1);
+
+        std::vector<size_t> skipJump;
+        compileConditionValue(expr->left, &reg, skipJump, /* onlyTruth= */ !and_);
+
+        compileExprTemp(expr->right, reg);
+
+        size_t moveLabel = bytecode.emitLabel();
+
+        patchJumps(expr, skipJump, moveLabel);
+
+        if (target != reg)
+            bytecode.emitABC(LOP_MOVE, target, reg, 0);
+    }
+
+    void compileExprUnary(AstExprUnary* expr, uint8_t target)
+    {
+        RegScope rs(this);
+
+        uint8_t re = compileExprAuto(expr->expr, rs);
+
+        bytecode.emitABC(getUnaryOp(expr->op), target, re, 0);
+    }
+
+    static void unrollConcats(std::vector<AstExpr*>& args)
+    {
+        for (;;)
+        {
+            AstExprBinary* be = args.back()->as<AstExprBinary>();
+
+            if (!be || be->op != AstExprBinary::Concat)
+                break;
+
+            args.back() = be->left;
+            args.push_back(be->right);
+        }
+    }
+
+    void compileExprBinary(AstExprBinary* expr, uint8_t target, bool targetTemp)
+    {
+        RegScope rs(this);
+
+        switch (expr->op)
+        {
+        case AstExprBinary::Add:
+        case AstExprBinary::Sub:
+        case AstExprBinary::Mul:
+        case AstExprBinary::Div:
+        case AstExprBinary::FloorDiv:
+        case AstExprBinary::Mod:
+        case AstExprBinary::Pow:
+        {
+            int32_t rc = getConstantNumber(expr->right);
+
+            if (rc >= 0 && rc <= 255)
+            {
+                uint8_t rl = compileExprAuto(expr->left, rs);
+
+                bytecode.emitABC(getBinaryOpArith(expr->op, /* k= */ true), target, rl, uint8_t(rc));
+            }
+            else
+            {
+                if (FFlag::LuauCompileRevK && (expr->op == AstExprBinary::Sub || expr->op == AstExprBinary::Div))
+                {
+                    int32_t lc = getConstantNumber(expr->left);
+
+                    if (lc >= 0 && lc <= 255)
+                    {
+                        uint8_t rr = compileExprAuto(expr->right, rs);
+                        LuauOpcode op = (expr->op == AstExprBinary::Sub) ? LOP_SUBRK : LOP_DIVRK;
+
+                        bytecode.emitABC(op, target, uint8_t(lc), uint8_t(rr));
+                        return;
+                    }
+                }
+
+                uint8_t rl = compileExprAuto(expr->left, rs);
+                uint8_t rr = compileExprAuto(expr->right, rs);
+
+                bytecode.emitABC(getBinaryOpArith(expr->op), target, rl, rr);
+            }
+        }
+        break;
+
+        case AstExprBinary::Concat:
+        {
+            std::vector<AstExpr*> args = {expr->left, expr->right};
+
+            // unroll the tree of concats down the right hand side to be able to do multiple ops
+            unrollConcats(args);
+
+            uint8_t regs = allocReg(expr, unsigned(args.size()));
+
+            for (size_t i = 0; i < args.size(); ++i)
+                compileExprTemp(args[i], uint8_t(regs + i));
+
+            bytecode.emitABC(LOP_CONCAT, target, regs, uint8_t(regs + args.size() - 1));
+        }
+        break;
+
+        case AstExprBinary::CompareNe:
+        case AstExprBinary::CompareEq:
+        case AstExprBinary::CompareLt:
+        case AstExprBinary::CompareLe:
+        case AstExprBinary::CompareGt:
+        case AstExprBinary::CompareGe:
+        {
+            size_t jumpLabel = compileCompareJump(expr);
+
+            // note: this skips over the next LOADB instruction because of "1" in the C slot
+            bytecode.emitABC(LOP_LOADB, target, 0, 1);
+
+            size_t thenLabel = bytecode.emitLabel();
+
+            bytecode.emitABC(LOP_LOADB, target, 1, 0);
+
+            patchJump(expr, jumpLabel, thenLabel);
+        }
+        break;
+
+        case AstExprBinary::And:
+        case AstExprBinary::Or:
+        {
+            compileExprAndOr(expr, target, targetTemp);
+        }
+        break;
+
+        default:
+            LUAU_ASSERT(!"Unexpected binary operation");
+        }
+    }
+
+    void compileExprIfElseAndOr(bool and_, uint8_t creg, AstExpr* other, uint8_t target)
+    {
+        int32_t cid = getConstantIndex(other);
+
+        if (cid >= 0 && cid <= 255)
+        {
+            bytecode.emitABC(and_ ? LOP_ANDK : LOP_ORK, target, creg, uint8_t(cid));
+        }
+        else
+        {
+            RegScope rs(this);
+            uint8_t oreg = compileExprAuto(other, rs);
+
+            bytecode.emitABC(and_ ? LOP_AND : LOP_OR, target, creg, oreg);
+        }
+    }
+
+    void compileExprIfElse(AstExprIfElse* expr, uint8_t target, bool targetTemp)
+    {
+        if (isConstant(expr->condition))
+        {
+            if (isConstantTrue(expr->condition))
+            {
+                compileExpr(expr->trueExpr, target, targetTemp);
+            }
+            else
+            {
+                compileExpr(expr->falseExpr, target, targetTemp);
+            }
+        }
+        else
+        {
+            // Optimization: convert some if..then..else expressions into and/or when the other side has no side effects and is very cheap to compute
+            // if v then v else e => v or e
+            // if v then e else v => v and e
+            if (int creg = getExprLocalReg(expr->condition); creg >= 0)
+            {
+                if (creg == getExprLocalReg(expr->trueExpr) && (getExprLocalReg(expr->falseExpr) >= 0 || isConstant(expr->falseExpr)))
+                    return compileExprIfElseAndOr(/* and_= */ false, uint8_t(creg), expr->falseExpr, target);
+                else if (creg == getExprLocalReg(expr->falseExpr) && (getExprLocalReg(expr->trueExpr) >= 0 || isConstant(expr->trueExpr)))
+                    return compileExprIfElseAndOr(/* and_= */ true, uint8_t(creg), expr->trueExpr, target);
+            }
+
+            std::vector<size_t> elseJump;
+            compileConditionValue(expr->condition, nullptr, elseJump, false);
+            compileExpr(expr->trueExpr, target, targetTemp);
+
+            // Jump over else expression evaluation
+            size_t thenLabel = bytecode.emitLabel();
+            bytecode.emitAD(LOP_JUMP, 0, 0);
+
+            size_t elseLabel = bytecode.emitLabel();
+            compileExpr(expr->falseExpr, target, targetTemp);
+            size_t endLabel = bytecode.emitLabel();
+
+            patchJumps(expr, elseJump, elseLabel);
+            patchJump(expr, thenLabel, endLabel);
+        }
+    }
+
+    void compileExprInterpString(AstExprInterpString* expr, uint8_t target, bool targetTemp)
+    {
+        size_t formatCapacity = 0;
+        for (AstArray<char> string : expr->strings)
+        {
+            formatCapacity += string.size + std::count(string.data, string.data + string.size, '%');
+        }
+
+        std::string formatString;
+        formatString.reserve(formatCapacity);
+
+        size_t stringsLeft = expr->strings.size;
+
+        for (AstArray<char> string : expr->strings)
+        {
+            if (memchr(string.data, '%', string.size))
+            {
+                for (size_t characterIndex = 0; characterIndex < string.size; ++characterIndex)
+                {
+                    char character = string.data[characterIndex];
+                    formatString.push_back(character);
+
+                    if (character == '%')
+                        formatString.push_back('%');
+                }
+            }
+            else
+                formatString.append(string.data, string.size);
+
+            stringsLeft--;
+
+            if (stringsLeft > 0)
+                formatString += "%*";
+        }
+
+        size_t formatStringSize = formatString.size();
+
+        // We can't use formatStringRef.data() directly, because short strings don't have their data
+        // pinned in memory, so when interpFormatStrings grows, these pointers will move and become invalid.
+        std::unique_ptr<char[]> formatStringPtr(new char[formatStringSize]);
+        memcpy(formatStringPtr.get(), formatString.data(), formatStringSize);
+
+        AstArray<char> formatStringArray{formatStringPtr.get(), formatStringSize};
+        interpStrings.emplace_back(std::move(formatStringPtr)); // invalidates formatStringPtr, but keeps formatStringArray intact
+
+        int32_t formatStringIndex = bytecode.addConstantString(sref(formatStringArray));
+        if (formatStringIndex < 0)
+            CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+        RegScope rs(this);
+
+        uint8_t baseReg = allocReg(expr, unsigned(2 + expr->expressions.size));
+
+        emitLoadK(baseReg, formatStringIndex);
+
+        for (size_t index = 0; index < expr->expressions.size; ++index)
+            compileExprTempTop(expr->expressions.data[index], uint8_t(baseReg + 2 + index));
+
+        BytecodeBuilder::StringRef formatMethod = sref(AstName("format"));
+
+        int32_t formatMethodIndex = bytecode.addConstantString(formatMethod);
+        if (formatMethodIndex < 0)
+            CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+        bytecode.emitABC(LOP_NAMECALL, baseReg, baseReg, uint8_t(BytecodeBuilder::getStringHash(formatMethod)));
+        bytecode.emitAux(formatMethodIndex);
+        bytecode.emitABC(LOP_CALL, baseReg, uint8_t(expr->expressions.size + 2), 2);
+        bytecode.emitABC(LOP_MOVE, target, baseReg, 0);
+    }
+
+    static uint8_t encodeHashSize(unsigned int hashSize)
+    {
+        size_t hashSizeLog2 = 0;
+        while ((1u << hashSizeLog2) < hashSize)
+            hashSizeLog2++;
+
+        return hashSize == 0 ? 0 : uint8_t(hashSizeLog2 + 1);
+    }
+
+    void compileExprTable(AstExprTable* expr, uint8_t target, bool targetTemp)
+    {
+        // Optimization: if the table is empty, we can compute it directly into the target
+        if (expr->items.size == 0)
+        {
+            TableShape shape = tableShapes[expr];
+
+            bytecode.addDebugRemark("allocation: table hash %d", shape.hashSize);
+
+            bytecode.emitABC(LOP_NEWTABLE, target, encodeHashSize(shape.hashSize), 0);
+            bytecode.emitAux(shape.arraySize);
+            return;
+        }
+
+        unsigned int arraySize = 0;
+        unsigned int hashSize = 0;
+        unsigned int recordSize = 0;
+        unsigned int indexSize = 0;
+
+        for (size_t i = 0; i < expr->items.size; ++i)
+        {
+            const AstExprTable::Item& item = expr->items.data[i];
+
+            arraySize += (item.kind == AstExprTable::Item::List);
+            hashSize += (item.kind != AstExprTable::Item::List);
+            recordSize += (item.kind == AstExprTable::Item::Record);
+        }
+
+        // Optimization: allocate sequential explicitly specified numeric indices ([1]) as arrays
+        if (arraySize == 0 && hashSize > 0)
+        {
+            for (size_t i = 0; i < expr->items.size; ++i)
+            {
+                const AstExprTable::Item& item = expr->items.data[i];
+                LUAU_ASSERT(item.key); // no list portion => all items have keys
+
+                const Constant* ckey = constants.find(item.key);
+
+                indexSize += (ckey && ckey->type == Constant::Type_Number && ckey->valueNumber == double(indexSize + 1));
+            }
+
+            // we only perform the optimization if we don't have any other []-keys
+            // technically it's "safe" to do this even if we have other keys, but doing so changes iteration order and may break existing code
+            if (hashSize == recordSize + indexSize)
+                hashSize = recordSize;
+            else
+                indexSize = 0;
+        }
+
+        int encodedHashSize = encodeHashSize(hashSize);
+
+        RegScope rs(this);
+
+        // Optimization: if target is a temp register, we can clobber it which allows us to compute the result directly into it
+        uint8_t reg = targetTemp ? target : allocReg(expr, 1);
+
+        // Optimization: when all items are record fields, use template tables to compile expression
+        if (arraySize == 0 && indexSize == 0 && hashSize == recordSize && recordSize >= 1 && recordSize <= BytecodeBuilder::TableShape::kMaxLength)
+        {
+            BytecodeBuilder::TableShape shape;
+
+            for (size_t i = 0; i < expr->items.size; ++i)
+            {
+                const AstExprTable::Item& item = expr->items.data[i];
+                LUAU_ASSERT(item.kind == AstExprTable::Item::Record);
+
+                AstExprConstantString* ckey = item.key->as<AstExprConstantString>();
+                LUAU_ASSERT(ckey);
+
+                int cid = bytecode.addConstantString(sref(ckey->value));
+                if (cid < 0)
+                    CompileError::raise(ckey->location, "Exceeded constant limit; simplify the code to compile");
+
+                LUAU_ASSERT(shape.length < BytecodeBuilder::TableShape::kMaxLength);
+                shape.keys[shape.length++] = int16_t(cid);
+            }
+
+            int32_t tid = bytecode.addConstantTable(shape);
+            if (tid < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            bytecode.addDebugRemark("allocation: table template %d", hashSize);
+
+            if (tid < 32768)
+            {
+                bytecode.emitAD(LOP_DUPTABLE, reg, int16_t(tid));
+            }
+            else
+            {
+                bytecode.emitABC(LOP_NEWTABLE, reg, uint8_t(encodedHashSize), 0);
+                bytecode.emitAux(0);
+            }
+        }
+        else
+        {
+            // Optimization: instead of allocating one extra element when the last element of the table literal is ..., let SETLIST allocate the
+            // correct amount of storage
+            const AstExprTable::Item* last = expr->items.size > 0 ? &expr->items.data[expr->items.size - 1] : nullptr;
+
+            bool trailingVarargs = last && last->kind == AstExprTable::Item::List && last->value->is<AstExprVarargs>();
+            LUAU_ASSERT(!trailingVarargs || arraySize > 0);
+
+            unsigned int arrayAllocation = arraySize - trailingVarargs + indexSize;
+
+            if (hashSize == 0)
+                bytecode.addDebugRemark("allocation: table array %d", arrayAllocation);
+            else if (arrayAllocation == 0)
+                bytecode.addDebugRemark("allocation: table hash %d", hashSize);
+            else
+                bytecode.addDebugRemark("allocation: table hash %d array %d", hashSize, arrayAllocation);
+
+            bytecode.emitABC(LOP_NEWTABLE, reg, uint8_t(encodedHashSize), 0);
+            bytecode.emitAux(arrayAllocation);
+        }
+
+        unsigned int arrayChunkSize = std::min(16u, arraySize);
+        uint8_t arrayChunkReg = allocReg(expr, arrayChunkSize);
+        unsigned int arrayChunkCurrent = 0;
+
+        unsigned int arrayIndex = 1;
+        bool multRet = false;
+
+        for (size_t i = 0; i < expr->items.size; ++i)
+        {
+            const AstExprTable::Item& item = expr->items.data[i];
+
+            AstExpr* key = item.key;
+            AstExpr* value = item.value;
+
+            // some key/value pairs don't require us to compile the expressions, so we need to setup the line info here
+            setDebugLine(value);
+
+            if (options.coverageLevel >= 2)
+            {
+                bytecode.emitABC(LOP_COVERAGE, 0, 0, 0);
+            }
+
+            // flush array chunk on overflow or before hash keys to maintain insertion order
+            if (arrayChunkCurrent > 0 && (key || arrayChunkCurrent == arrayChunkSize))
+            {
+                bytecode.emitABC(LOP_SETLIST, reg, arrayChunkReg, uint8_t(arrayChunkCurrent + 1));
+                bytecode.emitAux(arrayIndex);
+                arrayIndex += arrayChunkCurrent;
+                arrayChunkCurrent = 0;
+            }
+
+            // items with a key are set one by one via SETTABLE/SETTABLEKS/SETTABLEN
+            if (key)
+            {
+                RegScope rsi(this);
+
+                LValue lv = compileLValueIndex(reg, key, rsi);
+                uint8_t rv = compileExprAuto(value, rsi);
+
+                compileAssign(lv, rv);
+            }
+            // items without a key are set using SETLIST so that we can initialize large arrays quickly
+            else
+            {
+                uint8_t temp = uint8_t(arrayChunkReg + arrayChunkCurrent);
+
+                if (i + 1 == expr->items.size)
+                    multRet = compileExprTempMultRet(value, temp);
+                else
+                    compileExprTempTop(value, temp);
+
+                arrayChunkCurrent++;
+            }
+        }
+
+        // flush last array chunk; note that this needs multret handling if the last expression was multret
+        if (arrayChunkCurrent)
+        {
+            bytecode.emitABC(LOP_SETLIST, reg, arrayChunkReg, multRet ? 0 : uint8_t(arrayChunkCurrent + 1));
+            bytecode.emitAux(arrayIndex);
+        }
+
+        if (target != reg)
+            bytecode.emitABC(LOP_MOVE, target, reg, 0);
+    }
+
+    bool canImport(AstExprGlobal* expr)
+    {
+        return options.optimizationLevel >= 1 && getGlobalState(globals, expr->name) != Global::Written;
+    }
+
+    bool canImportChain(AstExprGlobal* expr)
+    {
+        return options.optimizationLevel >= 1 && getGlobalState(globals, expr->name) == Global::Default;
+    }
+
+    void compileExprIndexName(AstExprIndexName* expr, uint8_t target)
+    {
+        setDebugLine(expr); // normally compileExpr sets up line info, but compileExprIndexName can be called directly
+
+        // Optimization: index chains that start from global variables can be compiled into GETIMPORT statement
+        AstExprGlobal* importRoot = 0;
+        AstExprIndexName* import1 = 0;
+        AstExprIndexName* import2 = 0;
+
+        if (AstExprIndexName* index = expr->expr->as<AstExprIndexName>())
+        {
+            importRoot = index->expr->as<AstExprGlobal>();
+            import1 = index;
+            import2 = expr;
+        }
+        else
+        {
+            importRoot = expr->expr->as<AstExprGlobal>();
+            import1 = expr;
+        }
+
+        if (importRoot && canImportChain(importRoot))
+        {
+            int32_t id0 = bytecode.addConstantString(sref(importRoot->name));
+            int32_t id1 = bytecode.addConstantString(sref(import1->index));
+            int32_t id2 = import2 ? bytecode.addConstantString(sref(import2->index)) : -1;
+
+            if (id0 < 0 || id1 < 0 || (import2 && id2 < 0))
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            // Note: GETIMPORT encoding is limited to 10 bits per object id component
+            if (id0 < 1024 && id1 < 1024 && id2 < 1024)
+            {
+                uint32_t iid = import2 ? BytecodeBuilder::getImportId(id0, id1, id2) : BytecodeBuilder::getImportId(id0, id1);
+                int32_t cid = bytecode.addImport(iid);
+
+                if (cid >= 0 && cid < 32768)
+                {
+                    bytecode.emitAD(LOP_GETIMPORT, target, int16_t(cid));
+                    bytecode.emitAux(iid);
+                    return;
+                }
+            }
+        }
+
+        RegScope rs(this);
+        uint8_t reg = compileExprAuto(expr->expr, rs);
+
+        setDebugLine(expr->indexLocation);
+
+        BytecodeBuilder::StringRef iname = sref(expr->index);
+        int32_t cid = bytecode.addConstantString(iname);
+        if (cid < 0)
+            CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+        bytecode.emitABC(LOP_GETTABLEKS, target, reg, uint8_t(BytecodeBuilder::getStringHash(iname)));
+        bytecode.emitAux(cid);
+    }
+
+    void compileExprIndexExpr(AstExprIndexExpr* expr, uint8_t target)
+    {
+        RegScope rs(this);
+
+        Constant cv = getConstant(expr->index);
+
+        if (cv.type == Constant::Type_Number && cv.valueNumber >= 1 && cv.valueNumber <= 256 && double(int(cv.valueNumber)) == cv.valueNumber)
+        {
+            uint8_t i = uint8_t(int(cv.valueNumber) - 1);
+
+            uint8_t rt = compileExprAuto(expr->expr, rs);
+
+            setDebugLine(expr->index);
+
+            bytecode.emitABC(LOP_GETTABLEN, target, rt, i);
+        }
+        else if (cv.type == Constant::Type_String)
+        {
+            BytecodeBuilder::StringRef iname = sref(cv.getString());
+            int32_t cid = bytecode.addConstantString(iname);
+            if (cid < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            uint8_t rt = compileExprAuto(expr->expr, rs);
+
+            setDebugLine(expr->index);
+
+            bytecode.emitABC(LOP_GETTABLEKS, target, rt, uint8_t(BytecodeBuilder::getStringHash(iname)));
+            bytecode.emitAux(cid);
+        }
+        else
+        {
+            uint8_t rt = compileExprAuto(expr->expr, rs);
+            uint8_t ri = compileExprAuto(expr->index, rs);
+
+            bytecode.emitABC(LOP_GETTABLE, target, rt, ri);
+        }
+    }
+
+    void compileExprGlobal(AstExprGlobal* expr, uint8_t target)
+    {
+        // Optimization: builtin globals can be retrieved using GETIMPORT
+        if (canImport(expr))
+        {
+            int32_t id0 = bytecode.addConstantString(sref(expr->name));
+            if (id0 < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            // Note: GETIMPORT encoding is limited to 10 bits per object id component
+            if (id0 < 1024)
+            {
+                uint32_t iid = BytecodeBuilder::getImportId(id0);
+                int32_t cid = bytecode.addImport(iid);
+
+                if (cid >= 0 && cid < 32768)
+                {
+                    bytecode.emitAD(LOP_GETIMPORT, target, int16_t(cid));
+                    bytecode.emitAux(iid);
+                    return;
+                }
+            }
+        }
+
+        BytecodeBuilder::StringRef gname = sref(expr->name);
+        int32_t cid = bytecode.addConstantString(gname);
+        if (cid < 0)
+            CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+        bytecode.emitABC(LOP_GETGLOBAL, target, 0, uint8_t(BytecodeBuilder::getStringHash(gname)));
+        bytecode.emitAux(cid);
+    }
+
+    void compileExprConstant(AstExpr* node, const Constant* cv, uint8_t target)
+    {
+        switch (cv->type)
+        {
+        case Constant::Type_Nil:
+            bytecode.emitABC(LOP_LOADNIL, target, 0, 0);
+            break;
+
+        case Constant::Type_Boolean:
+            bytecode.emitABC(LOP_LOADB, target, cv->valueBoolean, 0);
+            break;
+
+        case Constant::Type_Number:
+        {
+            double d = cv->valueNumber;
+
+            if (d >= std::numeric_limits<int16_t>::min() && d <= std::numeric_limits<int16_t>::max() && double(int16_t(d)) == d &&
+                !(d == 0.0 && signbit(d)))
+            {
+                // short number encoding: doesn't require a table entry lookup
+                bytecode.emitAD(LOP_LOADN, target, int16_t(d));
+            }
+            else
+            {
+                // long number encoding: use generic constant path
+                int32_t cid = bytecode.addConstantNumber(d);
+                if (cid < 0)
+                    CompileError::raise(node->location, "Exceeded constant limit; simplify the code to compile");
+
+                emitLoadK(target, cid);
+            }
+        }
+        break;
+
+        case Constant::Type_Vector:
+        {
+            int32_t cid = bytecode.addConstantVector(cv->valueVector[0], cv->valueVector[1], cv->valueVector[2], cv->valueVector[3]);
+            emitLoadK(target, cid);
+        }
+        break;
+
+        case Constant::Type_String:
+        {
+            int32_t cid = bytecode.addConstantString(sref(cv->getString()));
+            if (cid < 0)
+                CompileError::raise(node->location, "Exceeded constant limit; simplify the code to compile");
+
+            emitLoadK(target, cid);
+        }
+        break;
+
+        default:
+            LUAU_ASSERT(!"Unexpected constant type");
+        }
+    }
+
+    void compileExpr(AstExpr* node, uint8_t target, bool targetTemp = false)
+    {
+        setDebugLine(node);
+
+        if (options.coverageLevel >= 2 && needsCoverage(node))
+        {
+            bytecode.emitABC(LOP_COVERAGE, 0, 0, 0);
+        }
+
+        // Optimization: if expression has a constant value, we can emit it directly
+        if (const Constant* cv = constants.find(node); cv && cv->type != Constant::Type_Unknown)
+        {
+            compileExprConstant(node, cv, target);
+            return;
+        }
+
+        if (AstExprGroup* expr = node->as<AstExprGroup>())
+        {
+            compileExpr(expr->expr, target, targetTemp);
+        }
+        else if (node->is<AstExprConstantNil>())
+        {
+            bytecode.emitABC(LOP_LOADNIL, target, 0, 0);
+        }
+        else if (AstExprConstantBool* expr = node->as<AstExprConstantBool>())
+        {
+            bytecode.emitABC(LOP_LOADB, target, expr->value, 0);
+        }
+        else if (AstExprConstantNumber* expr = node->as<AstExprConstantNumber>())
+        {
+            int32_t cid = bytecode.addConstantNumber(expr->value);
+            if (cid < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            emitLoadK(target, cid);
+        }
+        else if (AstExprConstantString* expr = node->as<AstExprConstantString>())
+        {
+            int32_t cid = bytecode.addConstantString(sref(expr->value));
+            if (cid < 0)
+                CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
+
+            emitLoadK(target, cid);
+        }
+        else if (AstExprLocal* expr = node->as<AstExprLocal>())
+        {
+            // note: this can't check expr->upvalue because upvalues may be upgraded to locals during inlining
+            if (int reg = getExprLocalReg(expr); reg >= 0)
+            {
+                // Optimization: we don't need to move if target happens to be in the same register
+                if (options.optimizationLevel == 0 || target != reg)
+                    bytecode.emitABC(LOP_MOVE, target, uint8_t(reg), 0);
+            }
+            else
+            {
+                LUAU_ASSERT(expr->upvalue);
+                uint8_t uid = getUpval(expr->local);
+
+                bytecode.emitABC(LOP_GETUPVAL, target, uid, 0);
+            }
+        }
+        else if (AstExprGlobal* expr = node->as<AstExprGlobal>())
+        {
+            compileExprGlobal(expr, target);
+        }
+        else if (AstExprVarargs* expr = node->as<AstExprVarargs>())
+        {
+            compileExprVarargs(expr, target, /* targetCount= */ 1);
+        }
+        else if (AstExprCall* expr = node->as<AstExprCall>())
+        {
+            // Optimization: when targeting temporary registers, we can compile call in a special mode that doesn't require extra register moves
+            if (targetTemp && target == regTop - 1)
+                compileExprCall(expr, target, 1, /* targetTop= */ true);
+            else
+                compileExprCall(expr, target, /* targetCount= */ 1);
+        }
+        else if (AstExprIndexName* expr = node->as<AstExprIndexName>())
+        {
+            compileExprIndexName(expr, target);
+        }
+        else if (AstExprIndexExpr* expr = node->as<AstExprIndexExpr>())
+        {
+            compileExprIndexExpr(expr, target);
+        }
+        else if (AstExprFunction* expr = node->as<AstExprFunction>())
+        {
+            compileExprFunction(expr, target);
+        }
+        else if (AstExprTable* expr = node->as<AstExprTable>())
+        {
+            compileExprTable(expr, target, targetTemp);
+        }
+        else if (AstExprUnary* expr = node->as<AstExprUnary>())
+        {
+            compileExprUnary(expr, target);
+        }
+        else if (AstExprBinary* expr = node->as<AstExprBinary>())
+        {
+            compileExprBinary(expr, target, targetTemp);
+        }
+        else if (AstExprTypeAssertion* expr = node->as<AstExprTypeAssertion>())
+        {
+            compileExpr(expr->expr, target, targetTemp);
+        }
+        else if (AstExprIfElse* expr = node->as<AstExprIfElse>())
+        {
+            compileExprIfElse(expr, target, targetTemp);
+        }
+        else if (AstExprInterpString* interpString = node->as<AstExprInterpString>())
+        {
+            compileExprInterpString(interpString, target, targetTemp);
+        }
+        else
+        {
+            LUAU_ASSERT(!"Unknown expression type");
+        }
+    }
+
+    void compileExprTemp(AstExpr* node, uint8_t target)
+    {
+        return compileExpr(node, target, /* targetTemp= */ true);
+    }
+
+    uint8_t compileExprAuto(AstExpr* node, RegScope&)
+    {
+        // Optimization: directly return locals instead of copying them to a temporary
+        if (int reg = getExprLocalReg(node); reg >= 0)
+            return uint8_t(reg);
+
+        // note: the register is owned by the parent scope
+        uint8_t reg = allocReg(node, 1);
+
+        compileExprTemp(node, reg);
+
+        return reg;
+    }
+
+    void compileExprSide(AstExpr* node)
+    {
+        // Optimization: some expressions never carry side effects so we don't need to emit any code
+        if (node->is<AstExprLocal>() || node->is<AstExprGlobal>() || node->is<AstExprVarargs>() || node->is<AstExprFunction>() || isConstant(node))
+            return;
+
+        // note: the remark is omitted for calls as it's fairly noisy due to inlining
+        if (!node->is<AstExprCall>())
+            bytecode.addDebugRemark("expression only compiled for side effects");
+
+        RegScope rsi(this);
+        compileExprAuto(node, rsi);
+    }
+
+    // initializes target..target+targetCount-1 range using expression
+    // if expression is a call/vararg, we assume it returns all values, otherwise we fill the rest with nil
+    // assumes target register range can be clobbered and is at the top of the register space if targetTop = true
+    void compileExprTempN(AstExpr* node, uint8_t target, uint8_t targetCount, bool targetTop)
+    {
+        // we assume that target range is at the top of the register space and can be clobbered
+        // this is what allows us to compile the last call expression - if it's a call - using targetTop=true
+        LUAU_ASSERT(!targetTop || unsigned(target + targetCount) == regTop);
+
+        if (AstExprCall* expr = node->as<AstExprCall>())
+        {
+            compileExprCall(expr, target, targetCount, targetTop);
+        }
+        else if (AstExprVarargs* expr = node->as<AstExprVarargs>())
+        {
+            compileExprVarargs(expr, target, targetCount);
+        }
+        else
+        {
+            compileExprTemp(node, target);
+
+            for (size_t i = 1; i < targetCount; ++i)
+                bytecode.emitABC(LOP_LOADNIL, uint8_t(target + i), 0, 0);
+        }
+    }
+
+    // initializes target..target+targetCount-1 range using expressions from the list
+    // if list has fewer expressions, and last expression is multret, we assume it returns the rest of the values
+    // if list has fewer expressions, and last expression isn't multret, we fill the rest with nil
+    // assumes target register range can be clobbered and is at the top of the register space if targetTop = true
+    void compileExprListTemp(const AstArray<AstExpr*>& list, uint8_t target, uint8_t targetCount, bool targetTop)
+    {
+        // we assume that target range is at the top of the register space and can be clobbered
+        // this is what allows us to compile the last call expression - if it's a call - using targetTop=true
+        LUAU_ASSERT(!targetTop || unsigned(target + targetCount) == regTop);
+
+        if (list.size == targetCount)
+        {
+            for (size_t i = 0; i < list.size; ++i)
+                compileExprTemp(list.data[i], uint8_t(target + i));
+        }
+        else if (list.size > targetCount)
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                compileExprTemp(list.data[i], uint8_t(target + i));
+
+            // evaluate extra expressions for side effects
+            for (size_t i = targetCount; i < list.size; ++i)
+                compileExprSide(list.data[i]);
+        }
+        else if (list.size > 0)
+        {
+            for (size_t i = 0; i < list.size - 1; ++i)
+                compileExprTemp(list.data[i], uint8_t(target + i));
+
+            compileExprTempN(list.data[list.size - 1], uint8_t(target + list.size - 1), uint8_t(targetCount - (list.size - 1)), targetTop);
+        }
+        else
+        {
+            for (size_t i = 0; i < targetCount; ++i)
+                bytecode.emitABC(LOP_LOADNIL, uint8_t(target + i), 0, 0);
+        }
+    }
+
+    struct LValue
+    {
+        enum Kind
+        {
+            Kind_Local,
+            Kind_Upvalue,
+            Kind_Global,
+            Kind_IndexName,
+            Kind_IndexNumber,
+            Kind_IndexExpr,
+        };
+
+        Kind kind;
+        uint8_t reg; // register for local (Local) or table (Index*)
+        uint8_t upval;
+        uint8_t index;  // register for index in IndexExpr
+        uint8_t number; // index-1 (0-255) in IndexNumber
+        BytecodeBuilder::StringRef name;
+        Location location;
+    };
+
+    LValue compileLValueIndex(uint8_t reg, AstExpr* index, RegScope& rs)
+    {
+        Constant cv = getConstant(index);
+
+        if (cv.type == Constant::Type_Number && cv.valueNumber >= 1 && cv.valueNumber <= 256 && double(int(cv.valueNumber)) == cv.valueNumber)
+        {
+            LValue result = {LValue::Kind_IndexNumber};
+            result.reg = reg;
+            result.number = uint8_t(int(cv.valueNumber) - 1);
+            result.location = index->location;
+
+            return result;
+        }
+        else if (cv.type == Constant::Type_String)
+        {
+            LValue result = {LValue::Kind_IndexName};
+            result.reg = reg;
+            result.name = sref(cv.getString());
+            result.location = index->location;
+
+            return result;
+        }
+        else
+        {
+            LValue result = {LValue::Kind_IndexExpr};
+            result.reg = reg;
+            result.index = compileExprAuto(index, rs);
+            result.location = index->location;
+
+            return result;
+        }
+    }
+
+    LValue compileLValue(AstExpr* node, RegScope& rs)
+    {
+        setDebugLine(node);
+
+        if (AstExprLocal* expr = node->as<AstExprLocal>())
+        {
+            // note: this can't check expr->upvalue because upvalues may be upgraded to locals during inlining
+            if (int reg = getExprLocalReg(expr); reg >= 0)
+            {
+                LValue result = {LValue::Kind_Local};
+                result.reg = uint8_t(reg);
+                result.location = node->location;
+
+                return result;
+            }
+            else
+            {
+                LUAU_ASSERT(expr->upvalue);
+
+                LValue result = {LValue::Kind_Upvalue};
+                result.upval = getUpval(expr->local);
+                result.location = node->location;
+
+                return result;
+            }
+        }
+        else if (AstExprGlobal* expr = node->as<AstExprGlobal>())
+        {
+            LValue result = {LValue::Kind_Global};
+            result.name = sref(expr->name);
+            result.location = node->location;
+
+            return result;
+        }
+        else if (AstExprIndexName* expr = node->as<AstExprIndexName>())
+        {
+            LValue result = {LValue::Kind_IndexName};
+            result.reg = compileExprAuto(expr->expr, rs);
+            result.name = sref(expr->index);
+            result.location = node->location;
+
+            return result;
+        }
+        else if (AstExprIndexExpr* expr = node->as<AstExprIndexExpr>())
+        {
+            uint8_t reg = compileExprAuto(expr->expr, rs);
+
+            return compileLValueIndex(reg, expr->index, rs);
+        }
+        else
+        {
+            LUAU_ASSERT(!"Unknown assignment expression");
+
+            return LValue();
+        }
+    }
+
+    void compileLValueUse(const LValue& lv, uint8_t reg, bool set)
+    {
+        setDebugLine(lv.location);
+
+        switch (lv.kind)
+        {
+        case LValue::Kind_Local:
+            if (set)
+                bytecode.emitABC(LOP_MOVE, lv.reg, reg, 0);
+            else
+                bytecode.emitABC(LOP_MOVE, reg, lv.reg, 0);
+            break;
+
+        case LValue::Kind_Upvalue:
+            bytecode.emitABC(set ? LOP_SETUPVAL : LOP_GETUPVAL, reg, lv.upval, 0);
+            break;
+
+        case LValue::Kind_Global:
+        {
+            int32_t cid = bytecode.addConstantString(lv.name);
+            if (cid < 0)
+                CompileError::raise(lv.location, "Exceeded constant limit; simplify the code to compile");
+
+            bytecode.emitABC(set ? LOP_SETGLOBAL : LOP_GETGLOBAL, reg, 0, uint8_t(BytecodeBuilder::getStringHash(lv.name)));
+            bytecode.emitAux(cid);
+        }
+        break;
+
+        case LValue::Kind_IndexName:
+        {
+            int32_t cid = bytecode.addConstantString(lv.name);
+            if (cid < 0)
+                CompileError::raise(lv.location, "Exceeded constant limit; simplify the code to compile");
+
+            bytecode.emitABC(set ? LOP_SETTABLEKS : LOP_GETTABLEKS, reg, lv.reg, uint8_t(BytecodeBuilder::getStringHash(lv.name)));
+            bytecode.emitAux(cid);
+        }
+        break;
+
+        case LValue::Kind_IndexNumber:
+            bytecode.emitABC(set ? LOP_SETTABLEN : LOP_GETTABLEN, reg, lv.reg, lv.number);
+            break;
+
+        case LValue::Kind_IndexExpr:
+            bytecode.emitABC(set ? LOP_SETTABLE : LOP_GETTABLE, reg, lv.reg, lv.index);
+            break;
+
+        default:
+            LUAU_ASSERT(!"Unknown lvalue kind");
+        }
+    }
+
+    void compileAssign(const LValue& lv, uint8_t source)
+    {
+        compileLValueUse(lv, source, /* set= */ true);
+    }
+
+    AstExprLocal* getExprLocal(AstExpr* node)
+    {
+        if (AstExprLocal* expr = node->as<AstExprLocal>())
+            return expr;
+        else if (AstExprGroup* expr = node->as<AstExprGroup>())
+            return getExprLocal(expr->expr);
+        else if (AstExprTypeAssertion* expr = node->as<AstExprTypeAssertion>())
+            return getExprLocal(expr->expr);
+        else
+            return nullptr;
+    }
+
+    int getExprLocalReg(AstExpr* node)
+    {
+        if (AstExprLocal* expr = getExprLocal(node))
+        {
+            // note: this can't check expr->upvalue because upvalues may be upgraded to locals during inlining
+            Local* l = locals.find(expr->local);
+
+            return l && l->allocated ? l->reg : -1;
+        }
+        else
+            return -1;
+    }
+
+    bool isStatBreak(AstStat* node)
+    {
+        if (AstStatBlock* stat = node->as<AstStatBlock>())
+            return stat->body.size == 1 && stat->body.data[0]->is<AstStatBreak>();
+
+        return node->is<AstStatBreak>();
+    }
+
+    AstStatContinue* extractStatContinue(AstStatBlock* block)
+    {
+        if (block->body.size == 1)
+            return block->body.data[0]->as<AstStatContinue>();
+        else
+            return nullptr;
+    }
+
+    void compileStatIf(AstStatIf* stat)
+    {
+        // Optimization: condition is always false => we only need the else body
+        if (isConstantFalse(stat->condition))
+        {
+            if (stat->elsebody)
+                compileStat(stat->elsebody);
+            return;
+        }
+
+        // Optimization: condition is always false but isn't a constant => we only need the else body and condition's side effects
+        if (AstExprBinary* cand = stat->condition->as<AstExprBinary>(); cand && cand->op == AstExprBinary::And && isConstantFalse(cand->right))
+        {
+            compileExprSide(cand->left);
+            if (stat->elsebody)
+                compileStat(stat->elsebody);
+            return;
+        }
+
+        // Optimization: body is a "break" statement with no "else" => we can directly break out of the loop in "then" case
+        if (!stat->elsebody && isStatBreak(stat->thenbody) && !areLocalsCaptured(loops.back().localOffset))
+        {
+            // fallthrough = continue with the loop as usual
+            std::vector<size_t> elseJump;
+            compileConditionValue(stat->condition, nullptr, elseJump, true);
+
+            for (size_t jump : elseJump)
+                loopJumps.push_back({LoopJump::Break, jump});
+            return;
+        }
+
+        AstStatContinue* continueStatement = extractStatContinue(stat->thenbody);
+
+        // Optimization: body is a "continue" statement with no "else" => we can directly continue in "then" case
+        if (!stat->elsebody && continueStatement != nullptr && !areLocalsCaptured(loops.back().localOffsetContinue))
+        {
+            // track continue statement for repeat..until validation (validateContinueUntil)
+            if (!loops.back().continueUsed)
+                loops.back().continueUsed = continueStatement;
+
+            // fallthrough = proceed with the loop body as usual
+            std::vector<size_t> elseJump;
+            compileConditionValue(stat->condition, nullptr, elseJump, true);
+
+            for (size_t jump : elseJump)
+                loopJumps.push_back({LoopJump::Continue, jump});
+            return;
+        }
+
+        std::vector<size_t> elseJump;
+        compileConditionValue(stat->condition, nullptr, elseJump, false);
+
+        compileStat(stat->thenbody);
+
+        if (stat->elsebody && elseJump.size() > 0)
+        {
+            // we don't need to skip past "else" body if "then" ends with return/break/continue
+            // this is important because, if "else" also ends with return, we may *not* have any statement to skip to!
+            if (alwaysTerminates(stat->thenbody))
+            {
+                size_t elseLabel = bytecode.emitLabel();
+
+                compileStat(stat->elsebody);
+
+                patchJumps(stat, elseJump, elseLabel);
+            }
+            else
+            {
+                size_t thenLabel = bytecode.emitLabel();
+
+                bytecode.emitAD(LOP_JUMP, 0, 0);
+
+                size_t elseLabel = bytecode.emitLabel();
+
+                compileStat(stat->elsebody);
+
+                size_t endLabel = bytecode.emitLabel();
+
+                patchJumps(stat, elseJump, elseLabel);
+                patchJump(stat, thenLabel, endLabel);
+            }
+        }
+        else
+        {
+            size_t endLabel = bytecode.emitLabel();
+
+            patchJumps(stat, elseJump, endLabel);
+        }
+    }
+
+    void compileStatWhile(AstStatWhile* stat)
+    {
+        // Optimization: condition is always false => there's no loop!
+        if (isConstantFalse(stat->condition))
+            return;
+
+        size_t oldJumps = loopJumps.size();
+        size_t oldLocals = localStack.size();
+
+        loops.push_back({oldLocals, oldLocals, nullptr});
+        hasLoops = true;
+
+        size_t loopLabel = bytecode.emitLabel();
+
+        std::vector<size_t> elseJump;
+        compileConditionValue(stat->condition, nullptr, elseJump, false);
+
+        compileStat(stat->body);
+
+        size_t contLabel = bytecode.emitLabel();
+
+        size_t backLabel = bytecode.emitLabel();
+
+        setDebugLine(stat->condition);
+
+        // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptible and we want all loops to have at least one interruptible
+        // instruction
+        bytecode.emitAD(LOP_JUMPBACK, 0, 0);
+
+        size_t endLabel = bytecode.emitLabel();
+
+        patchJump(stat, backLabel, loopLabel);
+        patchJumps(stat, elseJump, endLabel);
+
+        patchLoopJumps(stat, oldJumps, endLabel, contLabel);
+        loopJumps.resize(oldJumps);
+
+        loops.pop_back();
+    }
+
+    void compileStatRepeat(AstStatRepeat* stat)
+    {
+        size_t oldJumps = loopJumps.size();
+        size_t oldLocals = localStack.size();
+
+        loops.push_back({oldLocals, oldLocals, nullptr});
+        hasLoops = true;
+
+        size_t loopLabel = bytecode.emitLabel();
+
+        // note: we "inline" compileStatBlock here so that we can close/pop locals after evaluating condition
+        // this is necessary because condition can access locals declared inside the repeat..until body
+        AstStatBlock* body = stat->body;
+
+        RegScope rs(this);
+
+        bool continueValidated = false;
+
+        for (size_t i = 0; i < body->body.size; ++i)
+        {
+            compileStat(body->body.data[i]);
+
+            // continue statement inside the repeat..until loop should not close upvalues defined directly in the loop body
+            // (but it must still close upvalues defined in more nested blocks)
+            // this is because the upvalues defined inside the loop body may be captured by a closure defined in the until
+            // expression that continue will jump to.
+            loops.back().localOffsetContinue = localStack.size();
+
+            // if continue was called from this statement, any local defined after this in the loop body should not be accessed by until condition
+            // it is sufficient to check this condition once, as if this holds for the first continue, it must hold for all subsequent continues.
+            if (loops.back().continueUsed && !continueValidated)
+            {
+                validateContinueUntil(loops.back().continueUsed, stat->condition, body, i + 1);
+                continueValidated = true;
+            }
+        }
+
+        size_t contLabel = bytecode.emitLabel();
+
+        size_t endLabel;
+
+        setDebugLine(stat->condition);
+
+        if (isConstantTrue(stat->condition))
+        {
+            closeLocals(oldLocals);
+
+            endLabel = bytecode.emitLabel();
+        }
+        else
+        {
+            std::vector<size_t> skipJump;
+            compileConditionValue(stat->condition, nullptr, skipJump, true);
+
+            // we close locals *after* we compute loop conditionals because during computation of condition it's (in theory) possible that user code
+            // mutates them
+            closeLocals(oldLocals);
+
+            size_t backLabel = bytecode.emitLabel();
+
+            // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptible and we want all loops to have at least one interruptible
+            // instruction
+            bytecode.emitAD(LOP_JUMPBACK, 0, 0);
+
+            size_t skipLabel = bytecode.emitLabel();
+
+            // we need to close locals *again* after the loop ends because the first closeLocals would be jumped over on the last iteration
+            closeLocals(oldLocals);
+
+            endLabel = bytecode.emitLabel();
+
+            patchJump(stat, backLabel, loopLabel);
+            patchJumps(stat, skipJump, skipLabel);
+        }
+
+        popLocals(oldLocals);
+
+        patchLoopJumps(stat, oldJumps, endLabel, contLabel);
+        loopJumps.resize(oldJumps);
+
+        loops.pop_back();
+    }
+
+    void compileInlineReturn(AstStatReturn* stat, bool fallthrough)
+    {
+        setDebugLine(stat); // normally compileStat sets up line info, but compileInlineReturn can be called directly
+
+        InlineFrame frame = inlineFrames.back();
+
+        compileExprListTemp(stat->list, frame.target, frame.targetCount, /* targetTop= */ false);
+
+        closeLocals(frame.localOffset);
+
+        if (!fallthrough)
+        {
+            size_t jumpLabel = bytecode.emitLabel();
+            bytecode.emitAD(LOP_JUMP, 0, 0);
+
+            inlineFrames.back().returnJumps.push_back(jumpLabel);
+        }
+    }
+
+    void compileStatReturn(AstStatReturn* stat)
+    {
+        RegScope rs(this);
+
+        uint8_t temp = 0;
+        bool consecutive = false;
+        bool multRet = false;
+
+        // Optimization: return locals directly instead of copying them into a temporary
+        // this is very important for a single return value and occasionally effective for multiple values
+        if (int reg = stat->list.size > 0 ? getExprLocalReg(stat->list.data[0]) : -1; reg >= 0)
+        {
+            temp = uint8_t(reg);
+            consecutive = true;
+
+            for (size_t i = 1; i < stat->list.size; ++i)
+                if (getExprLocalReg(stat->list.data[i]) != int(temp + i))
+                {
+                    consecutive = false;
+                    break;
+                }
+        }
+
+        if (!consecutive && stat->list.size > 0)
+        {
+            temp = allocReg(stat, unsigned(stat->list.size));
+
+            // Note: if the last element is a function call or a vararg specifier, then we need to somehow return all values that that call returned
+            for (size_t i = 0; i < stat->list.size; ++i)
+                if (i + 1 == stat->list.size)
+                    multRet = compileExprTempMultRet(stat->list.data[i], uint8_t(temp + i));
+                else
+                    compileExprTempTop(stat->list.data[i], uint8_t(temp + i));
+        }
+
+        closeLocals(0);
+
+        bytecode.emitABC(LOP_RETURN, uint8_t(temp), multRet ? 0 : uint8_t(stat->list.size + 1), 0);
+    }
+
+    bool areLocalsRedundant(AstStatLocal* stat)
+    {
+        // Extra expressions may have side effects
+        if (stat->values.size > stat->vars.size)
+            return false;
+
+        for (AstLocal* local : stat->vars)
+        {
+            Variable* v = variables.find(local);
+
+            if (!v || !v->constant)
+                return false;
+        }
+
+        return true;
+    }
+
+    void compileStatLocal(AstStatLocal* stat)
+    {
+        // Optimization: we don't need to allocate and assign const locals, since their uses will be constant-folded
+        if (options.optimizationLevel >= 1 && options.debugLevel <= 1 && areLocalsRedundant(stat))
+            return;
+
+        // Optimization: for 1-1 local assignments, we can reuse the register *if* neither local is mutated
+        if (options.optimizationLevel >= 1 && stat->vars.size == 1 && stat->values.size == 1)
+        {
+            if (AstExprLocal* re = getExprLocal(stat->values.data[0]))
+            {
+                Variable* lv = variables.find(stat->vars.data[0]);
+                Variable* rv = variables.find(re->local);
+
+                if (int reg = getExprLocalReg(re); reg >= 0 && (!lv || !lv->written) && (!rv || !rv->written))
+                {
+                    pushLocal(stat->vars.data[0], uint8_t(reg));
+                    return;
+                }
+            }
+        }
+
+        // note: allocReg in this case allocates into parent block register - note that we don't have RegScope here
+        uint8_t vars = allocReg(stat, unsigned(stat->vars.size));
+
+        compileExprListTemp(stat->values, vars, uint8_t(stat->vars.size), /* targetTop= */ true);
+
+        for (size_t i = 0; i < stat->vars.size; ++i)
+            pushLocal(stat->vars.data[i], uint8_t(vars + i));
+    }
+
+    bool tryCompileUnrolledFor(AstStatFor* stat, int thresholdBase, int thresholdMaxBoost)
+    {
+        Constant one = {Constant::Type_Number};
+        one.valueNumber = 1.0;
+
+        Constant fromc = getConstant(stat->from);
+        Constant toc = getConstant(stat->to);
+        Constant stepc = stat->step ? getConstant(stat->step) : one;
+
+        int tripCount = (fromc.type == Constant::Type_Number && toc.type == Constant::Type_Number && stepc.type == Constant::Type_Number)
+                            ? getTripCount(fromc.valueNumber, toc.valueNumber, stepc.valueNumber)
+                            : -1;
+
+        if (tripCount < 0)
+        {
+            bytecode.addDebugRemark("loop unroll failed: invalid iteration count");
+            return false;
+        }
+
+        if (tripCount > thresholdBase)
+        {
+            bytecode.addDebugRemark("loop unroll failed: too many iterations (%d)", tripCount);
+            return false;
+        }
+
+        if (Variable* lv = variables.find(stat->var); lv && lv->written)
+        {
+            bytecode.addDebugRemark("loop unroll failed: mutable loop variable");
+            return false;
+        }
+
+        AstLocal* var = stat->var;
+        uint64_t costModel = modelCost(stat->body, &var, 1, builtins);
+
+        // we use a dynamic cost threshold that's based on the fixed limit boosted by the cost advantage we gain due to unrolling
+        bool varc = true;
+        int unrolledCost = computeCost(costModel, &varc, 1) * tripCount;
+        int baselineCost = (computeCost(costModel, nullptr, 0) + 1) * tripCount;
+        int unrollProfit = (unrolledCost == 0) ? thresholdMaxBoost : std::min(thresholdMaxBoost, 100 * baselineCost / unrolledCost);
+
+        int threshold = thresholdBase * unrollProfit / 100;
+
+        if (unrolledCost > threshold)
+        {
+            bytecode.addDebugRemark(
+                "loop unroll failed: too expensive (iterations %d, cost %d, profit %.2fx)", tripCount, unrolledCost, double(unrollProfit) / 100);
+            return false;
+        }
+
+        bytecode.addDebugRemark("loop unroll succeeded (iterations %d, cost %d, profit %.2fx)", tripCount, unrolledCost, double(unrollProfit) / 100);
+
+        compileUnrolledFor(stat, tripCount, fromc.valueNumber, stepc.valueNumber);
+        return true;
+    }
+
+    void compileUnrolledFor(AstStatFor* stat, int tripCount, double from, double step)
+    {
+        AstLocal* var = stat->var;
+
+        size_t oldLocals = localStack.size();
+        size_t oldJumps = loopJumps.size();
+
+        loops.push_back({oldLocals, oldLocals, nullptr});
+
+        for (int iv = 0; iv < tripCount; ++iv)
+        {
+            // we need to re-fold constants in the loop body with the new value; this reuses computed constant values elsewhere in the tree
+            locstants[var].type = Constant::Type_Number;
+            locstants[var].valueNumber = from + iv * step;
+
+            foldConstants(constants, variables, locstants, builtinsFold, builtinsFoldMathK, stat);
+
+            size_t iterJumps = loopJumps.size();
+
+            compileStat(stat->body);
+
+            // all continue jumps need to go to the next iteration
+            size_t contLabel = bytecode.emitLabel();
+
+            for (size_t i = iterJumps; i < loopJumps.size(); ++i)
+                if (loopJumps[i].type == LoopJump::Continue)
+                    patchJump(stat, loopJumps[i].label, contLabel);
+        }
+
+        // all break jumps need to go past the loop
+        size_t endLabel = bytecode.emitLabel();
+
+        for (size_t i = oldJumps; i < loopJumps.size(); ++i)
+            if (loopJumps[i].type == LoopJump::Break)
+                patchJump(stat, loopJumps[i].label, endLabel);
+
+        loopJumps.resize(oldJumps);
+
+        loops.pop_back();
+
+        // clean up fold state in case we need to recompile - normally we compile the loop body once, but due to inlining we may need to do it again
+        locstants[var].type = Constant::Type_Unknown;
+
+        foldConstants(constants, variables, locstants, builtinsFold, builtinsFoldMathK, stat);
+    }
+
+    void compileStatFor(AstStatFor* stat)
+    {
+        RegScope rs(this);
+
+        // Optimization: small loops can be unrolled when it is profitable
+        if (options.optimizationLevel >= 2 && isConstant(stat->to) && isConstant(stat->from) && (!stat->step || isConstant(stat->step)))
+            if (tryCompileUnrolledFor(stat, FInt::LuauCompileLoopUnrollThreshold, FInt::LuauCompileLoopUnrollThresholdMaxBoost))
+                return;
+
+        size_t oldLocals = localStack.size();
+        size_t oldJumps = loopJumps.size();
+
+        loops.push_back({oldLocals, oldLocals, nullptr});
+        hasLoops = true;
+
+        // register layout: limit, step, index
+        uint8_t regs = allocReg(stat, 3);
+
+        // if the iteration index is assigned from within the loop, we need to protect the internal index from the assignment
+        // to do that, we will copy the index into an actual local variable on each iteration
+        // this makes sure the code inside the loop can't interfere with the iteration process (other than modifying the table we're iterating
+        // through)
+        uint8_t varreg = regs + 2;
+
+        if (Variable* il = variables.find(stat->var); il && il->written)
+            varreg = allocReg(stat, 1);
+
+        compileExprTemp(stat->from, uint8_t(regs + 2));
+        compileExprTemp(stat->to, uint8_t(regs + 0));
+
+        if (stat->step)
+            compileExprTemp(stat->step, uint8_t(regs + 1));
+        else
+            bytecode.emitABC(LOP_LOADN, uint8_t(regs + 1), 1, 0);
+
+        size_t forLabel = bytecode.emitLabel();
+
+        bytecode.emitAD(LOP_FORNPREP, regs, 0);
+
+        size_t loopLabel = bytecode.emitLabel();
+
+        if (varreg != regs + 2)
+            bytecode.emitABC(LOP_MOVE, varreg, regs + 2, 0);
+
+        pushLocal(stat->var, varreg);
+
+        compileStat(stat->body);
+
+        closeLocals(oldLocals);
+        popLocals(oldLocals);
+
+        setDebugLine(stat);
+
+        size_t contLabel = bytecode.emitLabel();
+
+        size_t backLabel = bytecode.emitLabel();
+
+        bytecode.emitAD(LOP_FORNLOOP, regs, 0);
+
+        size_t endLabel = bytecode.emitLabel();
+
+        patchJump(stat, forLabel, endLabel);
+        patchJump(stat, backLabel, loopLabel);
+
+        patchLoopJumps(stat, oldJumps, endLabel, contLabel);
+        loopJumps.resize(oldJumps);
+
+        loops.pop_back();
+    }
+
+    void compileStatForIn(AstStatForIn* stat)
+    {
+        RegScope rs(this);
+
+        size_t oldLocals = localStack.size();
+        size_t oldJumps = loopJumps.size();
+
+        loops.push_back({oldLocals, oldLocals, nullptr});
+        hasLoops = true;
+
+        // register layout: generator, state, index, variables...
+        uint8_t regs = allocReg(stat, 3);
+
+        // this puts initial values of (generator, state, index) into the loop registers
+        compileExprListTemp(stat->values, regs, 3, /* targetTop= */ true);
+
+        // note that we reserve at least 2 variables; this allows our fast path to assume that we need 2 variables instead of 1 or 2
+        uint8_t vars = allocReg(stat, std::max(unsigned(stat->vars.size), 2u));
+        LUAU_ASSERT(vars == regs + 3);
+
+        LuauOpcode skipOp = LOP_FORGPREP;
+
+        // Optimization: when we iterate via pairs/ipairs, we generate special bytecode that optimizes the traversal using internal iteration index
+        // These instructions dynamically check if generator is equal to next/inext and bail out
+        // They assume that the generator produces 2 variables, which is why we allocate at least 2 above (see vars assignment)
+        if (options.optimizationLevel >= 1 && stat->vars.size <= 2)
+        {
+            if (stat->values.size == 1 && stat->values.data[0]->is<AstExprCall>())
+            {
+                Builtin builtin = getBuiltin(stat->values.data[0]->as<AstExprCall>()->func, globals, variables);
+
+                if (builtin.isGlobal("ipairs")) // for .. in ipairs(t)
+                    skipOp = LOP_FORGPREP_INEXT;
+                else if (builtin.isGlobal("pairs")) // for .. in pairs(t)
+                    skipOp = LOP_FORGPREP_NEXT;
+            }
+            else if (stat->values.size == 2)
+            {
+                Builtin builtin = getBuiltin(stat->values.data[0], globals, variables);
+
+                if (builtin.isGlobal("next")) // for .. in next,t
+                    skipOp = LOP_FORGPREP_NEXT;
+            }
+        }
+
+        // first iteration jumps into FORGLOOP instruction, but for ipairs/pairs it does extra preparation that makes the cost of an extra instruction
+        // worthwhile
+        size_t skipLabel = bytecode.emitLabel();
+
+        bytecode.emitAD(skipOp, regs, 0);
+
+        size_t loopLabel = bytecode.emitLabel();
+
+        for (size_t i = 0; i < stat->vars.size; ++i)
+            pushLocal(stat->vars.data[i], uint8_t(vars + i));
+
+        compileStat(stat->body);
+
+        closeLocals(oldLocals);
+        popLocals(oldLocals);
+
+        setDebugLine(stat);
+
+        size_t contLabel = bytecode.emitLabel();
+
+        size_t backLabel = bytecode.emitLabel();
+
+        // FORGLOOP uses aux to encode variable count and fast path flag for ipairs traversal in the high bit
+        bytecode.emitAD(LOP_FORGLOOP, regs, 0);
+        bytecode.emitAux((skipOp == LOP_FORGPREP_INEXT ? 0x80000000 : 0) | uint32_t(stat->vars.size));
+
+        size_t endLabel = bytecode.emitLabel();
+
+        patchJump(stat, skipLabel, backLabel);
+        patchJump(stat, backLabel, loopLabel);
+
+        patchLoopJumps(stat, oldJumps, endLabel, contLabel);
+        loopJumps.resize(oldJumps);
+
+        loops.pop_back();
+    }
+
+    struct Assignment
+    {
+        LValue lvalue;
+
+        uint8_t conflictReg = kInvalidReg;
+        uint8_t valueReg = kInvalidReg;
+    };
+
+    // This function analyzes assignments and marks assignment conflicts: cases when a variable is assigned on lhs
+    // but subsequently used on the rhs, assuming assignments are performed in order. Note that it's also possible
+    // for a variable to conflict on the lhs, if it's used in an lvalue expression after it's assigned.
+    // When conflicts are found, Assignment::conflictReg is allocated and that's where assignment is performed instead,
+    // until the final fixup in compileStatAssign. Assignment::valueReg is allocated by compileStatAssign as well.
+    //
+    // Per Lua manual, section 3.3.3 (Assignments), the proper assignment order is only guaranteed to hold for syntactic access:
+    //
+    //     Note that this guarantee covers only accesses syntactically inside the assignment statement. If a function or a metamethod called
+    //     during the assignment changes the value of a variable, Lua gives no guarantees about the order of that access.
+    //
+    // As such, we currently don't check if an assigned local is captured, which may mean it gets reassigned during a function call.
+    void resolveAssignConflicts(AstStat* stat, std::vector<Assignment>& vars, const AstArray<AstExpr*>& values)
+    {
+        struct Visitor : AstVisitor
+        {
+            Compiler* self;
+
+            std::bitset<256> conflict;
+            std::bitset<256> assigned;
+
+            Visitor(Compiler* self)
+                : self(self)
+            {
+            }
+
+            bool visit(AstExprLocal* node) override
+            {
+                int reg = self->getLocalReg(node->local);
+
+                if (reg >= 0 && assigned[reg])
+                    conflict[reg] = true;
+
+                return true;
+            }
+        };
+
+        Visitor visitor(this);
+
+        // mark any registers that are used *after* assignment as conflicting
+
+        // first we go through assignments to locals, since they are performed before assignments to other l-values
+        for (size_t i = 0; i < vars.size(); ++i)
+        {
+            const LValue& li = vars[i].lvalue;
+
+            if (li.kind == LValue::Kind_Local)
+            {
+                if (i < values.size)
+                    values.data[i]->visit(&visitor);
+
+                visitor.assigned[li.reg] = true;
+            }
+        }
+
+        // and now we handle all other l-values
+        for (size_t i = 0; i < vars.size(); ++i)
+        {
+            const LValue& li = vars[i].lvalue;
+
+            if (li.kind != LValue::Kind_Local && i < values.size)
+                values.data[i]->visit(&visitor);
+        }
+
+        // mark any registers used in trailing expressions as conflicting as well
+        for (size_t i = vars.size(); i < values.size; ++i)
+            values.data[i]->visit(&visitor);
+
+        // mark any registers used on left hand side that are also assigned anywhere as conflicting
+        // this is order-independent because we evaluate all right hand side arguments into registers before doing table assignments
+        for (const Assignment& var : vars)
+        {
+            const LValue& li = var.lvalue;
+
+            if ((li.kind == LValue::Kind_IndexName || li.kind == LValue::Kind_IndexNumber || li.kind == LValue::Kind_IndexExpr) &&
+                visitor.assigned[li.reg])
+                visitor.conflict[li.reg] = true;
+
+            if (li.kind == LValue::Kind_IndexExpr && visitor.assigned[li.index])
+                visitor.conflict[li.index] = true;
+        }
+
+        // for any conflicting var, we need to allocate a temporary register where the assignment is performed, so that we can move the value later
+        for (Assignment& var : vars)
+        {
+            const LValue& li = var.lvalue;
+
+            if (li.kind == LValue::Kind_Local && visitor.conflict[li.reg])
+                var.conflictReg = allocReg(stat, 1);
+        }
+    }
+
+    void compileStatAssign(AstStatAssign* stat)
+    {
+        RegScope rs(this);
+
+        // Optimization: one to one assignments don't require complex conflict resolution machinery
+        if (stat->vars.size == 1 && stat->values.size == 1)
+        {
+            LValue var = compileLValue(stat->vars.data[0], rs);
+
+            // Optimization: assign to locals directly
+            if (var.kind == LValue::Kind_Local)
+            {
+                compileExpr(stat->values.data[0], var.reg);
+            }
+            else
+            {
+                uint8_t reg = compileExprAuto(stat->values.data[0], rs);
+
+                setDebugLine(stat->vars.data[0]);
+                compileAssign(var, reg);
+            }
+            return;
+        }
+
+        // compute all l-values: note that this doesn't assign anything yet but it allocates registers and computes complex expressions on the
+        // left hand side - for example, in "a[expr] = foo" expr will get evaluated here
+        std::vector<Assignment> vars(stat->vars.size);
+
+        for (size_t i = 0; i < stat->vars.size; ++i)
+            vars[i].lvalue = compileLValue(stat->vars.data[i], rs);
+
+        // perform conflict resolution: if any expression refers to a local that is assigned before evaluating it, we assign to a temporary
+        // register after this, vars[i].conflictReg is set for locals that need to be assigned in the second pass
+        resolveAssignConflicts(stat, vars, stat->values);
+
+        // compute rhs into (mostly) fresh registers
+        // note that when the lhs assigment is a local, we evaluate directly into that register
+        // this is possible because resolveAssignConflicts renamed conflicting locals into temporaries
+        // after this, vars[i].valueReg is set to a register with the value for *all* vars, but some have already been assigned
+        for (size_t i = 0; i < stat->vars.size && i < stat->values.size; ++i)
+        {
+            AstExpr* value = stat->values.data[i];
+
+            if (i + 1 == stat->values.size && stat->vars.size > stat->values.size)
+            {
+                // allocate a consecutive range of regs for all remaining vars and compute everything into temps
+                // note, this also handles trailing nils
+                uint8_t rest = uint8_t(stat->vars.size - stat->values.size + 1);
+                uint8_t temp = allocReg(stat, rest);
+
+                compileExprTempN(value, temp, rest, /* targetTop= */ true);
+
+                for (size_t j = i; j < stat->vars.size; ++j)
+                    vars[j].valueReg = uint8_t(temp + (j - i));
+            }
+            else
+            {
+                Assignment& var = vars[i];
+
+                // if target is a local, use compileExpr directly to target
+                if (var.lvalue.kind == LValue::Kind_Local)
+                {
+                    var.valueReg = (var.conflictReg == kInvalidReg) ? var.lvalue.reg : var.conflictReg;
+
+                    compileExpr(stat->values.data[i], var.valueReg);
+                }
+                else
+                {
+                    var.valueReg = compileExprAuto(stat->values.data[i], rs);
+                }
+            }
+        }
+
+        // compute expressions with side effects
+        for (size_t i = stat->vars.size; i < stat->values.size; ++i)
+            compileExprSide(stat->values.data[i]);
+
+        // almost done... let's assign everything left to right, noting that locals were either written-to directly, or will be written-to in a
+        // separate pass to avoid conflicts
+        for (const Assignment& var : vars)
+        {
+            LUAU_ASSERT(var.valueReg != kInvalidReg);
+
+            if (var.lvalue.kind != LValue::Kind_Local)
+            {
+                setDebugLine(var.lvalue.location);
+                compileAssign(var.lvalue, var.valueReg);
+            }
+        }
+
+        // all regular local writes are done by the prior loops by computing result directly into target, so this just handles conflicts OR
+        // local copies from temporary registers in multret context, since in that case we have to allocate consecutive temporaries
+        for (const Assignment& var : vars)
+        {
+            if (var.lvalue.kind == LValue::Kind_Local && var.valueReg != var.lvalue.reg)
+                bytecode.emitABC(LOP_MOVE, var.lvalue.reg, var.valueReg, 0);
+        }
+    }
+
+    void compileStatCompoundAssign(AstStatCompoundAssign* stat)
+    {
+        RegScope rs(this);
+
+        LValue var = compileLValue(stat->var, rs);
+
+        // Optimization: assign to locals directly
+        uint8_t target = (var.kind == LValue::Kind_Local) ? var.reg : allocReg(stat, 1);
+
+        switch (stat->op)
+        {
+        case AstExprBinary::Add:
+        case AstExprBinary::Sub:
+        case AstExprBinary::Mul:
+        case AstExprBinary::Div:
+        case AstExprBinary::FloorDiv:
+        case AstExprBinary::Mod:
+        case AstExprBinary::Pow:
+        {
+            if (var.kind != LValue::Kind_Local)
+                compileLValueUse(var, target, /* set= */ false);
+
+            int32_t rc = getConstantNumber(stat->value);
+
+            if (rc >= 0 && rc <= 255)
+            {
+                bytecode.emitABC(getBinaryOpArith(stat->op, /* k= */ true), target, target, uint8_t(rc));
+            }
+            else
+            {
+                uint8_t rr = compileExprAuto(stat->value, rs);
+
+                bytecode.emitABC(getBinaryOpArith(stat->op), target, target, rr);
+            }
+        }
+        break;
+
+        case AstExprBinary::Concat:
+        {
+            std::vector<AstExpr*> args = {stat->value};
+
+            // unroll the tree of concats down the right hand side to be able to do multiple ops
+            unrollConcats(args);
+
+            uint8_t regs = allocReg(stat, unsigned(1 + args.size()));
+
+            compileLValueUse(var, regs, /* set= */ false);
+
+            for (size_t i = 0; i < args.size(); ++i)
+                compileExprTemp(args[i], uint8_t(regs + 1 + i));
+
+            bytecode.emitABC(LOP_CONCAT, target, regs, uint8_t(regs + args.size()));
+        }
+        break;
+
+        default:
+            LUAU_ASSERT(!"Unexpected compound assignment operation");
+        }
+
+        if (var.kind != LValue::Kind_Local)
+            compileAssign(var, target);
+    }
+
+    void compileStatFunction(AstStatFunction* stat)
+    {
+        // Optimization: compile value expresion directly into target local register
+        if (int reg = getExprLocalReg(stat->name); reg >= 0)
+        {
+            compileExpr(stat->func, uint8_t(reg));
+            return;
+        }
+
+        RegScope rs(this);
+        uint8_t reg = allocReg(stat, 1);
+
+        compileExprTemp(stat->func, reg);
+
+        LValue var = compileLValue(stat->name, rs);
+        compileAssign(var, reg);
+    }
+
+    void compileStat(AstStat* node)
+    {
+        setDebugLine(node);
+
+        if (options.coverageLevel >= 1 && needsCoverage(node))
+        {
+            bytecode.emitABC(LOP_COVERAGE, 0, 0, 0);
+        }
+
+        if (AstStatBlock* stat = node->as<AstStatBlock>())
+        {
+            RegScope rs(this);
+
+            size_t oldLocals = localStack.size();
+
+            for (size_t i = 0; i < stat->body.size; ++i)
+                compileStat(stat->body.data[i]);
+
+            closeLocals(oldLocals);
+
+            popLocals(oldLocals);
+        }
+        else if (AstStatIf* stat = node->as<AstStatIf>())
+        {
+            compileStatIf(stat);
+        }
+        else if (AstStatWhile* stat = node->as<AstStatWhile>())
+        {
+            compileStatWhile(stat);
+        }
+        else if (AstStatRepeat* stat = node->as<AstStatRepeat>())
+        {
+            compileStatRepeat(stat);
+        }
+        else if (node->is<AstStatBreak>())
+        {
+            LUAU_ASSERT(!loops.empty());
+
+            // before exiting out of the loop, we need to close all local variables that were captured in closures since loop start
+            // normally they are closed by the enclosing blocks, including the loop block, but we're skipping that here
+            closeLocals(loops.back().localOffset);
+
+            size_t label = bytecode.emitLabel();
+
+            bytecode.emitAD(LOP_JUMP, 0, 0);
+
+            loopJumps.push_back({LoopJump::Break, label});
+        }
+        else if (AstStatContinue* stat = node->as<AstStatContinue>())
+        {
+            LUAU_ASSERT(!loops.empty());
+
+            // track continue statement for repeat..until validation (validateContinueUntil)
+            if (!loops.back().continueUsed)
+                loops.back().continueUsed = stat;
+
+            // before continuing, we need to close all local variables that were captured in closures since loop start
+            // normally they are closed by the enclosing blocks, including the loop block, but we're skipping that here
+            closeLocals(loops.back().localOffsetContinue);
+
+            size_t label = bytecode.emitLabel();
+
+            bytecode.emitAD(LOP_JUMP, 0, 0);
+
+            loopJumps.push_back({LoopJump::Continue, label});
+        }
+        else if (AstStatReturn* stat = node->as<AstStatReturn>())
+        {
+            if (options.optimizationLevel >= 2 && !inlineFrames.empty())
+                compileInlineReturn(stat, /* fallthrough= */ false);
+            else
+                compileStatReturn(stat);
+        }
+        else if (AstStatExpr* stat = node->as<AstStatExpr>())
+        {
+            // Optimization: since we don't need to read anything from the stack, we can compile the call to not return anything which saves register
+            // moves
+            if (AstExprCall* expr = stat->expr->as<AstExprCall>())
+            {
+                uint8_t target = uint8_t(regTop);
+
+                compileExprCall(expr, target, /* targetCount= */ 0);
+            }
+            else
+            {
+                compileExprSide(stat->expr);
+            }
+        }
+        else if (AstStatLocal* stat = node->as<AstStatLocal>())
+        {
+            compileStatLocal(stat);
+        }
+        else if (AstStatFor* stat = node->as<AstStatFor>())
+        {
+            compileStatFor(stat);
+        }
+        else if (AstStatForIn* stat = node->as<AstStatForIn>())
+        {
+            compileStatForIn(stat);
+        }
+        else if (AstStatAssign* stat = node->as<AstStatAssign>())
+        {
+            compileStatAssign(stat);
+        }
+        else if (AstStatCompoundAssign* stat = node->as<AstStatCompoundAssign>())
+        {
+            compileStatCompoundAssign(stat);
+        }
+        else if (AstStatFunction* stat = node->as<AstStatFunction>())
+        {
+            compileStatFunction(stat);
+        }
+        else if (AstStatLocalFunction* stat = node->as<AstStatLocalFunction>())
+        {
+            uint8_t var = allocReg(stat, 1);
+
+            pushLocal(stat->name, var);
+            compileExprFunction(stat->func, var);
+
+            Local& l = locals[stat->name];
+
+            // we *have* to pushLocal before we compile the function, since the function may refer to the local as an upvalue
+            // however, this means the debugpc for the local is at an instruction where the local value hasn't been computed yet
+            // to fix this we just move the debugpc after the local value is established
+            l.debugpc = bytecode.getDebugPC();
+        }
+        else if (node->is<AstStatTypeAlias>())
+        {
+            // do nothing
+        }
+        else
+        {
+            LUAU_ASSERT(!"Unknown statement type");
+        }
+    }
+
+    void validateContinueUntil(AstStat* cont, AstExpr* condition, AstStatBlock* body, size_t start)
+    {
+        UndefinedLocalVisitor visitor(this);
+
+        for (size_t i = start; i < body->body.size; ++i)
+        {
+            if (AstStatLocal* stat = body->body.data[i]->as<AstStatLocal>())
+            {
+                for (AstLocal* local : stat->vars)
+                    visitor.locals.insert(local);
+            }
+            else if (AstStatLocalFunction* stat = body->body.data[i]->as<AstStatLocalFunction>())
+            {
+                visitor.locals.insert(stat->name);
+            }
+        }
+
+        condition->visit(&visitor);
+
+        if (visitor.undef)
+            CompileError::raise(condition->location,
+                "Local %s used in the repeat..until condition is undefined because continue statement on line %d jumps over it",
+                visitor.undef->name.value, cont->location.begin.line + 1);
+    }
+
+    void gatherConstUpvals(AstExprFunction* func)
+    {
+        ConstUpvalueVisitor visitor(this);
+        func->body->visit(&visitor);
+
+        for (AstLocal* local : visitor.upvals)
+            getUpval(local);
+    }
+
+    void pushLocal(AstLocal* local, uint8_t reg)
+    {
+        if (localStack.size() >= kMaxLocalCount)
+            CompileError::raise(
+                local->location, "Out of local registers when trying to allocate %s: exceeded limit %d", local->name.value, kMaxLocalCount);
+
+        localStack.push_back(local);
+
+        Local& l = locals[local];
+
+        LUAU_ASSERT(!l.allocated);
+
+        l.reg = reg;
+        l.allocated = true;
+        l.debugpc = bytecode.getDebugPC();
+    }
+
+    bool areLocalsCaptured(size_t start)
+    {
+        LUAU_ASSERT(start <= localStack.size());
+
+        for (size_t i = start; i < localStack.size(); ++i)
+        {
+            Local* l = locals.find(localStack[i]);
+            LUAU_ASSERT(l);
+
+            if (l->captured)
+                return true;
+        }
+
+        return false;
+    }
+
+    void closeLocals(size_t start)
+    {
+        LUAU_ASSERT(start <= localStack.size());
+
+        bool captured = false;
+        uint8_t captureReg = 255;
+
+        for (size_t i = start; i < localStack.size(); ++i)
+        {
+            Local* l = locals.find(localStack[i]);
+            LUAU_ASSERT(l);
+
+            if (l->captured)
+            {
+                captured = true;
+                captureReg = std::min(captureReg, l->reg);
+            }
+        }
+
+        if (captured)
+        {
+            bytecode.emitABC(LOP_CLOSEUPVALS, captureReg, 0, 0);
+        }
+    }
+
+    void popLocals(size_t start)
+    {
+        LUAU_ASSERT(start <= localStack.size());
+
+        for (size_t i = start; i < localStack.size(); ++i)
+        {
+            Local* l = locals.find(localStack[i]);
+            LUAU_ASSERT(l);
+            LUAU_ASSERT(l->allocated);
+
+            l->allocated = false;
+
+            if (options.debugLevel >= 2)
+            {
+                uint32_t debugpc = bytecode.getDebugPC();
+
+                bytecode.pushDebugLocal(sref(localStack[i]->name), l->reg, l->debugpc, debugpc);
+            }
+        }
+
+        localStack.resize(start);
+    }
+
+    void patchJump(AstNode* node, size_t label, size_t target)
+    {
+        if (!bytecode.patchJumpD(label, target))
+            CompileError::raise(node->location, "Exceeded jump distance limit; simplify the code to compile");
+    }
+
+    void patchJumps(AstNode* node, std::vector<size_t>& labels, size_t target)
+    {
+        for (size_t l : labels)
+            patchJump(node, l, target);
+    }
+
+    void patchLoopJumps(AstNode* node, size_t oldJumps, size_t endLabel, size_t contLabel)
+    {
+        LUAU_ASSERT(oldJumps <= loopJumps.size());
+
+        for (size_t i = oldJumps; i < loopJumps.size(); ++i)
+        {
+            const LoopJump& lj = loopJumps[i];
+
+            switch (lj.type)
+            {
+            case LoopJump::Break:
+                patchJump(node, lj.label, endLabel);
+                break;
+
+            case LoopJump::Continue:
+                patchJump(node, lj.label, contLabel);
+                break;
+
+            default:
+                LUAU_ASSERT(!"Unknown loop jump type");
+            }
+        }
+    }
+
+    uint8_t allocReg(AstNode* node, unsigned int count)
+    {
+        unsigned int top = regTop;
+        if (top + count > kMaxRegisterCount)
+            CompileError::raise(node->location, "Out of registers when trying to allocate %d registers: exceeded limit %d", count, kMaxRegisterCount);
+
+        regTop += count;
+        stackSize = std::max(stackSize, regTop);
+
+        return uint8_t(top);
+    }
+
+    void setDebugLine(AstNode* node)
+    {
+        if (options.debugLevel >= 1)
+            bytecode.setDebugLine(node->location.begin.line + 1);
+    }
+
+    void setDebugLine(const Location& location)
+    {
+        if (options.debugLevel >= 1)
+            bytecode.setDebugLine(location.begin.line + 1);
+    }
+
+    void setDebugLineEnd(AstNode* node)
+    {
+        if (options.debugLevel >= 1)
+            bytecode.setDebugLine(node->location.end.line + 1);
+    }
+
+    bool needsCoverage(AstNode* node)
+    {
+        return !node->is<AstStatBlock>() && !node->is<AstStatTypeAlias>();
+    }
+
+    struct FenvVisitor : AstVisitor
+    {
+        bool& getfenvUsed;
+        bool& setfenvUsed;
+
+        FenvVisitor(bool& getfenvUsed, bool& setfenvUsed)
+            : getfenvUsed(getfenvUsed)
+            , setfenvUsed(setfenvUsed)
+        {
+        }
+
+        bool visit(AstExprGlobal* node) override
+        {
+            if (node->name == "getfenv")
+                getfenvUsed = true;
+            if (node->name == "setfenv")
+                setfenvUsed = true;
+
+            return false;
+        }
+    };
+
+    struct FunctionVisitor : AstVisitor
+    {
+        Compiler* self;
+        std::vector<AstExprFunction*>& functions;
+        bool hasTypes = false;
+
+        FunctionVisitor(Compiler* self, std::vector<AstExprFunction*>& functions)
+            : self(self)
+            , functions(functions)
+        {
+            // preallocate the result; this works around std::vector's inefficient growth policy for small arrays
+            functions.reserve(16);
+        }
+
+        bool visit(AstExprFunction* node) override
+        {
+            node->body->visit(this);
+
+            for (AstLocal* arg : node->args)
+                hasTypes |= arg->annotation != nullptr;
+
+            // this makes sure all functions that are used when compiling this one have been already added to the vector
+            functions.push_back(node);
+
+            return false;
+        }
+    };
+
+    struct UndefinedLocalVisitor : AstVisitor
+    {
+        UndefinedLocalVisitor(Compiler* self)
+            : self(self)
+            , undef(nullptr)
+            , locals(nullptr)
+        {
+        }
+
+        void check(AstLocal* local)
+        {
+            if (!undef && locals.contains(local))
+                undef = local;
+        }
+
+        bool visit(AstExprLocal* node) override
+        {
+            if (!node->upvalue)
+                check(node->local);
+
+            return false;
+        }
+
+        bool visit(AstExprFunction* node) override
+        {
+            const Function* f = self->functions.find(node);
+            LUAU_ASSERT(f);
+
+            for (AstLocal* uv : f->upvals)
+            {
+                LUAU_ASSERT(uv->functionDepth < node->functionDepth);
+
+                if (uv->functionDepth == node->functionDepth - 1)
+                    check(uv);
+            }
+
+            return false;
+        }
+
+        Compiler* self;
+        AstLocal* undef;
+        DenseHashSet<AstLocal*> locals;
+    };
+
+    struct ConstUpvalueVisitor : AstVisitor
+    {
+        ConstUpvalueVisitor(Compiler* self)
+            : self(self)
+        {
+        }
+
+        bool visit(AstExprLocal* node) override
+        {
+            if (node->upvalue && self->isConstant(node))
+            {
+                upvals.push_back(node->local);
+            }
+
+            return false;
+        }
+
+        bool visit(AstExprFunction* node) override
+        {
+            // short-circuits the traversal to make it faster
+            return false;
+        }
+
+        Compiler* self;
+        std::vector<AstLocal*> upvals;
+    };
+
+    struct ReturnVisitor : AstVisitor
+    {
+        Compiler* self;
+        bool returnsOne = true;
+
+        ReturnVisitor(Compiler* self)
+            : self(self)
+        {
+        }
+
+        bool visit(AstExpr* expr) override
+        {
+            return false;
+        }
+
+        bool visit(AstStatReturn* stat) override
+        {
+            returnsOne &= stat->list.size == 1 && !self->isExprMultRet(stat->list.data[0]);
+
+            return false;
+        }
+    };
+
+    struct RegScope
+    {
+        RegScope(Compiler* self)
+            : self(self)
+            , oldTop(self->regTop)
+        {
+        }
+
+        // This ctor is useful to forcefully adjust the stack frame in case we know that registers after a certain point are scratch and can be
+        // discarded
+        RegScope(Compiler* self, unsigned int top)
+            : self(self)
+            , oldTop(self->regTop)
+        {
+            LUAU_ASSERT(top <= self->regTop);
+            self->regTop = top;
+        }
+
+        ~RegScope()
+        {
+            self->regTop = oldTop;
+        }
+
+        Compiler* self;
+        unsigned int oldTop;
+    };
+
+    struct Function
+    {
+        uint32_t id;
+        std::vector<AstLocal*> upvals;
+
+        uint64_t costModel = 0;
+        unsigned int stackSize = 0;
+        bool canInline = false;
+        bool returnsOne = false;
+    };
+
+    struct Local
+    {
+        uint8_t reg = 0;
+        bool allocated = false;
+        bool captured = false;
+        uint32_t debugpc = 0;
+    };
+
+    struct LoopJump
+    {
+        enum Type
+        {
+            Break,
+            Continue
+        };
+
+        Type type;
+        size_t label;
+    };
+
+    struct Loop
+    {
+        size_t localOffset;
+        size_t localOffsetContinue;
+
+        AstStatContinue* continueUsed;
+    };
+
+    struct InlineArg
+    {
+        AstLocal* local;
+
+        uint8_t reg;
+        Constant value;
+    };
+
+    struct InlineFrame
+    {
+        AstExprFunction* func;
+
+        size_t localOffset;
+
+        uint8_t target;
+        uint8_t targetCount;
+
+        std::vector<size_t> returnJumps;
+    };
+
+    struct Capture
+    {
+        LuauCaptureType type;
+        uint8_t data;
+    };
+
+    BytecodeBuilder& bytecode;
+
+    CompileOptions options;
+
+    DenseHashMap<AstExprFunction*, Function> functions;
+    DenseHashMap<AstLocal*, Local> locals;
+    DenseHashMap<AstName, Global> globals;
+    DenseHashMap<AstLocal*, Variable> variables;
+    DenseHashMap<AstExpr*, Constant> constants;
+    DenseHashMap<AstLocal*, Constant> locstants;
+    DenseHashMap<AstExprTable*, TableShape> tableShapes;
+    DenseHashMap<AstExprCall*, int> builtins;
+    DenseHashMap<AstExprFunction*, std::string> typeMap;
+
+    const DenseHashMap<AstExprCall*, int>* builtinsFold = nullptr;
+    bool builtinsFoldMathK = false;
+
+    // compileFunction state, gets reset for every function
+    unsigned int regTop = 0;
+    unsigned int stackSize = 0;
+    bool hasLoops = false;
+
+    bool getfenvUsed = false;
+    bool setfenvUsed = false;
+
+    std::vector<AstLocal*> localStack;
+    std::vector<AstLocal*> upvals;
+    std::vector<LoopJump> loopJumps;
+    std::vector<Loop> loops;
+    std::vector<InlineFrame> inlineFrames;
+    std::vector<Capture> captures;
+    std::vector<std::unique_ptr<char[]>> interpStrings;
+};
+
+void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, const AstNameTable& names, const CompileOptions& inputOptions)
+{
+    LUAU_TIMETRACE_SCOPE("compileOrThrow", "Compiler");
+
+    LUAU_ASSERT(parseResult.root);
+    LUAU_ASSERT(parseResult.errors.empty());
+
+    CompileOptions options = inputOptions;
+    uint8_t mainFlags = 0;
+
+    for (const HotComment& hc : parseResult.hotcomments)
+    {
+        if (hc.header && hc.content.compare(0, 9, "optimize ") == 0)
+            options.optimizationLevel = std::max(0, std::min(2, atoi(hc.content.c_str() + 9)));
+
+        if (hc.header && hc.content == "native")
+        {
+            mainFlags |= LPF_NATIVE_MODULE;
+            options.optimizationLevel = 2; // note: this might be removed in the future in favor of --!optimize
+        }
+    }
+
+    AstStatBlock* root = parseResult.root;
+
+    Compiler compiler(bytecode, options);
+
+    // since access to some global objects may result in values that change over time, we block imports from non-readonly tables
+    assignMutable(compiler.globals, names, options.mutableGlobals);
+
+    // this pass analyzes mutability of locals/globals and associates locals with their initial values
+    trackValues(compiler.globals, compiler.variables, root);
+
+    // this visitor tracks calls to getfenv/setfenv and disables some optimizations when they are found
+    if (options.optimizationLevel >= 1 && (names.get("getfenv").value || names.get("setfenv").value))
+    {
+        Compiler::FenvVisitor fenvVisitor(compiler.getfenvUsed, compiler.setfenvUsed);
+        root->visit(&fenvVisitor);
+    }
+
+    // builtin folding is enabled on optimization level 2 since we can't deoptimize folding at runtime
+    if (options.optimizationLevel >= 2 && (!compiler.getfenvUsed && !compiler.setfenvUsed))
+    {
+        compiler.builtinsFold = &compiler.builtins;
+
+        if (AstName math = names.get("math"); math.value && getGlobalState(compiler.globals, math) == Global::Default)
+            compiler.builtinsFoldMathK = true;
+    }
+
+    if (options.optimizationLevel >= 1)
+    {
+        // this pass tracks which calls are builtins and can be compiled more efficiently
+        analyzeBuiltins(compiler.builtins, compiler.globals, compiler.variables, options, root);
+
+        // this pass analyzes constantness of expressions
+        foldConstants(compiler.constants, compiler.variables, compiler.locstants, compiler.builtinsFold, compiler.builtinsFoldMathK, root);
+
+        // this pass analyzes table assignments to estimate table shapes for initially empty tables
+        predictTableShapes(compiler.tableShapes, root);
+    }
+
+    // gathers all functions with the invariant that all function references are to functions earlier in the list
+    // for example, function foo() return function() end end will result in two vector entries, [0] = anonymous and [1] = foo
+    std::vector<AstExprFunction*> functions;
+    Compiler::FunctionVisitor functionVisitor(&compiler, functions);
+    root->visit(&functionVisitor);
+
+    // computes type information for all functions based on type annotations
+    if (functionVisitor.hasTypes)
+        buildTypeMap(compiler.typeMap, root, options.vectorType);
+
+    for (AstExprFunction* expr : functions)
+        compiler.compileFunction(expr, 0);
+
+    AstExprFunction main(root->location, /*generics= */ AstArray<AstGenericType>(), /*genericPacks= */ AstArray<AstGenericTypePack>(),
+        /* self= */ nullptr, AstArray<AstLocal*>(), /* vararg= */ true, /* varargLocation= */ Luau::Location(), root, /* functionDepth= */ 0,
+        /* debugname= */ AstName());
+    uint32_t mainid = compiler.compileFunction(&main, mainFlags);
+
+    const Compiler::Function* mainf = compiler.functions.find(&main);
+    LUAU_ASSERT(mainf && mainf->upvals.empty());
+
+    bytecode.setMainFunction(mainid);
+    bytecode.finalize();
+}
+
+void compileOrThrow(BytecodeBuilder& bytecode, const std::string& source, const CompileOptions& options, const ParseOptions& parseOptions)
+{
+    Allocator allocator;
+    AstNameTable names(allocator);
+    ParseResult result = Parser::parse(source.c_str(), source.size(), names, allocator, parseOptions);
+
+    if (!result.errors.empty())
+        throw ParseErrors(result.errors);
+
+    compileOrThrow(bytecode, result, names, options);
+}
+
+std::string compile(const std::string& source, const CompileOptions& options, const ParseOptions& parseOptions, BytecodeEncoder* encoder)
+{
+    LUAU_TIMETRACE_SCOPE("compile", "Compiler");
+
+    Allocator allocator;
+    AstNameTable names(allocator);
+    ParseResult result = Parser::parse(source.c_str(), source.size(), names, allocator, parseOptions);
+
+    if (!result.errors.empty())
+    {
+        // Users of this function expect only a single error message
+        const Luau::ParseError& parseError = result.errors.front();
+        std::string error = format(":%d: %s", parseError.getLocation().begin.line + 1, parseError.what());
+
+        return BytecodeBuilder::getError(error);
+    }
+
+    try
+    {
+        BytecodeBuilder bcb(encoder);
+        compileOrThrow(bcb, result, names, options);
+
+        return bcb.getBytecode();
+    }
+    catch (CompileError& e)
+    {
+        std::string error = format(":%d: %s", e.getLocation().begin.line + 1, e.what());
+        return BytecodeBuilder::getError(error);
+    }
+}
+
+} // namespace Luau

--- a/lib/luau/Compiler/src/ConstantFolding.cpp
+++ b/lib/luau/Compiler/src/ConstantFolding.cpp
@@ -1,0 +1,469 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "ConstantFolding.h"
+
+#include "BuiltinFolding.h"
+
+#include <vector>
+#include <math.h>
+
+namespace Luau
+{
+namespace Compile
+{
+
+static bool constantsEqual(const Constant& la, const Constant& ra)
+{
+    LUAU_ASSERT(la.type != Constant::Type_Unknown && ra.type != Constant::Type_Unknown);
+
+    switch (la.type)
+    {
+    case Constant::Type_Nil:
+        return ra.type == Constant::Type_Nil;
+
+    case Constant::Type_Boolean:
+        return ra.type == Constant::Type_Boolean && la.valueBoolean == ra.valueBoolean;
+
+    case Constant::Type_Number:
+        return ra.type == Constant::Type_Number && la.valueNumber == ra.valueNumber;
+
+    case Constant::Type_Vector:
+        return ra.type == Constant::Type_Vector && la.valueVector[0] == ra.valueVector[0] && la.valueVector[1] == ra.valueVector[1] &&
+               la.valueVector[2] == ra.valueVector[2] && la.valueVector[3] == ra.valueVector[3];
+
+    case Constant::Type_String:
+        return ra.type == Constant::Type_String && la.stringLength == ra.stringLength && memcmp(la.valueString, ra.valueString, la.stringLength) == 0;
+
+    default:
+        LUAU_ASSERT(!"Unexpected constant type in comparison");
+        return false;
+    }
+}
+
+static void foldUnary(Constant& result, AstExprUnary::Op op, const Constant& arg)
+{
+    switch (op)
+    {
+    case AstExprUnary::Not:
+        if (arg.type != Constant::Type_Unknown)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = !arg.isTruthful();
+        }
+        break;
+
+    case AstExprUnary::Minus:
+        if (arg.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = -arg.valueNumber;
+        }
+        break;
+
+    case AstExprUnary::Len:
+        if (arg.type == Constant::Type_String)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = double(arg.stringLength);
+        }
+        break;
+
+    default:
+        LUAU_ASSERT(!"Unexpected unary operation");
+    }
+}
+
+static void foldBinary(Constant& result, AstExprBinary::Op op, const Constant& la, const Constant& ra)
+{
+    switch (op)
+    {
+    case AstExprBinary::Add:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = la.valueNumber + ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::Sub:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = la.valueNumber - ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::Mul:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = la.valueNumber * ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::Div:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = la.valueNumber / ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::FloorDiv:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = floor(la.valueNumber / ra.valueNumber);
+        }
+        break;
+
+    case AstExprBinary::Mod:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = la.valueNumber - floor(la.valueNumber / ra.valueNumber) * ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::Pow:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = pow(la.valueNumber, ra.valueNumber);
+        }
+        break;
+
+    case AstExprBinary::Concat:
+        break;
+
+    case AstExprBinary::CompareNe:
+        if (la.type != Constant::Type_Unknown && ra.type != Constant::Type_Unknown)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = !constantsEqual(la, ra);
+        }
+        break;
+
+    case AstExprBinary::CompareEq:
+        if (la.type != Constant::Type_Unknown && ra.type != Constant::Type_Unknown)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = constantsEqual(la, ra);
+        }
+        break;
+
+    case AstExprBinary::CompareLt:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = la.valueNumber < ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::CompareLe:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = la.valueNumber <= ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::CompareGt:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = la.valueNumber > ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::CompareGe:
+        if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = la.valueNumber >= ra.valueNumber;
+        }
+        break;
+
+    case AstExprBinary::And:
+        if (la.type != Constant::Type_Unknown)
+        {
+            result = la.isTruthful() ? ra : la;
+        }
+        break;
+
+    case AstExprBinary::Or:
+        if (la.type != Constant::Type_Unknown)
+        {
+            result = la.isTruthful() ? la : ra;
+        }
+        break;
+
+    default:
+        LUAU_ASSERT(!"Unexpected binary operation");
+    }
+}
+
+struct ConstantVisitor : AstVisitor
+{
+    DenseHashMap<AstExpr*, Constant>& constants;
+    DenseHashMap<AstLocal*, Variable>& variables;
+    DenseHashMap<AstLocal*, Constant>& locals;
+
+    const DenseHashMap<AstExprCall*, int>* builtins;
+    bool foldMathK = false;
+
+    bool wasEmpty = false;
+
+    std::vector<Constant> builtinArgs;
+
+    ConstantVisitor(DenseHashMap<AstExpr*, Constant>& constants, DenseHashMap<AstLocal*, Variable>& variables,
+        DenseHashMap<AstLocal*, Constant>& locals, const DenseHashMap<AstExprCall*, int>* builtins, bool foldMathK)
+        : constants(constants)
+        , variables(variables)
+        , locals(locals)
+        , builtins(builtins)
+        , foldMathK(foldMathK)
+    {
+        // since we do a single pass over the tree, if the initial state was empty we don't need to clear out old entries
+        wasEmpty = constants.empty() && locals.empty();
+    }
+
+    Constant analyze(AstExpr* node)
+    {
+        Constant result;
+        result.type = Constant::Type_Unknown;
+
+        if (AstExprGroup* expr = node->as<AstExprGroup>())
+        {
+            result = analyze(expr->expr);
+        }
+        else if (node->is<AstExprConstantNil>())
+        {
+            result.type = Constant::Type_Nil;
+        }
+        else if (AstExprConstantBool* expr = node->as<AstExprConstantBool>())
+        {
+            result.type = Constant::Type_Boolean;
+            result.valueBoolean = expr->value;
+        }
+        else if (AstExprConstantNumber* expr = node->as<AstExprConstantNumber>())
+        {
+            result.type = Constant::Type_Number;
+            result.valueNumber = expr->value;
+        }
+        else if (AstExprConstantString* expr = node->as<AstExprConstantString>())
+        {
+            result.type = Constant::Type_String;
+            result.valueString = expr->value.data;
+            result.stringLength = unsigned(expr->value.size);
+        }
+        else if (AstExprLocal* expr = node->as<AstExprLocal>())
+        {
+            const Constant* l = locals.find(expr->local);
+
+            if (l)
+                result = *l;
+        }
+        else if (node->is<AstExprGlobal>())
+        {
+            // nope
+        }
+        else if (node->is<AstExprVarargs>())
+        {
+            // nope
+        }
+        else if (AstExprCall* expr = node->as<AstExprCall>())
+        {
+            analyze(expr->func);
+
+            if (const int* bfid = builtins ? builtins->find(expr) : nullptr)
+            {
+                // since recursive calls to analyze() may reuse the vector we need to be careful and preserve existing contents
+                size_t offset = builtinArgs.size();
+                bool canFold = true;
+
+                builtinArgs.reserve(offset + expr->args.size);
+
+                for (size_t i = 0; i < expr->args.size; ++i)
+                {
+                    Constant ac = analyze(expr->args.data[i]);
+
+                    if (ac.type == Constant::Type_Unknown)
+                        canFold = false;
+                    else
+                        builtinArgs.push_back(ac);
+                }
+
+                if (canFold)
+                {
+                    LUAU_ASSERT(builtinArgs.size() == offset + expr->args.size);
+                    result = foldBuiltin(*bfid, builtinArgs.data() + offset, expr->args.size);
+                }
+
+                builtinArgs.resize(offset);
+            }
+            else
+            {
+                for (size_t i = 0; i < expr->args.size; ++i)
+                    analyze(expr->args.data[i]);
+            }
+        }
+        else if (AstExprIndexName* expr = node->as<AstExprIndexName>())
+        {
+            analyze(expr->expr);
+
+            if (foldMathK)
+            {
+                if (AstExprGlobal* eg = expr->expr->as<AstExprGlobal>(); eg && eg->name == "math")
+                {
+                    result = foldBuiltinMath(expr->index);
+                }
+            }
+        }
+        else if (AstExprIndexExpr* expr = node->as<AstExprIndexExpr>())
+        {
+            analyze(expr->expr);
+            analyze(expr->index);
+        }
+        else if (AstExprFunction* expr = node->as<AstExprFunction>())
+        {
+            // this is necessary to propagate constant information in all child functions
+            expr->body->visit(this);
+        }
+        else if (AstExprTable* expr = node->as<AstExprTable>())
+        {
+            for (size_t i = 0; i < expr->items.size; ++i)
+            {
+                const AstExprTable::Item& item = expr->items.data[i];
+
+                if (item.key)
+                    analyze(item.key);
+
+                analyze(item.value);
+            }
+        }
+        else if (AstExprUnary* expr = node->as<AstExprUnary>())
+        {
+            Constant arg = analyze(expr->expr);
+
+            if (arg.type != Constant::Type_Unknown)
+                foldUnary(result, expr->op, arg);
+        }
+        else if (AstExprBinary* expr = node->as<AstExprBinary>())
+        {
+            Constant la = analyze(expr->left);
+            Constant ra = analyze(expr->right);
+
+            // note: ra doesn't need to be constant to fold and/or
+            if (la.type != Constant::Type_Unknown)
+                foldBinary(result, expr->op, la, ra);
+        }
+        else if (AstExprTypeAssertion* expr = node->as<AstExprTypeAssertion>())
+        {
+            Constant arg = analyze(expr->expr);
+
+            result = arg;
+        }
+        else if (AstExprIfElse* expr = node->as<AstExprIfElse>())
+        {
+            Constant cond = analyze(expr->condition);
+            Constant trueExpr = analyze(expr->trueExpr);
+            Constant falseExpr = analyze(expr->falseExpr);
+
+            if (cond.type != Constant::Type_Unknown)
+                result = cond.isTruthful() ? trueExpr : falseExpr;
+        }
+        else if (AstExprInterpString* expr = node->as<AstExprInterpString>())
+        {
+            for (AstExpr* expression : expr->expressions)
+                analyze(expression);
+        }
+        else
+        {
+            LUAU_ASSERT(!"Unknown expression type");
+        }
+
+        recordConstant(constants, node, result);
+
+        return result;
+    }
+
+    template<typename T>
+    void recordConstant(DenseHashMap<T, Constant>& map, T key, const Constant& value)
+    {
+        if (value.type != Constant::Type_Unknown)
+            map[key] = value;
+        else if (wasEmpty)
+            ;
+        else if (Constant* old = map.find(key))
+            old->type = Constant::Type_Unknown;
+    }
+
+    void recordValue(AstLocal* local, const Constant& value)
+    {
+        // note: we rely on trackValues to have been run before us
+        Variable* v = variables.find(local);
+        LUAU_ASSERT(v);
+
+        if (!v->written)
+        {
+            v->constant = (value.type != Constant::Type_Unknown);
+            recordConstant(locals, local, value);
+        }
+    }
+
+    bool visit(AstExpr* node) override
+    {
+        // note: we short-circuit the visitor traversal through any expression trees by returning false
+        // recursive traversal is happening inside analyze() which makes it easier to get the resulting value of the subexpression
+        analyze(node);
+
+        return false;
+    }
+
+    bool visit(AstStatLocal* node) override
+    {
+        // all values that align wrt indexing are simple - we just match them 1-1
+        for (size_t i = 0; i < node->vars.size && i < node->values.size; ++i)
+        {
+            Constant arg = analyze(node->values.data[i]);
+
+            recordValue(node->vars.data[i], arg);
+        }
+
+        if (node->vars.size > node->values.size)
+        {
+            // if we have trailing variables, then depending on whether the last value is capable of returning multiple values
+            // (aka call or varargs), we either don't know anything about these vars, or we know they're nil
+            AstExpr* last = node->values.size ? node->values.data[node->values.size - 1] : nullptr;
+            bool multRet = last && (last->is<AstExprCall>() || last->is<AstExprVarargs>());
+
+            if (!multRet)
+            {
+                for (size_t i = node->values.size; i < node->vars.size; ++i)
+                {
+                    Constant nil = {Constant::Type_Nil};
+                    recordValue(node->vars.data[i], nil);
+                }
+            }
+        }
+        else
+        {
+            // we can have more values than variables; in this case we still need to analyze them to make sure we do constant propagation inside
+            // them
+            for (size_t i = node->vars.size; i < node->values.size; ++i)
+                analyze(node->values.data[i]);
+        }
+
+        return false;
+    }
+};
+
+void foldConstants(DenseHashMap<AstExpr*, Constant>& constants, DenseHashMap<AstLocal*, Variable>& variables,
+    DenseHashMap<AstLocal*, Constant>& locals, const DenseHashMap<AstExprCall*, int>* builtins, bool foldMathK, AstNode* root)
+{
+    ConstantVisitor visitor{constants, variables, locals, builtins, foldMathK};
+    root->visit(&visitor);
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/ConstantFolding.h
+++ b/lib/luau/Compiler/src/ConstantFolding.h
@@ -1,0 +1,51 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "ValueTracking.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+struct Constant
+{
+    enum Type
+    {
+        Type_Unknown,
+        Type_Nil,
+        Type_Boolean,
+        Type_Number,
+        Type_Vector,
+        Type_String,
+    };
+
+    Type type = Type_Unknown;
+    unsigned int stringLength = 0;
+
+    union
+    {
+        bool valueBoolean;
+        double valueNumber;
+        float valueVector[4];
+        const char* valueString = nullptr; // length stored in stringLength
+    };
+
+    bool isTruthful() const
+    {
+        LUAU_ASSERT(type != Type_Unknown);
+        return type != Type_Nil && !(type == Type_Boolean && valueBoolean == false);
+    }
+
+    AstArray<const char> getString() const
+    {
+        LUAU_ASSERT(type == Type_String);
+        return {valueString, stringLength};
+    }
+};
+
+void foldConstants(DenseHashMap<AstExpr*, Constant>& constants, DenseHashMap<AstLocal*, Variable>& variables,
+    DenseHashMap<AstLocal*, Constant>& locals, const DenseHashMap<AstExprCall*, int>* builtins, bool foldMathK, AstNode* root);
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/CostModel.cpp
+++ b/lib/luau/Compiler/src/CostModel.cpp
@@ -1,0 +1,416 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "CostModel.h"
+
+#include "Luau/Common.h"
+#include "Luau/DenseHash.h"
+
+#include <limits.h>
+
+namespace Luau
+{
+namespace Compile
+{
+
+inline uint64_t parallelAddSat(uint64_t x, uint64_t y)
+{
+    uint64_t r = x + y;
+    uint64_t s = r & 0x8080808080808080ull; // saturation mask
+
+    return (r ^ s) | (s - (s >> 7));
+}
+
+static uint64_t parallelMulSat(uint64_t a, int b)
+{
+    int bs = (b < 127) ? b : 127;
+
+    // multiply every other value by b, yielding 14-bit products
+    uint64_t l = bs * ((a >> 0) & 0x007f007f007f007full);
+    uint64_t h = bs * ((a >> 8) & 0x007f007f007f007full);
+
+    // each product is 14-bit, so adding 32768-128 sets high bit iff the sum is 128 or larger without an overflow
+    uint64_t ls = l + 0x7f807f807f807f80ull;
+    uint64_t hs = h + 0x7f807f807f807f80ull;
+
+    // we now merge saturation bits as well as low 7-bits of each product into one
+    uint64_t s = (hs & 0x8000800080008000ull) | ((ls & 0x8000800080008000ull) >> 8);
+    uint64_t r = ((h & 0x007f007f007f007full) << 8) | (l & 0x007f007f007f007full);
+
+    // the low bits are now correct for values that didn't saturate, and we simply need to mask them if high bit is 1
+    return r | (s - (s >> 7));
+}
+
+inline bool getNumber(AstExpr* node, double& result)
+{
+    // since constant model doesn't use constant folding atm, we perform the basic extraction that's sufficient to handle positive/negative literals
+    if (AstExprConstantNumber* ne = node->as<AstExprConstantNumber>())
+    {
+        result = ne->value;
+        return true;
+    }
+
+    if (AstExprUnary* ue = node->as<AstExprUnary>(); ue && ue->op == AstExprUnary::Minus)
+        if (AstExprConstantNumber* ne = ue->expr->as<AstExprConstantNumber>())
+        {
+            result = -ne->value;
+            return true;
+        }
+
+    return false;
+}
+
+struct Cost
+{
+    static const uint64_t kLiteral = ~0ull;
+
+    // cost model: 8 bytes, where first byte is the baseline cost, and the next 7 bytes are discounts for when variable #i is constant
+    uint64_t model;
+    // constant mask: 8-byte 0xff mask; equal to all ff's for literals, for variables only byte #i (1+) is set to align with model
+    uint64_t constant;
+
+    Cost(int cost = 0, uint64_t constant = 0)
+        : model(cost < 0x7f ? cost : 0x7f)
+        , constant(constant)
+    {
+    }
+
+    Cost operator+(const Cost& other) const
+    {
+        Cost result;
+        result.model = parallelAddSat(model, other.model);
+        return result;
+    }
+
+    Cost& operator+=(const Cost& other)
+    {
+        model = parallelAddSat(model, other.model);
+        constant = 0;
+        return *this;
+    }
+
+    Cost operator*(int other) const
+    {
+        Cost result;
+        result.model = parallelMulSat(model, other);
+        return result;
+    }
+
+    static Cost fold(const Cost& x, const Cost& y)
+    {
+        uint64_t newmodel = parallelAddSat(x.model, y.model);
+        uint64_t newconstant = x.constant & y.constant;
+
+        // the extra cost for folding is 1; the discount is 1 for the variable that is shared by x&y (or whichever one is used in x/y if the other is
+        // literal)
+        uint64_t extra = (newconstant == kLiteral) ? 0 : (1 | (0x0101010101010101ull & newconstant));
+
+        Cost result;
+        result.model = parallelAddSat(newmodel, extra);
+        result.constant = newconstant;
+
+        return result;
+    }
+};
+
+struct CostVisitor : AstVisitor
+{
+    const DenseHashMap<AstExprCall*, int>& builtins;
+
+    DenseHashMap<AstLocal*, uint64_t> vars;
+    Cost result;
+
+    CostVisitor(const DenseHashMap<AstExprCall*, int>& builtins)
+        : builtins(builtins)
+        , vars(nullptr)
+    {
+    }
+
+    Cost model(AstExpr* node)
+    {
+        if (AstExprGroup* expr = node->as<AstExprGroup>())
+        {
+            return model(expr->expr);
+        }
+        else if (node->is<AstExprConstantNil>() || node->is<AstExprConstantBool>() || node->is<AstExprConstantNumber>() ||
+                 node->is<AstExprConstantString>())
+        {
+            return Cost(0, Cost::kLiteral);
+        }
+        else if (AstExprLocal* expr = node->as<AstExprLocal>())
+        {
+            const uint64_t* i = vars.find(expr->local);
+
+            return Cost(0, i ? *i : 0); // locals typically don't require extra instructions to compute
+        }
+        else if (node->is<AstExprGlobal>())
+        {
+            return 1;
+        }
+        else if (node->is<AstExprVarargs>())
+        {
+            return 3;
+        }
+        else if (AstExprCall* expr = node->as<AstExprCall>())
+        {
+            // builtin cost modeling is different from regular calls because we use FASTCALL to compile these
+            // thus we use a cheaper baseline, don't account for function, and assume constant/local copy is free
+            bool builtin = builtins.find(expr) != nullptr;
+            bool builtinShort = builtin && expr->args.size <= 2; // FASTCALL1/2
+
+            Cost cost = builtin ? 2 : 3;
+
+            if (!builtin)
+                cost += model(expr->func);
+
+            for (size_t i = 0; i < expr->args.size; ++i)
+            {
+                Cost ac = model(expr->args.data[i]);
+                // for constants/locals we still need to copy them to the argument list
+                cost += ac.model == 0 && !builtinShort ? Cost(1) : ac;
+            }
+
+            return cost;
+        }
+        else if (AstExprIndexName* expr = node->as<AstExprIndexName>())
+        {
+            return model(expr->expr) + 1;
+        }
+        else if (AstExprIndexExpr* expr = node->as<AstExprIndexExpr>())
+        {
+            return model(expr->expr) + model(expr->index) + 1;
+        }
+        else if (AstExprFunction* expr = node->as<AstExprFunction>())
+        {
+            return 10; // high baseline cost due to allocation
+        }
+        else if (AstExprTable* expr = node->as<AstExprTable>())
+        {
+            Cost cost = 10; // high baseline cost due to allocation
+
+            for (size_t i = 0; i < expr->items.size; ++i)
+            {
+                const AstExprTable::Item& item = expr->items.data[i];
+
+                if (item.key)
+                    cost += model(item.key);
+
+                cost += model(item.value);
+                cost += 1;
+            }
+
+            return cost;
+        }
+        else if (AstExprUnary* expr = node->as<AstExprUnary>())
+        {
+            return Cost::fold(model(expr->expr), Cost(0, Cost::kLiteral));
+        }
+        else if (AstExprBinary* expr = node->as<AstExprBinary>())
+        {
+            return Cost::fold(model(expr->left), model(expr->right));
+        }
+        else if (AstExprTypeAssertion* expr = node->as<AstExprTypeAssertion>())
+        {
+            return model(expr->expr);
+        }
+        else if (AstExprIfElse* expr = node->as<AstExprIfElse>())
+        {
+            return model(expr->condition) + model(expr->trueExpr) + model(expr->falseExpr) + 2;
+        }
+        else if (AstExprInterpString* expr = node->as<AstExprInterpString>())
+        {
+            // Baseline cost of string.format
+            Cost cost = 3;
+
+            for (AstExpr* innerExpression : expr->expressions)
+                cost += model(innerExpression);
+
+            return cost;
+        }
+        else
+        {
+            LUAU_ASSERT(!"Unknown expression type");
+            return {};
+        }
+    }
+
+    void assign(AstExpr* expr)
+    {
+        // variable assignments reset variable mask, so that further uses of this variable aren't discounted
+        // this doesn't work perfectly with backwards control flow like loops, but is good enough for a single pass
+        if (AstExprLocal* lv = expr->as<AstExprLocal>())
+            if (uint64_t* i = vars.find(lv->local))
+                *i = 0;
+    }
+
+    void loop(AstStatBlock* body, Cost iterCost, int factor = 3)
+    {
+        Cost before = result;
+
+        result = Cost();
+        body->visit(this);
+
+        result = before + (result + iterCost) * factor;
+    }
+
+    bool visit(AstExpr* node) override
+    {
+        // note: we short-circuit the visitor traversal through any expression trees by returning false
+        // recursive traversal is happening inside model() which makes it easier to get the resulting value of the subexpression
+        result += model(node);
+
+        return false;
+    }
+
+    bool visit(AstStatFor* node) override
+    {
+        result += model(node->from);
+        result += model(node->to);
+
+        if (node->step)
+            result += model(node->step);
+
+        int tripCount = -1;
+        double from, to, step = 1;
+        if (getNumber(node->from, from) && getNumber(node->to, to) && (!node->step || getNumber(node->step, step)))
+            tripCount = getTripCount(from, to, step);
+
+        loop(node->body, 1, tripCount < 0 ? 3 : tripCount);
+        return false;
+    }
+
+    bool visit(AstStatForIn* node) override
+    {
+        for (size_t i = 0; i < node->values.size; ++i)
+            result += model(node->values.data[i]);
+
+        loop(node->body, 1);
+        return false;
+    }
+
+    bool visit(AstStatWhile* node) override
+    {
+        Cost condition = model(node->condition);
+
+        loop(node->body, condition);
+        return false;
+    }
+
+    bool visit(AstStatRepeat* node) override
+    {
+        Cost condition = model(node->condition);
+
+        loop(node->body, condition);
+        return false;
+    }
+
+    bool visit(AstStatIf* node) override
+    {
+        // unconditional 'else' may require a jump after the 'if' body
+        // note: this ignores cases when 'then' always terminates and also assumes comparison requires an extra instruction which may be false
+        result += 1 + (node->elsebody && !node->elsebody->is<AstStatIf>());
+
+        return true;
+    }
+
+    bool visit(AstStatLocal* node) override
+    {
+        for (size_t i = 0; i < node->values.size; ++i)
+        {
+            Cost arg = model(node->values.data[i]);
+
+            // propagate constant mask from expression through variables
+            if (arg.constant && i < node->vars.size)
+                vars[node->vars.data[i]] = arg.constant;
+
+            result += arg;
+        }
+
+        return false;
+    }
+
+    bool visit(AstStatAssign* node) override
+    {
+        for (size_t i = 0; i < node->vars.size; ++i)
+            assign(node->vars.data[i]);
+
+        for (size_t i = 0; i < node->vars.size || i < node->values.size; ++i)
+        {
+            Cost ac;
+            if (i < node->vars.size)
+                ac += model(node->vars.data[i]);
+            if (i < node->values.size)
+                ac += model(node->values.data[i]);
+            // local->local or constant->local assignment is not free
+            result += ac.model == 0 ? Cost(1) : ac;
+        }
+
+        return false;
+    }
+
+    bool visit(AstStatCompoundAssign* node) override
+    {
+        assign(node->var);
+
+        // if lhs is not a local, setting it requires an extra table operation
+        result += node->var->is<AstExprLocal>() ? 1 : 2;
+
+        return true;
+    }
+
+    bool visit(AstStatBreak* node) override
+    {
+        result += 1;
+
+        return false;
+    }
+
+    bool visit(AstStatContinue* node) override
+    {
+        result += 1;
+
+        return false;
+    }
+};
+
+uint64_t modelCost(AstNode* root, AstLocal* const* vars, size_t varCount, const DenseHashMap<AstExprCall*, int>& builtins)
+{
+    CostVisitor visitor{builtins};
+    for (size_t i = 0; i < varCount && i < 7; ++i)
+        visitor.vars[vars[i]] = 0xffull << (i * 8 + 8);
+
+    root->visit(&visitor);
+
+    return visitor.result.model;
+}
+
+int computeCost(uint64_t model, const bool* varsConst, size_t varCount)
+{
+    int cost = int(model & 0x7f);
+
+    // don't apply discounts to what is likely a saturated sum
+    if (cost == 0x7f)
+        return cost;
+
+    for (size_t i = 0; i < varCount && i < 7; ++i)
+        cost -= int((model >> (i * 8 + 8)) & 0x7f) * varsConst[i];
+
+    return cost;
+}
+
+int getTripCount(double from, double to, double step)
+{
+    // we compute trip count in integers because that way we know that the loop math (repeated addition) is precise
+    int fromi = (from >= -32767 && from <= 32767 && double(int(from)) == from) ? int(from) : INT_MIN;
+    int toi = (to >= -32767 && to <= 32767 && double(int(to)) == to) ? int(to) : INT_MIN;
+    int stepi = (step >= -32767 && step <= 32767 && double(int(step)) == step) ? int(step) : INT_MIN;
+
+    if (fromi == INT_MIN || toi == INT_MIN || stepi == INT_MIN || stepi == 0)
+        return -1;
+
+    if ((stepi < 0 && toi > fromi) || (stepi > 0 && toi < fromi))
+        return 0;
+
+    return (toi - fromi) / stepi + 1;
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/CostModel.h
+++ b/lib/luau/Compiler/src/CostModel.h
@@ -1,0 +1,22 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/DenseHash.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+// cost model: 8 bytes, where first byte is the baseline cost, and the next 7 bytes are discounts for when variable #i is constant
+uint64_t modelCost(AstNode* root, AstLocal* const* vars, size_t varCount, const DenseHashMap<AstExprCall*, int>& builtins);
+
+// cost is computed as B - sum(Di * Ci), where B is baseline cost, Di is the discount for each variable and Ci is 1 when variable #i is constant
+int computeCost(uint64_t model, const bool* varsConst, size_t varCount);
+
+// get loop trip count or -1 if we can't compute it precisely
+int getTripCount(double from, double to, double step);
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/TableShape.cpp
+++ b/lib/luau/Compiler/src/TableShape.cpp
@@ -1,0 +1,158 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "TableShape.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+// conservative limit for the loop bound that establishes table array size
+static const int kMaxLoopBound = 16;
+
+static AstExprTable* getTableHint(AstExpr* expr)
+{
+    // unadorned table literal
+    if (AstExprTable* table = expr->as<AstExprTable>())
+        return table;
+
+    // setmetatable(table literal, ...)
+    if (AstExprCall* call = expr->as<AstExprCall>(); call && !call->self && call->args.size == 2)
+        if (AstExprGlobal* func = call->func->as<AstExprGlobal>(); func && func->name == "setmetatable")
+            if (AstExprTable* table = call->args.data[0]->as<AstExprTable>())
+                return table;
+
+    return nullptr;
+}
+
+struct ShapeVisitor : AstVisitor
+{
+    struct Hasher
+    {
+        size_t operator()(const std::pair<AstExprTable*, AstName>& p) const
+        {
+            return DenseHashPointer()(p.first) ^ std::hash<AstName>()(p.second);
+        }
+    };
+
+    DenseHashMap<AstExprTable*, TableShape>& shapes;
+
+    DenseHashMap<AstLocal*, AstExprTable*> tables;
+    DenseHashSet<std::pair<AstExprTable*, AstName>, Hasher> fields;
+
+    DenseHashMap<AstLocal*, unsigned int> loops; // iterator => upper bound for 1..k
+
+    ShapeVisitor(DenseHashMap<AstExprTable*, TableShape>& shapes)
+        : shapes(shapes)
+        , tables(nullptr)
+        , fields(std::pair<AstExprTable*, AstName>())
+        , loops(nullptr)
+    {
+    }
+
+    void assignField(AstExpr* expr, AstName index)
+    {
+        if (AstExprLocal* lv = expr->as<AstExprLocal>())
+        {
+            if (AstExprTable** table = tables.find(lv->local))
+            {
+                std::pair<AstExprTable*, AstName> field = {*table, index};
+
+                if (!fields.contains(field))
+                {
+                    fields.insert(field);
+                    shapes[*table].hashSize += 1;
+                }
+            }
+        }
+    }
+
+    void assignField(AstExpr* expr, AstExpr* index)
+    {
+        AstExprLocal* lv = expr->as<AstExprLocal>();
+        if (!lv)
+            return;
+
+        AstExprTable** table = tables.find(lv->local);
+        if (!table)
+            return;
+
+        if (AstExprConstantNumber* number = index->as<AstExprConstantNumber>())
+        {
+            TableShape& shape = shapes[*table];
+
+            if (number->value == double(shape.arraySize + 1))
+                shape.arraySize += 1;
+        }
+        else if (AstExprLocal* iter = index->as<AstExprLocal>())
+        {
+            if (const unsigned int* bound = loops.find(iter->local))
+            {
+                TableShape& shape = shapes[*table];
+
+                if (shape.arraySize == 0)
+                    shape.arraySize = *bound;
+            }
+        }
+    }
+
+    void assign(AstExpr* var)
+    {
+        if (AstExprIndexName* index = var->as<AstExprIndexName>())
+        {
+            assignField(index->expr, index->index);
+        }
+        else if (AstExprIndexExpr* index = var->as<AstExprIndexExpr>())
+        {
+            assignField(index->expr, index->index);
+        }
+    }
+
+    bool visit(AstStatLocal* node) override
+    {
+        // track local -> table association so that we can update table size prediction in assignField
+        if (node->vars.size == 1 && node->values.size == 1)
+            if (AstExprTable* table = getTableHint(node->values.data[0]); table && table->items.size == 0)
+                tables[node->vars.data[0]] = table;
+
+        return true;
+    }
+
+    bool visit(AstStatAssign* node) override
+    {
+        for (size_t i = 0; i < node->vars.size; ++i)
+            assign(node->vars.data[i]);
+
+        for (size_t i = 0; i < node->values.size; ++i)
+            node->values.data[i]->visit(this);
+
+        return false;
+    }
+
+    bool visit(AstStatFunction* node) override
+    {
+        assign(node->name);
+        node->func->visit(this);
+
+        return false;
+    }
+
+    bool visit(AstStatFor* node) override
+    {
+        AstExprConstantNumber* from = node->from->as<AstExprConstantNumber>();
+        AstExprConstantNumber* to = node->to->as<AstExprConstantNumber>();
+
+        if (from && to && from->value == 1.0 && to->value >= 1.0 && to->value <= double(kMaxLoopBound) && !node->step)
+            loops[node->var] = unsigned(to->value);
+
+        return true;
+    }
+};
+
+void predictTableShapes(DenseHashMap<AstExprTable*, TableShape>& shapes, AstNode* root)
+{
+    ShapeVisitor visitor{shapes};
+    root->visit(&visitor);
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/TableShape.h
+++ b/lib/luau/Compiler/src/TableShape.h
@@ -1,0 +1,21 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/DenseHash.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+struct TableShape
+{
+    unsigned int arraySize = 0;
+    unsigned int hashSize = 0;
+};
+
+void predictTableShapes(DenseHashMap<AstExprTable*, TableShape>& shapes, AstNode* root);
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/Types.cpp
+++ b/lib/luau/Compiler/src/Types.cpp
@@ -1,0 +1,233 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Types.h"
+
+#include "Luau/BytecodeBuilder.h"
+
+LUAU_FASTFLAGVARIABLE(LuauCompileBufferAnnotation, false)
+
+namespace Luau
+{
+
+static bool isGeneric(AstName name, const AstArray<AstGenericType>& generics)
+{
+    for (const AstGenericType& gt : generics)
+        if (gt.name == name)
+            return true;
+
+    return false;
+}
+
+static LuauBytecodeType getPrimitiveType(AstName name)
+{
+    if (name == "nil")
+        return LBC_TYPE_NIL;
+    else if (name == "boolean")
+        return LBC_TYPE_BOOLEAN;
+    else if (name == "number")
+        return LBC_TYPE_NUMBER;
+    else if (name == "string")
+        return LBC_TYPE_STRING;
+    else if (name == "thread")
+        return LBC_TYPE_THREAD;
+    else if (FFlag::LuauCompileBufferAnnotation && name == "buffer")
+        return LBC_TYPE_BUFFER;
+    else if (name == "any" || name == "unknown")
+        return LBC_TYPE_ANY;
+    else
+        return LBC_TYPE_INVALID;
+}
+
+static LuauBytecodeType getType(AstType* ty, const AstArray<AstGenericType>& generics, const DenseHashMap<AstName, AstStatTypeAlias*>& typeAliases,
+    bool resolveAliases, const char* vectorType)
+{
+    if (AstTypeReference* ref = ty->as<AstTypeReference>())
+    {
+        if (ref->prefix)
+            return LBC_TYPE_ANY;
+
+        if (AstStatTypeAlias* const* alias = typeAliases.find(ref->name); alias && *alias)
+        {
+            // note: we only resolve aliases to the depth of 1 to avoid dealing with recursive aliases
+            if (resolveAliases)
+                return getType((*alias)->type, (*alias)->generics, typeAliases, /* resolveAliases= */ false, vectorType);
+            else
+                return LBC_TYPE_ANY;
+        }
+
+        if (isGeneric(ref->name, generics))
+            return LBC_TYPE_ANY;
+
+        if (vectorType && ref->name == vectorType)
+            return LBC_TYPE_VECTOR;
+
+        if (LuauBytecodeType prim = getPrimitiveType(ref->name); prim != LBC_TYPE_INVALID)
+            return prim;
+
+        // not primitive or alias or generic => host-provided, we assume userdata for now
+        return LBC_TYPE_USERDATA;
+    }
+    else if (AstTypeTable* table = ty->as<AstTypeTable>())
+    {
+        return LBC_TYPE_TABLE;
+    }
+    else if (AstTypeFunction* func = ty->as<AstTypeFunction>())
+    {
+        return LBC_TYPE_FUNCTION;
+    }
+    else if (AstTypeUnion* un = ty->as<AstTypeUnion>())
+    {
+        bool optional = false;
+        LuauBytecodeType type = LBC_TYPE_INVALID;
+
+        for (AstType* ty : un->types)
+        {
+            LuauBytecodeType et = getType(ty, generics, typeAliases, resolveAliases, vectorType);
+
+            if (et == LBC_TYPE_NIL)
+            {
+                optional = true;
+                continue;
+            }
+
+            if (type == LBC_TYPE_INVALID)
+            {
+                type = et;
+                continue;
+            }
+
+            if (type != et)
+                return LBC_TYPE_ANY;
+        }
+
+        if (type == LBC_TYPE_INVALID)
+            return LBC_TYPE_ANY;
+
+        return LuauBytecodeType(type | (optional && (type != LBC_TYPE_ANY) ? LBC_TYPE_OPTIONAL_BIT : 0));
+    }
+    else if (AstTypeIntersection* inter = ty->as<AstTypeIntersection>())
+    {
+        return LBC_TYPE_ANY;
+    }
+
+    return LBC_TYPE_ANY;
+}
+
+static std::string getFunctionType(const AstExprFunction* func, const DenseHashMap<AstName, AstStatTypeAlias*>& typeAliases, const char* vectorType)
+{
+    bool self = func->self != 0;
+
+    std::string typeInfo;
+    typeInfo.reserve(func->args.size + self + 2);
+
+    typeInfo.push_back(LBC_TYPE_FUNCTION);
+    typeInfo.push_back(uint8_t(self + func->args.size));
+
+    if (self)
+        typeInfo.push_back(LBC_TYPE_TABLE);
+
+    bool haveNonAnyParam = false;
+    for (AstLocal* arg : func->args)
+    {
+        LuauBytecodeType ty =
+            arg->annotation ? getType(arg->annotation, func->generics, typeAliases, /* resolveAliases= */ true, vectorType) : LBC_TYPE_ANY;
+
+        if (ty != LBC_TYPE_ANY)
+            haveNonAnyParam = true;
+
+        typeInfo.push_back(ty);
+    }
+
+    // If all parameters simplify to any, we can just omit type info for this function
+    if (!haveNonAnyParam)
+        return {};
+
+    return typeInfo;
+}
+
+struct TypeMapVisitor : AstVisitor
+{
+    DenseHashMap<AstExprFunction*, std::string>& typeMap;
+    const char* vectorType;
+
+    DenseHashMap<AstName, AstStatTypeAlias*> typeAliases;
+    std::vector<std::pair<AstName, AstStatTypeAlias*>> typeAliasStack;
+
+    TypeMapVisitor(DenseHashMap<AstExprFunction*, std::string>& typeMap, const char* vectorType)
+        : typeMap(typeMap)
+        , vectorType(vectorType)
+        , typeAliases(AstName())
+    {
+    }
+
+    size_t pushTypeAliases(AstStatBlock* block)
+    {
+        size_t aliasStackTop = typeAliasStack.size();
+
+        for (AstStat* stat : block->body)
+            if (AstStatTypeAlias* alias = stat->as<AstStatTypeAlias>())
+            {
+                AstStatTypeAlias*& prevAlias = typeAliases[alias->name];
+
+                typeAliasStack.push_back(std::make_pair(alias->name, prevAlias));
+                prevAlias = alias;
+            }
+
+        return aliasStackTop;
+    }
+
+    void popTypeAliases(size_t aliasStackTop)
+    {
+        while (typeAliasStack.size() > aliasStackTop)
+        {
+            std::pair<AstName, AstStatTypeAlias*>& top = typeAliasStack.back();
+
+            typeAliases[top.first] = top.second;
+            typeAliasStack.pop_back();
+        }
+    }
+
+    bool visit(AstStatBlock* node) override
+    {
+        size_t aliasStackTop = pushTypeAliases(node);
+
+        for (AstStat* stat : node->body)
+            stat->visit(this);
+
+        popTypeAliases(aliasStackTop);
+
+        return false;
+    }
+
+    // repeat..until scoping rules are such that condition (along with any possible functions declared in it) has aliases from repeat body in scope
+    bool visit(AstStatRepeat* node) override
+    {
+        size_t aliasStackTop = pushTypeAliases(node->body);
+
+        for (AstStat* stat : node->body->body)
+            stat->visit(this);
+
+        node->condition->visit(this);
+
+        popTypeAliases(aliasStackTop);
+
+        return false;
+    }
+
+    bool visit(AstExprFunction* node) override
+    {
+        std::string type = getFunctionType(node, typeAliases, vectorType);
+
+        if (!type.empty())
+            typeMap[node] = std::move(type);
+
+        return true;
+    }
+};
+
+void buildTypeMap(DenseHashMap<AstExprFunction*, std::string>& typeMap, AstNode* root, const char* vectorType)
+{
+    TypeMapVisitor visitor(typeMap, vectorType);
+    root->visit(&visitor);
+}
+
+} // namespace Luau

--- a/lib/luau/Compiler/src/Types.h
+++ b/lib/luau/Compiler/src/Types.h
@@ -1,0 +1,14 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/DenseHash.h"
+
+#include <string>
+
+namespace Luau
+{
+
+void buildTypeMap(DenseHashMap<AstExprFunction*, std::string>& typeMap, AstNode* root, const char* vectorType);
+
+} // namespace Luau

--- a/lib/luau/Compiler/src/ValueTracking.cpp
+++ b/lib/luau/Compiler/src/ValueTracking.cpp
@@ -1,0 +1,103 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "ValueTracking.h"
+
+#include "Luau/Lexer.h"
+
+namespace Luau
+{
+namespace Compile
+{
+
+struct ValueVisitor : AstVisitor
+{
+    DenseHashMap<AstName, Global>& globals;
+    DenseHashMap<AstLocal*, Variable>& variables;
+
+    ValueVisitor(DenseHashMap<AstName, Global>& globals, DenseHashMap<AstLocal*, Variable>& variables)
+        : globals(globals)
+        , variables(variables)
+    {
+    }
+
+    void assign(AstExpr* var)
+    {
+        if (AstExprLocal* lv = var->as<AstExprLocal>())
+        {
+            variables[lv->local].written = true;
+        }
+        else if (AstExprGlobal* gv = var->as<AstExprGlobal>())
+        {
+            globals[gv->name] = Global::Written;
+        }
+        else
+        {
+            // we need to be able to track assignments in all expressions, including crazy ones like t[function() t = nil end] = 5
+            var->visit(this);
+        }
+    }
+
+    bool visit(AstStatLocal* node) override
+    {
+        for (size_t i = 0; i < node->vars.size && i < node->values.size; ++i)
+            variables[node->vars.data[i]].init = node->values.data[i];
+
+        for (size_t i = node->values.size; i < node->vars.size; ++i)
+            variables[node->vars.data[i]].init = nullptr;
+
+        return true;
+    }
+
+    bool visit(AstStatAssign* node) override
+    {
+        for (size_t i = 0; i < node->vars.size; ++i)
+            assign(node->vars.data[i]);
+
+        for (size_t i = 0; i < node->values.size; ++i)
+            node->values.data[i]->visit(this);
+
+        return false;
+    }
+
+    bool visit(AstStatCompoundAssign* node) override
+    {
+        assign(node->var);
+        node->value->visit(this);
+
+        return false;
+    }
+
+    bool visit(AstStatLocalFunction* node) override
+    {
+        variables[node->name].init = node->func;
+
+        return true;
+    }
+
+    bool visit(AstStatFunction* node) override
+    {
+        assign(node->name);
+        node->func->visit(this);
+
+        return false;
+    }
+};
+
+void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char* const* mutableGlobals)
+{
+    if (AstName name = names.get("_G"); name.value)
+        globals[name] = Global::Mutable;
+
+    if (mutableGlobals)
+        for (const char* const* ptr = mutableGlobals; *ptr; ++ptr)
+            if (AstName name = names.get(*ptr); name.value)
+                globals[name] = Global::Mutable;
+}
+
+void trackValues(DenseHashMap<AstName, Global>& globals, DenseHashMap<AstLocal*, Variable>& variables, AstNode* root)
+{
+    ValueVisitor visitor{globals, variables};
+    root->visit(&visitor);
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/ValueTracking.h
+++ b/lib/luau/Compiler/src/ValueTracking.h
@@ -1,0 +1,42 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/DenseHash.h"
+
+namespace Luau
+{
+class AstNameTable;
+}
+
+namespace Luau
+{
+namespace Compile
+{
+
+enum class Global
+{
+    Default = 0,
+    Mutable, // builtin that has contents unknown at compile time, blocks GETIMPORT for chains
+    Written, // written in the code which means we can't reason about the value
+};
+
+struct Variable
+{
+    AstExpr* init = nullptr; // initial value of the variable; filled by trackValues
+    bool written = false;    // is the variable ever assigned to? filled by trackValues
+    bool constant = false;   // is the variable's value a compile-time constant? filled by constantFold
+};
+
+void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char* const* mutableGlobals);
+void trackValues(DenseHashMap<AstName, Global>& globals, DenseHashMap<AstLocal*, Variable>& variables, AstNode* root);
+
+inline Global getGlobalState(const DenseHashMap<AstName, Global>& globals, AstName name)
+{
+    const Global* it = globals.find(name);
+
+    return it ? *it : Global::Default;
+}
+
+} // namespace Compile
+} // namespace Luau

--- a/lib/luau/Compiler/src/lcode.cpp
+++ b/lib/luau/Compiler/src/lcode.cpp
@@ -1,0 +1,29 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "luacode.h"
+
+#include "Luau/Compiler.h"
+
+#include <string.h>
+
+char* luau_compile(const char* source, size_t size, lua_CompileOptions* options, size_t* outsize)
+{
+    LUAU_ASSERT(outsize);
+
+    Luau::CompileOptions opts;
+
+    if (options)
+    {
+        static_assert(sizeof(lua_CompileOptions) == sizeof(Luau::CompileOptions), "C and C++ interface must match");
+        memcpy(static_cast<void*>(&opts), options, sizeof(opts));
+    }
+
+    std::string result = compile(std::string(source, size), opts);
+
+    char* copy = static_cast<char*>(malloc(result.size()));
+    if (!copy)
+        return nullptr;
+
+    memcpy(copy, result.data(), result.size());
+    *outsize = result.size();
+    return copy;
+}

--- a/lib/luau/LICENSE.txt
+++ b/lib/luau/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019-2023 Roblox Corporation
+Copyright (c) 1994–2019 Lua.org, PUC-Rio.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/luau/VM/include/lua.h
+++ b/lib/luau/VM/include/lua.h
@@ -1,0 +1,480 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "luaconf.h"
+
+
+
+
+// option for multiple returns in `lua_pcall' and `lua_call'
+#define LUA_MULTRET (-1)
+
+/*
+** pseudo-indices
+*/
+#define LUA_REGISTRYINDEX (-LUAI_MAXCSTACK - 2000)
+#define LUA_ENVIRONINDEX (-LUAI_MAXCSTACK - 2001)
+#define LUA_GLOBALSINDEX (-LUAI_MAXCSTACK - 2002)
+#define lua_upvalueindex(i) (LUA_GLOBALSINDEX - (i))
+#define lua_ispseudo(i) ((i) <= LUA_REGISTRYINDEX)
+
+// thread status; 0 is OK
+enum lua_Status
+{
+    LUA_OK = 0,
+    LUA_YIELD,
+    LUA_ERRRUN,
+    LUA_ERRSYNTAX, // legacy error code, preserved for compatibility
+    LUA_ERRMEM,
+    LUA_ERRERR,
+    LUA_BREAK, // yielded for a debug breakpoint
+};
+
+enum lua_CoStatus
+{
+    LUA_CORUN = 0, // running
+    LUA_COSUS,     // suspended
+    LUA_CONOR,     // 'normal' (it resumed another coroutine)
+    LUA_COFIN,     // finished
+    LUA_COERR,     // finished with error
+};
+
+typedef struct lua_State lua_State;
+
+typedef int (*lua_CFunction)(lua_State* L);
+typedef int (*lua_Continuation)(lua_State* L, int status);
+
+/*
+** prototype for memory-allocation functions
+*/
+
+typedef void* (*lua_Alloc)(void* ud, void* ptr, size_t osize, size_t nsize);
+
+// non-return type
+#define l_noret void LUA_NORETURN
+
+/*
+** basic types
+*/
+#define LUA_TNONE (-1)
+
+/*
+ * WARNING: if you change the order of this enumeration,
+ * grep "ORDER TYPE"
+ */
+// clang-format off
+enum lua_Type
+{
+    LUA_TNIL = 0,     // must be 0 due to lua_isnoneornil
+    LUA_TBOOLEAN = 1, // must be 1 due to l_isfalse
+
+
+    LUA_TLIGHTUSERDATA,
+    LUA_TNUMBER,
+    LUA_TVECTOR,
+
+    LUA_TSTRING, // all types above this must be value types, all types below this must be GC types - see iscollectable
+
+
+    LUA_TTABLE,
+    LUA_TFUNCTION,
+    LUA_TUSERDATA,
+    LUA_TTHREAD,
+    LUA_TBUFFER,
+
+    // values below this line are used in GCObject tags but may never show up in TValue type tags
+    LUA_TPROTO,
+    LUA_TUPVAL,
+    LUA_TDEADKEY,
+
+    // the count of TValue type tags
+    LUA_T_COUNT = LUA_TPROTO
+};
+// clang-format on
+
+// type of numbers in Luau
+typedef double lua_Number;
+
+// type for integer functions
+typedef int lua_Integer;
+
+// unsigned integer type
+typedef unsigned lua_Unsigned;
+
+/*
+** state manipulation
+*/
+LUA_API lua_State* lua_newstate(lua_Alloc f, void* ud);
+LUA_API void lua_close(lua_State* L);
+LUA_API lua_State* lua_newthread(lua_State* L);
+LUA_API lua_State* lua_mainthread(lua_State* L);
+LUA_API void lua_resetthread(lua_State* L);
+LUA_API int lua_isthreadreset(lua_State* L);
+
+/*
+** basic stack manipulation
+*/
+LUA_API int lua_absindex(lua_State* L, int idx);
+LUA_API int lua_gettop(lua_State* L);
+LUA_API void lua_settop(lua_State* L, int idx);
+LUA_API void lua_pushvalue(lua_State* L, int idx);
+LUA_API void lua_remove(lua_State* L, int idx);
+LUA_API void lua_insert(lua_State* L, int idx);
+LUA_API void lua_replace(lua_State* L, int idx);
+LUA_API int lua_checkstack(lua_State* L, int sz);
+LUA_API void lua_rawcheckstack(lua_State* L, int sz); // allows for unlimited stack frames
+
+LUA_API void lua_xmove(lua_State* from, lua_State* to, int n);
+LUA_API void lua_xpush(lua_State* from, lua_State* to, int idx);
+
+/*
+** access functions (stack -> C)
+*/
+
+LUA_API int lua_isnumber(lua_State* L, int idx);
+LUA_API int lua_isstring(lua_State* L, int idx);
+LUA_API int lua_iscfunction(lua_State* L, int idx);
+LUA_API int lua_isLfunction(lua_State* L, int idx);
+LUA_API int lua_isuserdata(lua_State* L, int idx);
+LUA_API int lua_type(lua_State* L, int idx);
+LUA_API const char* lua_typename(lua_State* L, int tp);
+
+LUA_API int lua_equal(lua_State* L, int idx1, int idx2);
+LUA_API int lua_rawequal(lua_State* L, int idx1, int idx2);
+LUA_API int lua_lessthan(lua_State* L, int idx1, int idx2);
+
+LUA_API double lua_tonumberx(lua_State* L, int idx, int* isnum);
+LUA_API int lua_tointegerx(lua_State* L, int idx, int* isnum);
+LUA_API unsigned lua_tounsignedx(lua_State* L, int idx, int* isnum);
+LUA_API const float* lua_tovector(lua_State* L, int idx);
+LUA_API int lua_toboolean(lua_State* L, int idx);
+LUA_API const char* lua_tolstring(lua_State* L, int idx, size_t* len);
+LUA_API const char* lua_tostringatom(lua_State* L, int idx, int* atom);
+LUA_API const char* lua_namecallatom(lua_State* L, int* atom);
+LUA_API int lua_objlen(lua_State* L, int idx);
+LUA_API lua_CFunction lua_tocfunction(lua_State* L, int idx);
+LUA_API void* lua_tolightuserdata(lua_State* L, int idx);
+LUA_API void* lua_tolightuserdatatagged(lua_State* L, int idx, int tag);
+LUA_API void* lua_touserdata(lua_State* L, int idx);
+LUA_API void* lua_touserdatatagged(lua_State* L, int idx, int tag);
+LUA_API int lua_userdatatag(lua_State* L, int idx);
+LUA_API int lua_lightuserdatatag(lua_State* L, int idx);
+LUA_API lua_State* lua_tothread(lua_State* L, int idx);
+LUA_API void* lua_tobuffer(lua_State* L, int idx, size_t* len);
+LUA_API const void* lua_topointer(lua_State* L, int idx);
+
+/*
+** push functions (C -> stack)
+*/
+LUA_API void lua_pushnil(lua_State* L);
+LUA_API void lua_pushnumber(lua_State* L, double n);
+LUA_API void lua_pushinteger(lua_State* L, int n);
+LUA_API void lua_pushunsigned(lua_State* L, unsigned n);
+#if LUA_VECTOR_SIZE == 4
+LUA_API void lua_pushvector(lua_State* L, float x, float y, float z, float w);
+#else
+LUA_API void lua_pushvector(lua_State* L, float x, float y, float z);
+#endif
+LUA_API void lua_pushlstring(lua_State* L, const char* s, size_t l);
+LUA_API void lua_pushstring(lua_State* L, const char* s);
+LUA_API const char* lua_pushvfstring(lua_State* L, const char* fmt, va_list argp);
+LUA_API LUA_PRINTF_ATTR(2, 3) const char* lua_pushfstringL(lua_State* L, const char* fmt, ...);
+LUA_API void lua_pushcclosurek(lua_State* L, lua_CFunction fn, const char* debugname, int nup, lua_Continuation cont);
+LUA_API void lua_pushboolean(lua_State* L, int b);
+LUA_API int lua_pushthread(lua_State* L);
+
+LUA_API void lua_pushlightuserdatatagged(lua_State* L, void* p, int tag);
+LUA_API void* lua_newuserdatatagged(lua_State* L, size_t sz, int tag);
+LUA_API void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*));
+
+LUA_API void* lua_newbuffer(lua_State* L, size_t sz);
+
+/*
+** get functions (Lua -> stack)
+*/
+LUA_API int lua_gettable(lua_State* L, int idx);
+LUA_API int lua_getfield(lua_State* L, int idx, const char* k);
+LUA_API int lua_rawgetfield(lua_State* L, int idx, const char* k);
+LUA_API int lua_rawget(lua_State* L, int idx);
+LUA_API int lua_rawgeti(lua_State* L, int idx, int n);
+LUA_API void lua_createtable(lua_State* L, int narr, int nrec);
+
+LUA_API void lua_setreadonly(lua_State* L, int idx, int enabled);
+LUA_API int lua_getreadonly(lua_State* L, int idx);
+LUA_API void lua_setsafeenv(lua_State* L, int idx, int enabled);
+
+LUA_API int lua_getmetatable(lua_State* L, int objindex);
+LUA_API void lua_getfenv(lua_State* L, int idx);
+
+/*
+** set functions (stack -> Lua)
+*/
+LUA_API void lua_settable(lua_State* L, int idx);
+LUA_API void lua_setfield(lua_State* L, int idx, const char* k);
+LUA_API void lua_rawsetfield(lua_State* L, int idx, const char* k);
+LUA_API void lua_rawset(lua_State* L, int idx);
+LUA_API void lua_rawseti(lua_State* L, int idx, int n);
+LUA_API int lua_setmetatable(lua_State* L, int objindex);
+LUA_API int lua_setfenv(lua_State* L, int idx);
+
+/*
+** `load' and `call' functions (load and run Luau bytecode)
+*/
+LUA_API int luau_load(lua_State* L, const char* chunkname, const char* data, size_t size, int env);
+LUA_API void lua_call(lua_State* L, int nargs, int nresults);
+LUA_API int lua_pcall(lua_State* L, int nargs, int nresults, int errfunc);
+
+/*
+** coroutine functions
+*/
+LUA_API int lua_yield(lua_State* L, int nresults);
+LUA_API int lua_break(lua_State* L);
+LUA_API int lua_resume(lua_State* L, lua_State* from, int narg);
+LUA_API int lua_resumeerror(lua_State* L, lua_State* from);
+LUA_API int lua_status(lua_State* L);
+LUA_API int lua_isyieldable(lua_State* L);
+LUA_API void* lua_getthreaddata(lua_State* L);
+LUA_API void lua_setthreaddata(lua_State* L, void* data);
+LUA_API int lua_costatus(lua_State* L, lua_State* co);
+
+/*
+** garbage-collection function and options
+*/
+
+enum lua_GCOp
+{
+    // stop and resume incremental garbage collection
+    LUA_GCSTOP,
+    LUA_GCRESTART,
+
+    // run a full GC cycle; not recommended for latency sensitive applications
+    LUA_GCCOLLECT,
+
+    // return the heap size in KB and the remainder in bytes
+    LUA_GCCOUNT,
+    LUA_GCCOUNTB,
+
+    // return 1 if GC is active (not stopped); note that GC may not be actively collecting even if it's running
+    LUA_GCISRUNNING,
+
+    /*
+    ** perform an explicit GC step, with the step size specified in KB
+    **
+    ** garbage collection is handled by 'assists' that perform some amount of GC work matching pace of allocation
+    ** explicit GC steps allow to perform some amount of work at custom points to offset the need for GC assists
+    ** note that GC might also be paused for some duration (until bytes allocated meet the threshold)
+    ** if an explicit step is performed during this pause, it will trigger the start of the next collection cycle
+    */
+    LUA_GCSTEP,
+
+    /*
+    ** tune GC parameters G (goal), S (step multiplier) and step size (usually best left ignored)
+    **
+    ** garbage collection is incremental and tries to maintain the heap size to balance memory and performance overhead
+    ** this overhead is determined by G (goal) which is the ratio between total heap size and the amount of live data in it
+    ** G is specified in percentages; by default G=200% which means that the heap is allowed to grow to ~2x the size of live data.
+    **
+    ** collector tries to collect S% of allocated bytes by interrupting the application after step size bytes were allocated.
+    ** when S is too small, collector may not be able to catch up and the effective goal that can be reached will be larger.
+    ** S is specified in percentages; by default S=200% which means that collector will run at ~2x the pace of allocations.
+    **
+    ** it is recommended to set S in the interval [100 / (G - 100), 100 + 100 / (G - 100))] with a minimum value of 150%; for example:
+    ** - for G=200%, S should be in the interval [150%, 200%]
+    ** - for G=150%, S should be in the interval [200%, 300%]
+    ** - for G=125%, S should be in the interval [400%, 500%]
+    */
+    LUA_GCSETGOAL,
+    LUA_GCSETSTEPMUL,
+    LUA_GCSETSTEPSIZE,
+};
+
+LUA_API int lua_gc(lua_State* L, int what, int data);
+
+/*
+** memory statistics
+** all allocated bytes are attributed to the memory category of the running thread (0..LUA_MEMORY_CATEGORIES-1)
+*/
+
+LUA_API void lua_setmemcat(lua_State* L, int category);
+LUA_API size_t lua_totalbytes(lua_State* L, int category);
+
+/*
+** miscellaneous functions
+*/
+
+LUA_API l_noret lua_error(lua_State* L);
+
+LUA_API int lua_next(lua_State* L, int idx);
+LUA_API int lua_rawiter(lua_State* L, int idx, int iter);
+
+LUA_API void lua_concat(lua_State* L, int n);
+
+LUA_API uintptr_t lua_encodepointer(lua_State* L, uintptr_t p);
+
+LUA_API double lua_clock();
+
+LUA_API void lua_setuserdatatag(lua_State* L, int idx, int tag);
+
+typedef void (*lua_Destructor)(lua_State* L, void* userdata);
+
+LUA_API void lua_setuserdatadtor(lua_State* L, int tag, lua_Destructor dtor);
+LUA_API lua_Destructor lua_getuserdatadtor(lua_State* L, int tag);
+
+LUA_API void lua_setlightuserdataname(lua_State* L, int tag, const char* name);
+LUA_API const char* lua_getlightuserdataname(lua_State* L, int tag);
+
+LUA_API void lua_clonefunction(lua_State* L, int idx);
+
+LUA_API void lua_cleartable(lua_State* L, int idx);
+
+LUA_API lua_Alloc lua_getallocf(lua_State* L, void** ud);
+
+/*
+** reference system, can be used to pin objects
+*/
+#define LUA_NOREF -1
+#define LUA_REFNIL 0
+
+LUA_API int lua_ref(lua_State* L, int idx);
+LUA_API void lua_unref(lua_State* L, int ref);
+
+#define lua_getref(L, ref) lua_rawgeti(L, LUA_REGISTRYINDEX, (ref))
+
+/*
+** ===============================================================
+** some useful macros
+** ===============================================================
+*/
+#define lua_tonumber(L, i) lua_tonumberx(L, i, NULL)
+#define lua_tointeger(L, i) lua_tointegerx(L, i, NULL)
+#define lua_tounsigned(L, i) lua_tounsignedx(L, i, NULL)
+
+#define lua_pop(L, n) lua_settop(L, -(n)-1)
+
+#define lua_newtable(L) lua_createtable(L, 0, 0)
+#define lua_newuserdata(L, s) lua_newuserdatatagged(L, s, 0)
+
+#define lua_strlen(L, i) lua_objlen(L, (i))
+
+#define lua_isfunction(L, n) (lua_type(L, (n)) == LUA_TFUNCTION)
+#define lua_istable(L, n) (lua_type(L, (n)) == LUA_TTABLE)
+#define lua_islightuserdata(L, n) (lua_type(L, (n)) == LUA_TLIGHTUSERDATA)
+#define lua_isnil(L, n) (lua_type(L, (n)) == LUA_TNIL)
+#define lua_isboolean(L, n) (lua_type(L, (n)) == LUA_TBOOLEAN)
+#define lua_isvector(L, n) (lua_type(L, (n)) == LUA_TVECTOR)
+#define lua_isthread(L, n) (lua_type(L, (n)) == LUA_TTHREAD)
+#define lua_isbuffer(L, n) (lua_type(L, (n)) == LUA_TBUFFER)
+#define lua_isnone(L, n) (lua_type(L, (n)) == LUA_TNONE)
+#define lua_isnoneornil(L, n) (lua_type(L, (n)) <= LUA_TNIL)
+
+#define lua_pushliteral(L, s) lua_pushlstring(L, "" s, (sizeof(s) / sizeof(char)) - 1)
+#define lua_pushcfunction(L, fn, debugname) lua_pushcclosurek(L, fn, debugname, 0, NULL)
+#define lua_pushcclosure(L, fn, debugname, nup) lua_pushcclosurek(L, fn, debugname, nup, NULL)
+#define lua_pushlightuserdata(L, p) lua_pushlightuserdatatagged(L, p, 0)
+
+#define lua_setglobal(L, s) lua_setfield(L, LUA_GLOBALSINDEX, (s))
+#define lua_getglobal(L, s) lua_getfield(L, LUA_GLOBALSINDEX, (s))
+
+#define lua_tostring(L, i) lua_tolstring(L, (i), NULL)
+
+#define lua_pushfstring(L, fmt, ...) lua_pushfstringL(L, fmt, ##__VA_ARGS__)
+
+/*
+** {======================================================================
+** Debug API
+** =======================================================================
+*/
+
+typedef struct lua_Debug lua_Debug; // activation record
+
+// Functions to be called by the debugger in specific events
+typedef void (*lua_Hook)(lua_State* L, lua_Debug* ar);
+
+LUA_API int lua_stackdepth(lua_State* L);
+LUA_API int lua_getinfo(lua_State* L, int level, const char* what, lua_Debug* ar);
+LUA_API int lua_getargument(lua_State* L, int level, int n);
+LUA_API const char* lua_getlocal(lua_State* L, int level, int n);
+LUA_API const char* lua_setlocal(lua_State* L, int level, int n);
+LUA_API const char* lua_getupvalue(lua_State* L, int funcindex, int n);
+LUA_API const char* lua_setupvalue(lua_State* L, int funcindex, int n);
+
+LUA_API void lua_singlestep(lua_State* L, int enabled);
+LUA_API int lua_breakpoint(lua_State* L, int funcindex, int line, int enabled);
+
+typedef void (*lua_Coverage)(void* context, const char* function, int linedefined, int depth, const int* hits, size_t size);
+
+LUA_API void lua_getcoverage(lua_State* L, int funcindex, void* context, lua_Coverage callback);
+
+// Warning: this function is not thread-safe since it stores the result in a shared global array! Only use for debugging.
+LUA_API const char* lua_debugtrace(lua_State* L);
+
+struct lua_Debug
+{
+    const char* name;      // (n)
+    const char* what;      // (s) `Lua', `C', `main', `tail'
+    const char* source;    // (s)
+    const char* short_src; // (s)
+    int linedefined;       // (s)
+    int currentline;       // (l)
+    unsigned char nupvals; // (u) number of upvalues
+    unsigned char nparams; // (a) number of parameters
+    char isvararg;         // (a)
+    void* userdata;        // only valid in luau_callhook
+
+    char ssbuf[LUA_IDSIZE];
+};
+
+// }======================================================================
+
+/* Callbacks that can be used to reconfigure behavior of the VM dynamically.
+ * These are shared between all coroutines.
+ *
+ * Note: interrupt is safe to set from an arbitrary thread but all other callbacks
+ * can only be changed when the VM is not running any code */
+struct lua_Callbacks
+{
+    void* userdata; // arbitrary userdata pointer that is never overwritten by Luau
+
+    void (*interrupt)(lua_State* L, int gc);  // gets called at safepoints (loop back edges, call/ret, gc) if set
+    void (*panic)(lua_State* L, int errcode); // gets called when an unprotected error is raised (if longjmp is used)
+
+    void (*userthread)(lua_State* LP, lua_State* L); // gets called when L is created (LP == parent) or destroyed (LP == NULL)
+    int16_t (*useratom)(const char* s, size_t l);    // gets called when a string is created; returned atom can be retrieved via tostringatom
+
+    void (*debugbreak)(lua_State* L, lua_Debug* ar);     // gets called when BREAK instruction is encountered
+    void (*debugstep)(lua_State* L, lua_Debug* ar);      // gets called after each instruction in single step mode
+    void (*debuginterrupt)(lua_State* L, lua_Debug* ar); // gets called when thread execution is interrupted by break in another thread
+    void (*debugprotectederror)(lua_State* L);           // gets called when protected call results in an error
+};
+typedef struct lua_Callbacks lua_Callbacks;
+
+LUA_API lua_Callbacks* lua_callbacks(lua_State* L);
+
+/******************************************************************************
+ * Copyright (c) 2019-2023 Roblox Corporation
+ * Copyright (C) 1994-2008 Lua.org, PUC-Rio.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/

--- a/lib/luau/VM/include/luaconf.h
+++ b/lib/luau/VM/include/luaconf.h
@@ -1,0 +1,150 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+// When debugging complex issues, consider enabling one of these:
+// This will reallocate the stack very aggressively at every opportunity; use this with asan to catch stale stack pointers
+// #define HARDSTACKTESTS 1
+// This will call GC validation very aggressively at every incremental GC step; use this with caution as it's SLOW
+// #define HARDMEMTESTS 1
+// This will call GC validation very aggressively at every GC opportunity; use this with caution as it's VERY SLOW
+// #define HARDMEMTESTS 2
+
+// To force MSVC2017+ to generate SSE2 code for some stdlib functions we need to locally enable /fp:fast
+// Note that /fp:fast changes the semantics of floating point comparisons so this is only safe to do for functions without ones
+#if defined(_MSC_VER) && !defined(__clang__)
+#define LUAU_FASTMATH_BEGIN __pragma(float_control(precise, off, push))
+#define LUAU_FASTMATH_END __pragma(float_control(pop))
+#else
+#define LUAU_FASTMATH_BEGIN
+#define LUAU_FASTMATH_END
+#endif
+
+// Some functions like floor/ceil have SSE4.1 equivalents but we currently support systems without SSE4.1
+// Note that we only need to do this when SSE4.1 support is not guaranteed by compiler settings, as otherwise compiler will optimize these for us.
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(__SSE4_1__) && !defined(__AVX__)
+#if defined(_MSC_VER) && !defined(__clang__)
+#define LUAU_TARGET_SSE41
+#elif defined(__GNUC__) && defined(__has_attribute)
+#if __has_attribute(target)
+#define LUAU_TARGET_SSE41 __attribute__((target("sse4.1")))
+#endif
+#endif
+#endif
+
+// Used on functions that have a printf-like interface to validate them statically
+#if defined(__GNUC__)
+#define LUA_PRINTF_ATTR(fmt, arg) __attribute__((format(printf, fmt, arg)))
+#else
+#define LUA_PRINTF_ATTR(fmt, arg)
+#endif
+
+#ifdef _MSC_VER
+#define LUA_NORETURN __declspec(noreturn)
+#else
+#define LUA_NORETURN __attribute__((__noreturn__))
+#endif
+
+// Can be used to reconfigure visibility/exports for public APIs
+#ifndef LUA_API
+#define LUA_API extern
+#endif
+
+#define LUALIB_API LUA_API
+
+// Can be used to reconfigure visibility for internal APIs
+#if defined(__GNUC__)
+#define LUAI_FUNC __attribute__((visibility("hidden"))) extern
+#define LUAI_DATA LUAI_FUNC
+#else
+#define LUAI_FUNC extern
+#define LUAI_DATA extern
+#endif
+
+// Can be used to reconfigure internal error handling to use longjmp instead of C++ EH
+#ifndef LUA_USE_LONGJMP
+#define LUA_USE_LONGJMP 0
+#endif
+
+// LUA_IDSIZE gives the maximum size for the description of the source
+#ifndef LUA_IDSIZE
+#define LUA_IDSIZE 256
+#endif
+
+// LUA_MINSTACK is the guaranteed number of Lua stack slots available to a C function
+#ifndef LUA_MINSTACK
+#define LUA_MINSTACK 20
+#endif
+
+// LUAI_MAXCSTACK limits the number of Lua stack slots that a C function can use
+#ifndef LUAI_MAXCSTACK
+#define LUAI_MAXCSTACK 8000
+#endif
+
+// LUAI_MAXCALLS limits the number of nested calls
+#ifndef LUAI_MAXCALLS
+#define LUAI_MAXCALLS 20000
+#endif
+
+// LUAI_MAXCCALLS is the maximum depth for nested C calls; this limit depends on native stack size
+#ifndef LUAI_MAXCCALLS
+#define LUAI_MAXCCALLS 200
+#endif
+
+// buffer size used for on-stack string operations; this limit depends on native stack size
+#ifndef LUA_BUFFERSIZE
+#define LUA_BUFFERSIZE 512
+#endif
+
+// number of valid Lua userdata tags
+#ifndef LUA_UTAG_LIMIT
+#define LUA_UTAG_LIMIT 128
+#endif
+
+// number of valid Lua lightuserdata tags
+#ifndef LUA_LUTAG_LIMIT
+#define LUA_LUTAG_LIMIT 128
+#endif
+
+// upper bound for number of size classes used by page allocator
+#ifndef LUA_SIZECLASSES
+#define LUA_SIZECLASSES 32
+#endif
+
+// available number of separate memory categories
+#ifndef LUA_MEMORY_CATEGORIES
+#define LUA_MEMORY_CATEGORIES 256
+#endif
+
+// minimum size for the string table (must be power of 2)
+#ifndef LUA_MINSTRTABSIZE
+#define LUA_MINSTRTABSIZE 32
+#endif
+
+// maximum number of captures supported by pattern matching
+#ifndef LUA_MAXCAPTURES
+#define LUA_MAXCAPTURES 32
+#endif
+
+// }==================================================================
+
+/*
+@@ LUAI_USER_ALIGNMENT_T is a type that requires maximum alignment.
+** CHANGE it if your system requires alignments larger than double. (For
+** instance, if your system supports long doubles and they must be
+** aligned in 16-byte boundaries, then you should add long double in the
+** union.) Probably you do not need to change this.
+*/
+#define LUAI_USER_ALIGNMENT_T \
+    union \
+    { \
+        double u; \
+        void* s; \
+        long l; \
+    }
+
+#ifndef LUA_VECTOR_SIZE
+#define LUA_VECTOR_SIZE 3 // must be 3 or 4
+#endif
+
+#define LUA_EXTRA_SIZE (LUA_VECTOR_SIZE - 2)

--- a/lib/luau/VM/include/lualib.h
+++ b/lib/luau/VM/include/lualib.h
@@ -1,0 +1,144 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lua.h"
+
+#define luaL_error(L, fmt, ...) luaL_errorL(L, fmt, ##__VA_ARGS__)
+#define luaL_typeerror(L, narg, tname) luaL_typeerrorL(L, narg, tname)
+#define luaL_argerror(L, narg, extramsg) luaL_argerrorL(L, narg, extramsg)
+
+struct luaL_Reg
+{
+    const char* name;
+    lua_CFunction func;
+};
+typedef struct luaL_Reg luaL_Reg;
+
+LUALIB_API void luaL_register(lua_State* L, const char* libname, const luaL_Reg* l);
+LUALIB_API int luaL_getmetafield(lua_State* L, int obj, const char* e);
+LUALIB_API int luaL_callmeta(lua_State* L, int obj, const char* e);
+LUALIB_API l_noret luaL_typeerrorL(lua_State* L, int narg, const char* tname);
+LUALIB_API l_noret luaL_argerrorL(lua_State* L, int narg, const char* extramsg);
+LUALIB_API const char* luaL_checklstring(lua_State* L, int numArg, size_t* l);
+LUALIB_API const char* luaL_optlstring(lua_State* L, int numArg, const char* def, size_t* l);
+LUALIB_API double luaL_checknumber(lua_State* L, int numArg);
+LUALIB_API double luaL_optnumber(lua_State* L, int nArg, double def);
+
+LUALIB_API int luaL_checkboolean(lua_State* L, int narg);
+LUALIB_API int luaL_optboolean(lua_State* L, int narg, int def);
+
+LUALIB_API int luaL_checkinteger(lua_State* L, int numArg);
+LUALIB_API int luaL_optinteger(lua_State* L, int nArg, int def);
+LUALIB_API unsigned luaL_checkunsigned(lua_State* L, int numArg);
+LUALIB_API unsigned luaL_optunsigned(lua_State* L, int numArg, unsigned def);
+
+LUALIB_API const float* luaL_checkvector(lua_State* L, int narg);
+LUALIB_API const float* luaL_optvector(lua_State* L, int narg, const float* def);
+
+LUALIB_API void luaL_checkstack(lua_State* L, int sz, const char* msg);
+LUALIB_API void luaL_checktype(lua_State* L, int narg, int t);
+LUALIB_API void luaL_checkany(lua_State* L, int narg);
+
+LUALIB_API int luaL_newmetatable(lua_State* L, const char* tname);
+LUALIB_API void* luaL_checkudata(lua_State* L, int ud, const char* tname);
+
+LUALIB_API void* luaL_checkbuffer(lua_State* L, int narg, size_t* len);
+
+LUALIB_API void luaL_where(lua_State* L, int lvl);
+LUALIB_API LUA_PRINTF_ATTR(2, 3) l_noret luaL_errorL(lua_State* L, const char* fmt, ...);
+
+LUALIB_API int luaL_checkoption(lua_State* L, int narg, const char* def, const char* const lst[]);
+
+LUALIB_API const char* luaL_tolstring(lua_State* L, int idx, size_t* len);
+
+LUALIB_API lua_State* luaL_newstate(void);
+
+LUALIB_API const char* luaL_findtable(lua_State* L, int idx, const char* fname, int szhint);
+
+LUALIB_API const char* luaL_typename(lua_State* L, int idx);
+
+/*
+** ===============================================================
+** some useful macros
+** ===============================================================
+*/
+
+#define luaL_argcheck(L, cond, arg, extramsg) ((void)((cond) ? (void)0 : luaL_argerror(L, arg, extramsg)))
+#define luaL_argexpected(L, cond, arg, tname) ((void)((cond) ? (void)0 : luaL_typeerror(L, arg, tname)))
+
+#define luaL_checkstring(L, n) (luaL_checklstring(L, (n), NULL))
+#define luaL_optstring(L, n, d) (luaL_optlstring(L, (n), (d), NULL))
+
+#define luaL_getmetatable(L, n) (lua_getfield(L, LUA_REGISTRYINDEX, (n)))
+
+#define luaL_opt(L, f, n, d) (lua_isnoneornil(L, (n)) ? (d) : f(L, (n)))
+
+// generic buffer manipulation
+
+struct luaL_Strbuf
+{
+    char* p;   // current position in buffer
+    char* end; // end of the current buffer
+    lua_State* L;
+    struct TString* storage;
+    char buffer[LUA_BUFFERSIZE];
+};
+typedef struct luaL_Strbuf luaL_Strbuf;
+
+// compatibility typedef: this type is called luaL_Buffer in Lua headers
+// renamed to luaL_Strbuf to reduce confusion with internal VM buffer type
+typedef struct luaL_Strbuf luaL_Buffer;
+
+// when internal buffer storage is exhausted, a mutable string value 'storage' will be placed on the stack
+// in general, functions expect the mutable string buffer to be placed on top of the stack (top-1)
+// with the exception of luaL_addvalue that expects the value at the top and string buffer further away (top-2)
+
+#define luaL_addchar(B, c) ((void)((B)->p < (B)->end || luaL_prepbuffsize(B, 1)), (*(B)->p++ = (char)(c)))
+#define luaL_addstring(B, s) luaL_addlstring(B, s, strlen(s))
+
+LUALIB_API void luaL_buffinit(lua_State* L, luaL_Strbuf* B);
+LUALIB_API char* luaL_buffinitsize(lua_State* L, luaL_Strbuf* B, size_t size);
+LUALIB_API char* luaL_prepbuffsize(luaL_Buffer* B, size_t size);
+LUALIB_API void luaL_addlstring(luaL_Strbuf* B, const char* s, size_t l);
+LUALIB_API void luaL_addvalue(luaL_Strbuf* B);
+LUALIB_API void luaL_addvalueany(luaL_Strbuf* B, int idx);
+LUALIB_API void luaL_pushresult(luaL_Strbuf* B);
+LUALIB_API void luaL_pushresultsize(luaL_Strbuf* B, size_t size);
+
+// builtin libraries
+LUALIB_API int luaopen_base(lua_State* L);
+
+#define LUA_COLIBNAME "coroutine"
+LUALIB_API int luaopen_coroutine(lua_State* L);
+
+#define LUA_TABLIBNAME "table"
+LUALIB_API int luaopen_table(lua_State* L);
+
+#define LUA_OSLIBNAME "os"
+LUALIB_API int luaopen_os(lua_State* L);
+
+#define LUA_STRLIBNAME "string"
+LUALIB_API int luaopen_string(lua_State* L);
+
+#define LUA_BITLIBNAME "bit32"
+LUALIB_API int luaopen_bit32(lua_State* L);
+
+#define LUA_BUFFERLIBNAME "buffer"
+LUALIB_API int luaopen_buffer(lua_State* L);
+
+#define LUA_UTF8LIBNAME "utf8"
+LUALIB_API int luaopen_utf8(lua_State* L);
+
+#define LUA_MATHLIBNAME "math"
+LUALIB_API int luaopen_math(lua_State* L);
+
+#define LUA_DBLIBNAME "debug"
+LUALIB_API int luaopen_debug(lua_State* L);
+
+// open all builtin libraries
+LUALIB_API void luaL_openlibs(lua_State* L);
+
+// sandbox libraries and globals
+LUALIB_API void luaL_sandbox(lua_State* L);
+LUALIB_API void luaL_sandboxthread(lua_State* L);

--- a/lib/luau/VM/src/lapi.cpp
+++ b/lib/luau/VM/src/lapi.cpp
@@ -1,0 +1,1495 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lapi.h"
+
+#include "lstate.h"
+#include "lstring.h"
+#include "ltable.h"
+#include "lfunc.h"
+#include "lgc.h"
+#include "ldo.h"
+#include "ludata.h"
+#include "lvm.h"
+#include "lnumutils.h"
+#include "lbuffer.h"
+
+#include <string.h>
+
+/*
+ * This file contains most implementations of core Lua APIs from lua.h.
+ *
+ * These implementations should use api_check macros to verify that stack and type contracts hold; it's the callers
+ * responsibility to, for example, pass a valid table index to lua_rawgetfield. Generally errors should only be raised
+ * for conditions caller can't predict such as an out-of-memory error.
+ *
+ * The caller is expected to handle stack reservation (by using less than LUA_MINSTACK slots or by calling lua_checkstack).
+ * To ensure this is handled correctly, use api_incr_top(L) when pushing values to the stack.
+ *
+ * Functions that push any collectable objects to the stack *should* call luaC_threadbarrier. Failure to do this can result
+ * in stack references that point to dead objects since black threads don't get rescanned.
+ *
+ * Functions that push newly created objects to the stack *should* call luaC_checkGC in addition to luaC_threadbarrier.
+ * Failure to do this can result in OOM since GC may never run.
+ *
+ * Note that luaC_checkGC may mark the thread and paint it black; functions that call both before pushing objects must
+ * therefore call luaC_checkGC before luaC_threadbarrier to guarantee the object is pushed to a gray thread.
+ */
+
+const char* lua_ident = "$Lua: Lua 5.1.4 Copyright (C) 1994-2008 Lua.org, PUC-Rio $\n"
+                        "$Authors: R. Ierusalimschy, L. H. de Figueiredo & W. Celes $\n"
+                        "$URL: www.lua.org $\n";
+
+const char* luau_ident = "$Luau: Copyright (C) 2019-2023 Roblox Corporation $\n"
+                         "$URL: luau-lang.org $\n";
+
+#define api_checknelems(L, n) api_check(L, (n) <= (L->top - L->base))
+
+#define api_checkvalidindex(L, i) api_check(L, (i) != luaO_nilobject)
+
+#define api_incr_top(L) \
+    { \
+        api_check(L, L->top < L->ci->top); \
+        L->top++; \
+    }
+
+#define api_update_top(L, p) \
+    { \
+        api_check(L, p >= L->base && p < L->ci->top); \
+        L->top = p; \
+    }
+
+#define updateatom(L, ts) \
+    { \
+        if (ts->atom == ATOM_UNDEF) \
+            ts->atom = L->global->cb.useratom ? L->global->cb.useratom(ts->data, ts->len) : -1; \
+    }
+
+static Table* getcurrenv(lua_State* L)
+{
+    if (L->ci == L->base_ci) // no enclosing function?
+        return L->gt;        // use global table as environment
+    else
+        return curr_func(L)->env;
+}
+
+static LUAU_NOINLINE TValue* pseudo2addr(lua_State* L, int idx)
+{
+    api_check(L, lua_ispseudo(idx));
+    switch (idx)
+    { // pseudo-indices
+    case LUA_REGISTRYINDEX:
+        return registry(L);
+    case LUA_ENVIRONINDEX:
+    {
+        sethvalue(L, &L->global->pseudotemp, getcurrenv(L));
+        return &L->global->pseudotemp;
+    }
+    case LUA_GLOBALSINDEX:
+    {
+        sethvalue(L, &L->global->pseudotemp, L->gt);
+        return &L->global->pseudotemp;
+    }
+    default:
+    {
+        Closure* func = curr_func(L);
+        idx = LUA_GLOBALSINDEX - idx;
+        return (idx <= func->nupvalues) ? &func->c.upvals[idx - 1] : cast_to(TValue*, luaO_nilobject);
+    }
+    }
+}
+
+static LUAU_FORCEINLINE TValue* index2addr(lua_State* L, int idx)
+{
+    if (idx > 0)
+    {
+        TValue* o = L->base + (idx - 1);
+        api_check(L, idx <= L->ci->top - L->base);
+        if (o >= L->top)
+            return cast_to(TValue*, luaO_nilobject);
+        else
+            return o;
+    }
+    else if (idx > LUA_REGISTRYINDEX)
+    {
+        api_check(L, idx != 0 && -idx <= L->top - L->base);
+        return L->top + idx;
+    }
+    else
+    {
+        return pseudo2addr(L, idx);
+    }
+}
+
+const TValue* luaA_toobject(lua_State* L, int idx)
+{
+    StkId p = index2addr(L, idx);
+    return (p == luaO_nilobject) ? NULL : p;
+}
+
+void luaA_pushobject(lua_State* L, const TValue* o)
+{
+    setobj2s(L, L->top, o);
+    api_incr_top(L);
+}
+
+int lua_checkstack(lua_State* L, int size)
+{
+    int res = 1;
+    if (size > LUAI_MAXCSTACK || (L->top - L->base + size) > LUAI_MAXCSTACK)
+        res = 0; // stack overflow
+    else if (size > 0)
+    {
+        luaD_checkstack(L, size);
+        expandstacklimit(L, L->top + size);
+    }
+    return res;
+}
+
+void lua_rawcheckstack(lua_State* L, int size)
+{
+    luaD_checkstack(L, size);
+    expandstacklimit(L, L->top + size);
+}
+
+void lua_xmove(lua_State* from, lua_State* to, int n)
+{
+    if (from == to)
+        return;
+    api_checknelems(from, n);
+    api_check(from, from->global == to->global);
+    api_check(from, to->ci->top - to->top >= n);
+    luaC_threadbarrier(to);
+
+    StkId ttop = to->top;
+    StkId ftop = from->top - n;
+    for (int i = 0; i < n; i++)
+        setobj2s(to, ttop + i, ftop + i);
+
+    from->top = ftop;
+    to->top = ttop + n;
+}
+
+void lua_xpush(lua_State* from, lua_State* to, int idx)
+{
+    api_check(from, from->global == to->global);
+    luaC_threadbarrier(to);
+    setobj2s(to, to->top, index2addr(from, idx));
+    api_incr_top(to);
+}
+
+lua_State* lua_newthread(lua_State* L)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    lua_State* L1 = luaE_newthread(L);
+    setthvalue(L, L->top, L1);
+    api_incr_top(L);
+    global_State* g = L->global;
+    if (g->cb.userthread)
+        g->cb.userthread(L, L1);
+    return L1;
+}
+
+lua_State* lua_mainthread(lua_State* L)
+{
+    return L->global->mainthread;
+}
+
+/*
+** basic stack manipulation
+*/
+
+int lua_absindex(lua_State* L, int idx)
+{
+    api_check(L, (idx > 0 && idx <= L->top - L->base) || (idx < 0 && -idx <= L->top - L->base) || lua_ispseudo(idx));
+    return idx > 0 || lua_ispseudo(idx) ? idx : cast_int(L->top - L->base) + idx + 1;
+}
+
+int lua_gettop(lua_State* L)
+{
+    return cast_int(L->top - L->base);
+}
+
+void lua_settop(lua_State* L, int idx)
+{
+    if (idx >= 0)
+    {
+        api_check(L, idx <= L->stack_last - L->base);
+        while (L->top < L->base + idx)
+            setnilvalue(L->top++);
+        L->top = L->base + idx;
+    }
+    else
+    {
+        api_check(L, -(idx + 1) <= (L->top - L->base));
+        L->top += idx + 1; // `subtract' index (index is negative)
+    }
+}
+
+void lua_remove(lua_State* L, int idx)
+{
+    StkId p = index2addr(L, idx);
+    api_checkvalidindex(L, p);
+    while (++p < L->top)
+        setobj2s(L, p - 1, p);
+    L->top--;
+}
+
+void lua_insert(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId p = index2addr(L, idx);
+    api_checkvalidindex(L, p);
+    for (StkId q = L->top; q > p; q--)
+        setobj2s(L, q, q - 1);
+    setobj2s(L, p, L->top);
+}
+
+void lua_replace(lua_State* L, int idx)
+{
+    api_checknelems(L, 1);
+    luaC_threadbarrier(L);
+    StkId o = index2addr(L, idx);
+    api_checkvalidindex(L, o);
+    if (idx == LUA_ENVIRONINDEX)
+    {
+        api_check(L, L->ci != L->base_ci);
+        Closure* func = curr_func(L);
+        api_check(L, ttistable(L->top - 1));
+        func->env = hvalue(L->top - 1);
+        luaC_barrier(L, func, L->top - 1);
+    }
+    else if (idx == LUA_GLOBALSINDEX)
+    {
+        api_check(L, ttistable(L->top - 1));
+        L->gt = hvalue(L->top - 1);
+    }
+    else
+    {
+        setobj(L, o, L->top - 1);
+        if (idx < LUA_GLOBALSINDEX) // function upvalue?
+            luaC_barrier(L, curr_func(L), L->top - 1);
+    }
+    L->top--;
+}
+
+void lua_pushvalue(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId o = index2addr(L, idx);
+    setobj2s(L, L->top, o);
+    api_incr_top(L);
+}
+
+/*
+** access functions (stack -> C)
+*/
+
+int lua_type(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return (o == luaO_nilobject) ? LUA_TNONE : ttype(o);
+}
+
+const char* lua_typename(lua_State* L, int t)
+{
+    return (t == LUA_TNONE) ? "no value" : luaT_typenames[t];
+}
+
+int lua_iscfunction(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return iscfunction(o);
+}
+
+int lua_isLfunction(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return isLfunction(o);
+}
+
+int lua_isnumber(lua_State* L, int idx)
+{
+    TValue n;
+    const TValue* o = index2addr(L, idx);
+    return tonumber(o, &n);
+}
+
+int lua_isstring(lua_State* L, int idx)
+{
+    int t = lua_type(L, idx);
+    return (t == LUA_TSTRING || t == LUA_TNUMBER);
+}
+
+int lua_isuserdata(lua_State* L, int idx)
+{
+    const TValue* o = index2addr(L, idx);
+    return (ttisuserdata(o) || ttislightuserdata(o));
+}
+
+int lua_rawequal(lua_State* L, int index1, int index2)
+{
+    StkId o1 = index2addr(L, index1);
+    StkId o2 = index2addr(L, index2);
+    return (o1 == luaO_nilobject || o2 == luaO_nilobject) ? 0 : luaO_rawequalObj(o1, o2);
+}
+
+int lua_equal(lua_State* L, int index1, int index2)
+{
+    StkId o1, o2;
+    int i;
+    o1 = index2addr(L, index1);
+    o2 = index2addr(L, index2);
+    i = (o1 == luaO_nilobject || o2 == luaO_nilobject) ? 0 : equalobj(L, o1, o2);
+    return i;
+}
+
+int lua_lessthan(lua_State* L, int index1, int index2)
+{
+    StkId o1, o2;
+    int i;
+    o1 = index2addr(L, index1);
+    o2 = index2addr(L, index2);
+    i = (o1 == luaO_nilobject || o2 == luaO_nilobject) ? 0 : luaV_lessthan(L, o1, o2);
+    return i;
+}
+
+double lua_tonumberx(lua_State* L, int idx, int* isnum)
+{
+    TValue n;
+    const TValue* o = index2addr(L, idx);
+    if (tonumber(o, &n))
+    {
+        if (isnum)
+            *isnum = 1;
+        return nvalue(o);
+    }
+    else
+    {
+        if (isnum)
+            *isnum = 0;
+        return 0;
+    }
+}
+
+int lua_tointegerx(lua_State* L, int idx, int* isnum)
+{
+    TValue n;
+    const TValue* o = index2addr(L, idx);
+    if (tonumber(o, &n))
+    {
+        int res;
+        double num = nvalue(o);
+        luai_num2int(res, num);
+        if (isnum)
+            *isnum = 1;
+        return res;
+    }
+    else
+    {
+        if (isnum)
+            *isnum = 0;
+        return 0;
+    }
+}
+
+unsigned lua_tounsignedx(lua_State* L, int idx, int* isnum)
+{
+    TValue n;
+    const TValue* o = index2addr(L, idx);
+    if (tonumber(o, &n))
+    {
+        unsigned res;
+        double num = nvalue(o);
+        luai_num2unsigned(res, num);
+        if (isnum)
+            *isnum = 1;
+        return res;
+    }
+    else
+    {
+        if (isnum)
+            *isnum = 0;
+        return 0;
+    }
+}
+
+int lua_toboolean(lua_State* L, int idx)
+{
+    const TValue* o = index2addr(L, idx);
+    return !l_isfalse(o);
+}
+
+const char* lua_tolstring(lua_State* L, int idx, size_t* len)
+{
+    StkId o = index2addr(L, idx);
+    if (!ttisstring(o))
+    {
+        luaC_threadbarrier(L);
+        if (!luaV_tostring(L, o))
+        { // conversion failed?
+            if (len != NULL)
+                *len = 0;
+            return NULL;
+        }
+        luaC_checkGC(L);
+        o = index2addr(L, idx); // previous call may reallocate the stack
+    }
+    if (len != NULL)
+        *len = tsvalue(o)->len;
+    return svalue(o);
+}
+
+const char* lua_tostringatom(lua_State* L, int idx, int* atom)
+{
+    StkId o = index2addr(L, idx);
+    if (!ttisstring(o))
+        return NULL;
+    TString* s = tsvalue(o);
+    if (atom)
+    {
+        updateatom(L, s);
+        *atom = s->atom;
+    }
+    return getstr(s);
+}
+
+const char* lua_namecallatom(lua_State* L, int* atom)
+{
+    TString* s = L->namecall;
+    if (!s)
+        return NULL;
+    if (atom)
+    {
+        updateatom(L, s);
+        *atom = s->atom;
+    }
+    return getstr(s);
+}
+
+const float* lua_tovector(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    if (!ttisvector(o))
+        return NULL;
+    return vvalue(o);
+}
+
+int lua_objlen(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    switch (ttype(o))
+    {
+    case LUA_TSTRING:
+        return tsvalue(o)->len;
+    case LUA_TUSERDATA:
+        return uvalue(o)->len;
+    case LUA_TBUFFER:
+        return bufvalue(o)->len;
+    case LUA_TTABLE:
+        return luaH_getn(hvalue(o));
+    default:
+        return 0;
+    }
+}
+
+lua_CFunction lua_tocfunction(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return (!iscfunction(o)) ? NULL : cast_to(lua_CFunction, clvalue(o)->c.f);
+}
+
+void* lua_tolightuserdata(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return (!ttislightuserdata(o)) ? NULL : pvalue(o);
+}
+
+void* lua_tolightuserdatatagged(lua_State* L, int idx, int tag)
+{
+    StkId o = index2addr(L, idx);
+    return (!ttislightuserdata(o) || lightuserdatatag(o) != tag) ? NULL : pvalue(o);
+}
+
+void* lua_touserdata(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    if (ttisuserdata(o))
+        return uvalue(o)->data;
+    else if (ttislightuserdata(o))
+        return pvalue(o);
+    else
+        return NULL;
+}
+
+void* lua_touserdatatagged(lua_State* L, int idx, int tag)
+{
+    StkId o = index2addr(L, idx);
+    return (ttisuserdata(o) && uvalue(o)->tag == tag) ? uvalue(o)->data : NULL;
+}
+
+int lua_userdatatag(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    if (ttisuserdata(o))
+        return uvalue(o)->tag;
+    return -1;
+}
+
+int lua_lightuserdatatag(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    if (ttislightuserdata(o))
+        return lightuserdatatag(o);
+    return -1;
+}
+
+lua_State* lua_tothread(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return (!ttisthread(o)) ? NULL : thvalue(o);
+}
+
+void* lua_tobuffer(lua_State* L, int idx, size_t* len)
+{
+    StkId o = index2addr(L, idx);
+
+    if (!ttisbuffer(o))
+        return NULL;
+
+    Buffer* b = bufvalue(o);
+
+    if (len)
+        *len = b->len;
+
+    return b->data;
+}
+
+const void* lua_topointer(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    switch (ttype(o))
+    {
+    case LUA_TUSERDATA:
+        return uvalue(o)->data;
+    case LUA_TLIGHTUSERDATA:
+        return pvalue(o);
+    default:
+        return iscollectable(o) ? gcvalue(o) : NULL;
+    }
+}
+
+/*
+** push functions (C -> stack)
+*/
+
+void lua_pushnil(lua_State* L)
+{
+    setnilvalue(L->top);
+    api_incr_top(L);
+}
+
+void lua_pushnumber(lua_State* L, double n)
+{
+    setnvalue(L->top, n);
+    api_incr_top(L);
+}
+
+void lua_pushinteger(lua_State* L, int n)
+{
+    setnvalue(L->top, cast_num(n));
+    api_incr_top(L);
+}
+
+void lua_pushunsigned(lua_State* L, unsigned u)
+{
+    setnvalue(L->top, cast_num(u));
+    api_incr_top(L);
+}
+
+#if LUA_VECTOR_SIZE == 4
+void lua_pushvector(lua_State* L, float x, float y, float z, float w)
+{
+    setvvalue(L->top, x, y, z, w);
+    api_incr_top(L);
+}
+#else
+void lua_pushvector(lua_State* L, float x, float y, float z)
+{
+    setvvalue(L->top, x, y, z, 0.0f);
+    api_incr_top(L);
+}
+#endif
+
+void lua_pushlstring(lua_State* L, const char* s, size_t len)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    setsvalue(L, L->top, luaS_newlstr(L, s, len));
+    api_incr_top(L);
+}
+
+void lua_pushstring(lua_State* L, const char* s)
+{
+    if (s == NULL)
+        lua_pushnil(L);
+    else
+        lua_pushlstring(L, s, strlen(s));
+}
+
+const char* lua_pushvfstring(lua_State* L, const char* fmt, va_list argp)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    const char* ret = luaO_pushvfstring(L, fmt, argp);
+    return ret;
+}
+
+const char* lua_pushfstringL(lua_State* L, const char* fmt, ...)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    va_list argp;
+    va_start(argp, fmt);
+    const char* ret = luaO_pushvfstring(L, fmt, argp);
+    va_end(argp);
+    return ret;
+}
+
+void lua_pushcclosurek(lua_State* L, lua_CFunction fn, const char* debugname, int nup, lua_Continuation cont)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    api_checknelems(L, nup);
+    Closure* cl = luaF_newCclosure(L, nup, getcurrenv(L));
+    cl->c.f = fn;
+    cl->c.cont = cont;
+    cl->c.debugname = debugname;
+    L->top -= nup;
+    while (nup--)
+        setobj2n(L, &cl->c.upvals[nup], L->top + nup);
+    setclvalue(L, L->top, cl);
+    LUAU_ASSERT(iswhite(obj2gco(cl)));
+    api_incr_top(L);
+}
+
+void lua_pushboolean(lua_State* L, int b)
+{
+    setbvalue(L->top, (b != 0)); // ensure that true is 1
+    api_incr_top(L);
+}
+
+void lua_pushlightuserdatatagged(lua_State* L, void* p, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_LUTAG_LIMIT);
+    setpvalue(L->top, p, tag);
+    api_incr_top(L);
+}
+
+int lua_pushthread(lua_State* L)
+{
+    luaC_threadbarrier(L);
+    setthvalue(L, L->top, L);
+    api_incr_top(L);
+    return L->global->mainthread == L;
+}
+
+/*
+** get functions (Lua -> stack)
+*/
+
+int lua_gettable(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_checkvalidindex(L, t);
+    luaV_gettable(L, t, L->top - 1, L->top - 1);
+    return ttype(L->top - 1);
+}
+
+int lua_getfield(lua_State* L, int idx, const char* k)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_checkvalidindex(L, t);
+    TValue key;
+    setsvalue(L, &key, luaS_new(L, k));
+    luaV_gettable(L, t, &key, L->top);
+    api_incr_top(L);
+    return ttype(L->top - 1);
+}
+
+int lua_rawgetfield(lua_State* L, int idx, const char* k)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    TValue key;
+    setsvalue(L, &key, luaS_new(L, k));
+    setobj2s(L, L->top, luaH_getstr(hvalue(t), tsvalue(&key)));
+    api_incr_top(L);
+    return ttype(L->top - 1);
+}
+
+int lua_rawget(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    setobj2s(L, L->top - 1, luaH_get(hvalue(t), L->top - 1));
+    return ttype(L->top - 1);
+}
+
+int lua_rawgeti(lua_State* L, int idx, int n)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    setobj2s(L, L->top, luaH_getnum(hvalue(t), n));
+    api_incr_top(L);
+    return ttype(L->top - 1);
+}
+
+void lua_createtable(lua_State* L, int narray, int nrec)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    sethvalue(L, L->top, luaH_new(L, narray, nrec));
+    api_incr_top(L);
+}
+
+void lua_setreadonly(lua_State* L, int objindex, int enabled)
+{
+    const TValue* o = index2addr(L, objindex);
+    api_check(L, ttistable(o));
+    Table* t = hvalue(o);
+    api_check(L, t != hvalue(registry(L)));
+    t->readonly = bool(enabled);
+}
+
+int lua_getreadonly(lua_State* L, int objindex)
+{
+    const TValue* o = index2addr(L, objindex);
+    api_check(L, ttistable(o));
+    Table* t = hvalue(o);
+    int res = t->readonly;
+    return res;
+}
+
+void lua_setsafeenv(lua_State* L, int objindex, int enabled)
+{
+    const TValue* o = index2addr(L, objindex);
+    api_check(L, ttistable(o));
+    Table* t = hvalue(o);
+    t->safeenv = bool(enabled);
+}
+
+int lua_getmetatable(lua_State* L, int objindex)
+{
+    luaC_threadbarrier(L);
+    Table* mt = NULL;
+    const TValue* obj = index2addr(L, objindex);
+    switch (ttype(obj))
+    {
+    case LUA_TTABLE:
+        mt = hvalue(obj)->metatable;
+        break;
+    case LUA_TUSERDATA:
+        mt = uvalue(obj)->metatable;
+        break;
+    default:
+        mt = L->global->mt[ttype(obj)];
+        break;
+    }
+    if (mt)
+    {
+        sethvalue(L, L->top, mt);
+        api_incr_top(L);
+    }
+    return mt != NULL;
+}
+
+void lua_getfenv(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId o = index2addr(L, idx);
+    api_checkvalidindex(L, o);
+    switch (ttype(o))
+    {
+    case LUA_TFUNCTION:
+        sethvalue(L, L->top, clvalue(o)->env);
+        break;
+    case LUA_TTHREAD:
+        sethvalue(L, L->top, thvalue(o)->gt);
+        break;
+    default:
+        setnilvalue(L->top);
+        break;
+    }
+    api_incr_top(L);
+}
+
+/*
+** set functions (stack -> Lua)
+*/
+
+void lua_settable(lua_State* L, int idx)
+{
+    api_checknelems(L, 2);
+    StkId t = index2addr(L, idx);
+    api_checkvalidindex(L, t);
+    luaV_settable(L, t, L->top - 2, L->top - 1);
+    L->top -= 2; // pop index and value
+}
+
+void lua_setfield(lua_State* L, int idx, const char* k)
+{
+    api_checknelems(L, 1);
+    StkId t = index2addr(L, idx);
+    api_checkvalidindex(L, t);
+    TValue key;
+    setsvalue(L, &key, luaS_new(L, k));
+    luaV_settable(L, t, &key, L->top - 1);
+    L->top--;
+}
+
+void lua_rawsetfield(lua_State* L, int idx, const char* k)
+{
+    api_checknelems(L, 1);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    if (hvalue(t)->readonly)
+        luaG_readonlyerror(L);
+    setobj2t(L, luaH_setstr(L, hvalue(t), luaS_new(L, k)), L->top - 1);
+    luaC_barriert(L, hvalue(t), L->top - 1);
+    L->top--;
+}
+
+void lua_rawset(lua_State* L, int idx)
+{
+    api_checknelems(L, 2);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    if (hvalue(t)->readonly)
+        luaG_readonlyerror(L);
+    setobj2t(L, luaH_set(L, hvalue(t), L->top - 2), L->top - 1);
+    luaC_barriert(L, hvalue(t), L->top - 1);
+    L->top -= 2;
+}
+
+void lua_rawseti(lua_State* L, int idx, int n)
+{
+    api_checknelems(L, 1);
+    StkId o = index2addr(L, idx);
+    api_check(L, ttistable(o));
+    if (hvalue(o)->readonly)
+        luaG_readonlyerror(L);
+    setobj2t(L, luaH_setnum(L, hvalue(o), n), L->top - 1);
+    luaC_barriert(L, hvalue(o), L->top - 1);
+    L->top--;
+}
+
+int lua_setmetatable(lua_State* L, int objindex)
+{
+    api_checknelems(L, 1);
+    TValue* obj = index2addr(L, objindex);
+    api_checkvalidindex(L, obj);
+    Table* mt = NULL;
+    if (!ttisnil(L->top - 1))
+    {
+        api_check(L, ttistable(L->top - 1));
+        mt = hvalue(L->top - 1);
+    }
+    switch (ttype(obj))
+    {
+    case LUA_TTABLE:
+    {
+        if (hvalue(obj)->readonly)
+            luaG_readonlyerror(L);
+        hvalue(obj)->metatable = mt;
+        if (mt)
+            luaC_objbarrier(L, hvalue(obj), mt);
+        break;
+    }
+    case LUA_TUSERDATA:
+    {
+        uvalue(obj)->metatable = mt;
+        if (mt)
+            luaC_objbarrier(L, uvalue(obj), mt);
+        break;
+    }
+    default:
+    {
+        L->global->mt[ttype(obj)] = mt;
+        break;
+    }
+    }
+    L->top--;
+    return 1;
+}
+
+int lua_setfenv(lua_State* L, int idx)
+{
+    int res = 1;
+    api_checknelems(L, 1);
+    StkId o = index2addr(L, idx);
+    api_checkvalidindex(L, o);
+    api_check(L, ttistable(L->top - 1));
+    switch (ttype(o))
+    {
+    case LUA_TFUNCTION:
+        clvalue(o)->env = hvalue(L->top - 1);
+        break;
+    case LUA_TTHREAD:
+        thvalue(o)->gt = hvalue(L->top - 1);
+        break;
+    default:
+        res = 0;
+        break;
+    }
+    if (res)
+    {
+        luaC_objbarrier(L, &gcvalue(o)->gch, hvalue(L->top - 1));
+    }
+    L->top--;
+    return res;
+}
+
+/*
+** `load' and `call' functions (run Lua code)
+*/
+
+#define adjustresults(L, nres) \
+    { \
+        if (nres == LUA_MULTRET && L->top >= L->ci->top) \
+            L->ci->top = L->top; \
+    }
+
+#define checkresults(L, na, nr) api_check(L, (nr) == LUA_MULTRET || (L->ci->top - L->top >= (nr) - (na)))
+
+void lua_call(lua_State* L, int nargs, int nresults)
+{
+    StkId func;
+    api_checknelems(L, nargs + 1);
+    api_check(L, L->status == 0);
+    checkresults(L, nargs, nresults);
+    func = L->top - (nargs + 1);
+
+    luaD_call(L, func, nresults);
+
+    adjustresults(L, nresults);
+}
+
+/*
+** Execute a protected call.
+*/
+struct CallS
+{ // data to `f_call'
+    StkId func;
+    int nresults;
+};
+
+static void f_call(lua_State* L, void* ud)
+{
+    struct CallS* c = cast_to(struct CallS*, ud);
+    luaD_call(L, c->func, c->nresults);
+}
+
+int lua_pcall(lua_State* L, int nargs, int nresults, int errfunc)
+{
+    api_checknelems(L, nargs + 1);
+    api_check(L, L->status == 0);
+    checkresults(L, nargs, nresults);
+    ptrdiff_t func = 0;
+    if (errfunc != 0)
+    {
+        StkId o = index2addr(L, errfunc);
+        api_checkvalidindex(L, o);
+        func = savestack(L, o);
+    }
+    struct CallS c;
+    c.func = L->top - (nargs + 1); // function to be called
+    c.nresults = nresults;
+
+    int status = luaD_pcall(L, f_call, &c, savestack(L, c.func), func);
+
+    adjustresults(L, nresults);
+    return status;
+}
+
+int lua_status(lua_State* L)
+{
+    return L->status;
+}
+
+int lua_costatus(lua_State* L, lua_State* co)
+{
+    if (co == L)
+        return LUA_CORUN;
+    if (co->status == LUA_YIELD)
+        return LUA_COSUS;
+    if (co->status == LUA_BREAK)
+        return LUA_CONOR;
+    if (co->status != 0) // some error occurred
+        return LUA_COERR;
+    if (co->ci != co->base_ci) // does it have frames?
+        return LUA_CONOR;
+    if (co->top == co->base)
+        return LUA_COFIN;
+    return LUA_COSUS; // initial state
+}
+
+void* lua_getthreaddata(lua_State* L)
+{
+    return L->userdata;
+}
+
+void lua_setthreaddata(lua_State* L, void* data)
+{
+    L->userdata = data;
+}
+
+/*
+** Garbage-collection function
+*/
+
+int lua_gc(lua_State* L, int what, int data)
+{
+    int res = 0;
+    condhardmemtests(luaC_validate(L), 1);
+    global_State* g = L->global;
+    switch (what)
+    {
+    case LUA_GCSTOP:
+    {
+        g->GCthreshold = SIZE_MAX;
+        break;
+    }
+    case LUA_GCRESTART:
+    {
+        g->GCthreshold = g->totalbytes;
+        break;
+    }
+    case LUA_GCCOLLECT:
+    {
+        luaC_fullgc(L);
+        break;
+    }
+    case LUA_GCCOUNT:
+    {
+        // GC values are expressed in Kbytes: #bytes/2^10
+        res = cast_int(g->totalbytes >> 10);
+        break;
+    }
+    case LUA_GCCOUNTB:
+    {
+        res = cast_int(g->totalbytes & 1023);
+        break;
+    }
+    case LUA_GCISRUNNING:
+    {
+        res = (g->GCthreshold != SIZE_MAX);
+        break;
+    }
+    case LUA_GCSTEP:
+    {
+        size_t amount = (cast_to(size_t, data) << 10);
+        ptrdiff_t oldcredit = g->gcstate == GCSpause ? 0 : g->GCthreshold - g->totalbytes;
+
+        // temporarily adjust the threshold so that we can perform GC work
+        if (amount <= g->totalbytes)
+            g->GCthreshold = g->totalbytes - amount;
+        else
+            g->GCthreshold = 0;
+
+#ifdef LUAI_GCMETRICS
+        double startmarktime = g->gcmetrics.currcycle.marktime;
+        double startsweeptime = g->gcmetrics.currcycle.sweeptime;
+#endif
+
+        // track how much work the loop will actually perform
+        size_t actualwork = 0;
+
+        while (g->GCthreshold <= g->totalbytes)
+        {
+            size_t stepsize = luaC_step(L, false);
+
+            actualwork += stepsize;
+
+            if (g->gcstate == GCSpause)
+            {            // end of cycle?
+                res = 1; // signal it
+                break;
+            }
+        }
+
+#ifdef LUAI_GCMETRICS
+        // record explicit step statistics
+        GCCycleMetrics* cyclemetrics = g->gcstate == GCSpause ? &g->gcmetrics.lastcycle : &g->gcmetrics.currcycle;
+
+        double totalmarktime = cyclemetrics->marktime - startmarktime;
+        double totalsweeptime = cyclemetrics->sweeptime - startsweeptime;
+
+        if (totalmarktime > 0.0)
+        {
+            cyclemetrics->markexplicitsteps++;
+
+            if (totalmarktime > cyclemetrics->markmaxexplicittime)
+                cyclemetrics->markmaxexplicittime = totalmarktime;
+        }
+
+        if (totalsweeptime > 0.0)
+        {
+            cyclemetrics->sweepexplicitsteps++;
+
+            if (totalsweeptime > cyclemetrics->sweepmaxexplicittime)
+                cyclemetrics->sweepmaxexplicittime = totalsweeptime;
+        }
+#endif
+
+        // if cycle hasn't finished, advance threshold forward for the amount of extra work performed
+        if (g->gcstate != GCSpause)
+        {
+            // if a new cycle was triggered by explicit step, old 'credit' of GC work is 0
+            ptrdiff_t newthreshold = g->totalbytes + actualwork + oldcredit;
+            g->GCthreshold = newthreshold < 0 ? 0 : newthreshold;
+        }
+        break;
+    }
+    case LUA_GCSETGOAL:
+    {
+        res = g->gcgoal;
+        g->gcgoal = data;
+        break;
+    }
+    case LUA_GCSETSTEPMUL:
+    {
+        res = g->gcstepmul;
+        g->gcstepmul = data;
+        break;
+    }
+    case LUA_GCSETSTEPSIZE:
+    {
+        // GC values are expressed in Kbytes: #bytes/2^10
+        res = g->gcstepsize >> 10;
+        g->gcstepsize = data << 10;
+        break;
+    }
+    default:
+        res = -1; // invalid option
+    }
+    return res;
+}
+
+/*
+** miscellaneous functions
+*/
+
+l_noret lua_error(lua_State* L)
+{
+    api_checknelems(L, 1);
+
+    luaD_throw(L, LUA_ERRRUN);
+}
+
+int lua_next(lua_State* L, int idx)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    int more = luaH_next(L, hvalue(t), L->top - 1);
+    if (more)
+    {
+        api_incr_top(L);
+    }
+    else             // no more elements
+        L->top -= 1; // remove key
+    return more;
+}
+
+int lua_rawiter(lua_State* L, int idx, int iter)
+{
+    luaC_threadbarrier(L);
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    api_check(L, iter >= 0);
+
+    Table* h = hvalue(t);
+    int sizearray = h->sizearray;
+
+    // first we advance iter through the array portion
+    for (; unsigned(iter) < unsigned(sizearray); ++iter)
+    {
+        TValue* e = &h->array[iter];
+
+        if (!ttisnil(e))
+        {
+            StkId top = L->top;
+            setnvalue(top + 0, double(iter + 1));
+            setobj2s(L, top + 1, e);
+            api_update_top(L, top + 2);
+            return iter + 1;
+        }
+    }
+
+    int sizenode = 1 << h->lsizenode;
+
+    // then we advance iter through the hash portion
+    for (; unsigned(iter - sizearray) < unsigned(sizenode); ++iter)
+    {
+        LuaNode* n = &h->node[iter - sizearray];
+
+        if (!ttisnil(gval(n)))
+        {
+            StkId top = L->top;
+            getnodekey(L, top + 0, n);
+            setobj2s(L, top + 1, gval(n));
+            api_update_top(L, top + 2);
+            return iter + 1;
+        }
+    }
+
+    // traversal finished
+    return -1;
+}
+
+void lua_concat(lua_State* L, int n)
+{
+    api_checknelems(L, n);
+    if (n >= 2)
+    {
+        luaC_checkGC(L);
+        luaC_threadbarrier(L);
+        luaV_concat(L, n, cast_int(L->top - L->base) - 1);
+        L->top -= (n - 1);
+    }
+    else if (n == 0)
+    { // push empty string
+        luaC_threadbarrier(L);
+        setsvalue(L, L->top, luaS_newlstr(L, "", 0));
+        api_incr_top(L);
+    }
+    // else n == 1; nothing to do
+}
+
+void* lua_newuserdatatagged(lua_State* L, size_t sz, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_UTAG_LIMIT || tag == UTAG_PROXY);
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    Udata* u = luaU_newudata(L, sz, tag);
+    setuvalue(L, L->top, u);
+    api_incr_top(L);
+    return u->data;
+}
+
+void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*))
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    // make sure sz + sizeof(dtor) doesn't overflow; luaU_newdata will reject SIZE_MAX correctly
+    size_t as = sz < SIZE_MAX - sizeof(dtor) ? sz + sizeof(dtor) : SIZE_MAX;
+    Udata* u = luaU_newudata(L, as, UTAG_IDTOR);
+    memcpy(&u->data + sz, &dtor, sizeof(dtor));
+    setuvalue(L, L->top, u);
+    api_incr_top(L);
+    return u->data;
+}
+
+void* lua_newbuffer(lua_State* L, size_t sz)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    Buffer* b = luaB_newbuffer(L, sz);
+    setbufvalue(L, L->top, b);
+    api_incr_top(L);
+    return b->data;
+}
+
+static const char* aux_upvalue(StkId fi, int n, TValue** val)
+{
+    Closure* f;
+    if (!ttisfunction(fi))
+        return NULL;
+    f = clvalue(fi);
+    if (f->isC)
+    {
+        if (!(1 <= n && n <= f->nupvalues))
+            return NULL;
+        *val = &f->c.upvals[n - 1];
+        return "";
+    }
+    else
+    {
+        Proto* p = f->l.p;
+        if (!(1 <= n && n <= p->nups)) // not a valid upvalue
+            return NULL;
+        TValue* r = &f->l.uprefs[n - 1];
+        *val = ttisupval(r) ? upvalue(r)->v : r;
+        if (!(1 <= n && n <= p->sizeupvalues)) // don't have a name for this upvalue
+            return "";
+        return getstr(p->upvalues[n - 1]);
+    }
+}
+
+const char* lua_getupvalue(lua_State* L, int funcindex, int n)
+{
+    luaC_threadbarrier(L);
+    TValue* val;
+    const char* name = aux_upvalue(index2addr(L, funcindex), n, &val);
+    if (name)
+    {
+        setobj2s(L, L->top, val);
+        api_incr_top(L);
+    }
+    return name;
+}
+
+const char* lua_setupvalue(lua_State* L, int funcindex, int n)
+{
+    api_checknelems(L, 1);
+    StkId fi = index2addr(L, funcindex);
+    TValue* val;
+    const char* name = aux_upvalue(fi, n, &val);
+    if (name)
+    {
+        L->top--;
+        setobj(L, val, L->top);
+        luaC_barrier(L, clvalue(fi), L->top);
+    }
+    return name;
+}
+
+uintptr_t lua_encodepointer(lua_State* L, uintptr_t p)
+{
+    global_State* g = L->global;
+    return uintptr_t((g->ptrenckey[0] * p + g->ptrenckey[2]) ^ (g->ptrenckey[1] * p + g->ptrenckey[3]));
+}
+
+int lua_ref(lua_State* L, int idx)
+{
+    api_check(L, idx != LUA_REGISTRYINDEX); // idx is a stack index for value
+    int ref = LUA_REFNIL;
+    global_State* g = L->global;
+    StkId p = index2addr(L, idx);
+    if (!ttisnil(p))
+    {
+        Table* reg = hvalue(registry(L));
+
+        if (g->registryfree != 0)
+        { // reuse existing slot
+            ref = g->registryfree;
+        }
+        else
+        { // no free elements
+            ref = luaH_getn(reg);
+            ref++; // create new reference
+        }
+
+        TValue* slot = luaH_setnum(L, reg, ref);
+        if (g->registryfree != 0)
+            g->registryfree = int(nvalue(slot));
+        setobj2t(L, slot, p);
+        luaC_barriert(L, reg, p);
+    }
+    return ref;
+}
+
+void lua_unref(lua_State* L, int ref)
+{
+    if (ref <= LUA_REFNIL)
+        return;
+
+    global_State* g = L->global;
+    Table* reg = hvalue(registry(L));
+    TValue* slot = luaH_setnum(L, reg, ref);
+    setnvalue(slot, g->registryfree); // NB: no barrier needed because value isn't collectable
+    g->registryfree = ref;
+}
+
+void lua_setuserdatatag(lua_State* L, int idx, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_UTAG_LIMIT);
+    StkId o = index2addr(L, idx);
+    api_check(L, ttisuserdata(o));
+    uvalue(o)->tag = uint8_t(tag);
+}
+
+void lua_setuserdatadtor(lua_State* L, int tag, lua_Destructor dtor)
+{
+    api_check(L, unsigned(tag) < LUA_UTAG_LIMIT);
+    L->global->udatagc[tag] = dtor;
+}
+
+lua_Destructor lua_getuserdatadtor(lua_State* L, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_UTAG_LIMIT);
+    return L->global->udatagc[tag];
+}
+
+void lua_setlightuserdataname(lua_State* L, int tag, const char* name)
+{
+    api_check(L, unsigned(tag) < LUA_LUTAG_LIMIT);
+    api_check(L, !L->global->lightuserdataname[tag]); // renaming not supported
+    if (!L->global->lightuserdataname[tag])
+    {
+        L->global->lightuserdataname[tag] = luaS_new(L, name);
+        luaS_fix(L->global->lightuserdataname[tag]); // never collect these names
+    }
+}
+
+const char* lua_getlightuserdataname(lua_State* L, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_LUTAG_LIMIT);
+    const TString* name = L->global->lightuserdataname[tag];
+    return name ? getstr(name) : nullptr;
+}
+
+void lua_clonefunction(lua_State* L, int idx)
+{
+    luaC_checkGC(L);
+    luaC_threadbarrier(L);
+    StkId p = index2addr(L, idx);
+    api_check(L, isLfunction(p));
+    Closure* cl = clvalue(p);
+    Closure* newcl = luaF_newLclosure(L, cl->nupvalues, L->gt, cl->l.p);
+    for (int i = 0; i < cl->nupvalues; ++i)
+        setobj2n(L, &newcl->l.uprefs[i], &cl->l.uprefs[i]);
+    setclvalue(L, L->top, newcl);
+    api_incr_top(L);
+}
+
+void lua_cleartable(lua_State* L, int idx)
+{
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    Table* tt = hvalue(t);
+    if (tt->readonly)
+        luaG_readonlyerror(L);
+    luaH_clear(tt);
+}
+
+lua_Callbacks* lua_callbacks(lua_State* L)
+{
+    return &L->global->cb;
+}
+
+void lua_setmemcat(lua_State* L, int category)
+{
+    api_check(L, unsigned(category) < LUA_MEMORY_CATEGORIES);
+    L->activememcat = uint8_t(category);
+}
+
+size_t lua_totalbytes(lua_State* L, int category)
+{
+    api_check(L, category < LUA_MEMORY_CATEGORIES);
+    return category < 0 ? L->global->totalbytes : L->global->memcatbytes[category];
+}
+
+lua_Alloc lua_getallocf(lua_State* L, void** ud)
+{
+    lua_Alloc f = L->global->frealloc;
+    if (ud)
+        *ud = L->global->ud;
+    return f;
+}

--- a/lib/luau/VM/src/lapi.h
+++ b/lib/luau/VM/src/lapi.h
@@ -1,0 +1,8 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+LUAI_FUNC const TValue* luaA_toobject(lua_State* L, int idx);
+LUAI_FUNC void luaA_pushobject(lua_State* L, const TValue* o);

--- a/lib/luau/VM/src/laux.cpp
+++ b/lib/luau/VM/src/laux.cpp
@@ -1,0 +1,586 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lobject.h"
+#include "lstate.h"
+#include "lstring.h"
+#include "lapi.h"
+#include "lgc.h"
+#include "lnumutils.h"
+
+#include <string.h>
+
+// convert a stack index to positive
+#define abs_index(L, i) ((i) > 0 || (i) <= LUA_REGISTRYINDEX ? (i) : lua_gettop(L) + (i) + 1)
+
+/*
+** {======================================================
+** Error-report functions
+** =======================================================
+*/
+
+static const char* currfuncname(lua_State* L)
+{
+    Closure* cl = L->ci > L->base_ci ? curr_func(L) : NULL;
+    const char* debugname = cl && cl->isC ? cl->c.debugname + 0 : NULL;
+
+    if (debugname && strcmp(debugname, "__namecall") == 0)
+        return L->namecall ? getstr(L->namecall) : NULL;
+    else
+        return debugname;
+}
+
+l_noret luaL_argerrorL(lua_State* L, int narg, const char* extramsg)
+{
+    const char* fname = currfuncname(L);
+
+    if (fname)
+        luaL_error(L, "invalid argument #%d to '%s' (%s)", narg, fname, extramsg);
+    else
+        luaL_error(L, "invalid argument #%d (%s)", narg, extramsg);
+}
+
+l_noret luaL_typeerrorL(lua_State* L, int narg, const char* tname)
+{
+    const char* fname = currfuncname(L);
+    const TValue* obj = luaA_toobject(L, narg);
+
+    if (obj)
+    {
+        if (fname)
+            luaL_error(L, "invalid argument #%d to '%s' (%s expected, got %s)", narg, fname, tname, luaT_objtypename(L, obj));
+        else
+            luaL_error(L, "invalid argument #%d (%s expected, got %s)", narg, tname, luaT_objtypename(L, obj));
+    }
+    else
+    {
+        if (fname)
+            luaL_error(L, "missing argument #%d to '%s' (%s expected)", narg, fname, tname);
+        else
+            luaL_error(L, "missing argument #%d (%s expected)", narg, tname);
+    }
+}
+
+static l_noret tag_error(lua_State* L, int narg, int tag)
+{
+    luaL_typeerrorL(L, narg, lua_typename(L, tag));
+}
+
+void luaL_where(lua_State* L, int level)
+{
+    lua_Debug ar;
+    if (lua_getinfo(L, level, "sl", &ar) && ar.currentline > 0)
+    {
+        lua_pushfstring(L, "%s:%d: ", ar.short_src, ar.currentline);
+        return;
+    }
+    lua_pushliteral(L, ""); // else, no information available...
+}
+
+l_noret luaL_errorL(lua_State* L, const char* fmt, ...)
+{
+    va_list argp;
+    va_start(argp, fmt);
+    luaL_where(L, 1);
+    lua_pushvfstring(L, fmt, argp);
+    va_end(argp);
+    lua_concat(L, 2);
+    lua_error(L);
+}
+
+// }======================================================
+
+int luaL_checkoption(lua_State* L, int narg, const char* def, const char* const lst[])
+{
+    const char* name = (def) ? luaL_optstring(L, narg, def) : luaL_checkstring(L, narg);
+    int i;
+    for (i = 0; lst[i]; i++)
+        if (strcmp(lst[i], name) == 0)
+            return i;
+    const char* msg = lua_pushfstring(L, "invalid option '%s'", name);
+    luaL_argerrorL(L, narg, msg);
+}
+
+int luaL_newmetatable(lua_State* L, const char* tname)
+{
+    lua_getfield(L, LUA_REGISTRYINDEX, tname); // get registry.name
+    if (!lua_isnil(L, -1))                     // name already in use?
+        return 0;                              // leave previous value on top, but return 0
+    lua_pop(L, 1);
+    lua_newtable(L); // create metatable
+    lua_pushvalue(L, -1);
+    lua_setfield(L, LUA_REGISTRYINDEX, tname); // registry.name = metatable
+    return 1;
+}
+
+void* luaL_checkudata(lua_State* L, int ud, const char* tname)
+{
+    void* p = lua_touserdata(L, ud);
+    if (p != NULL)
+    { // value is a userdata?
+        if (lua_getmetatable(L, ud))
+        {                                              // does it have a metatable?
+            lua_getfield(L, LUA_REGISTRYINDEX, tname); // get correct metatable
+            if (lua_rawequal(L, -1, -2))
+            {                  // does it have the correct mt?
+                lua_pop(L, 2); // remove both metatables
+                return p;
+            }
+        }
+    }
+    luaL_typeerrorL(L, ud, tname); // else error
+}
+
+void* luaL_checkbuffer(lua_State* L, int narg, size_t* len)
+{
+    void* b = lua_tobuffer(L, narg, len);
+    if (!b)
+        tag_error(L, narg, LUA_TBUFFER);
+    return b;
+}
+
+void luaL_checkstack(lua_State* L, int space, const char* mes)
+{
+    if (!lua_checkstack(L, space))
+        luaL_error(L, "stack overflow (%s)", mes);
+}
+
+void luaL_checktype(lua_State* L, int narg, int t)
+{
+    if (lua_type(L, narg) != t)
+        tag_error(L, narg, t);
+}
+
+void luaL_checkany(lua_State* L, int narg)
+{
+    if (lua_type(L, narg) == LUA_TNONE)
+        luaL_error(L, "missing argument #%d", narg);
+}
+
+const char* luaL_checklstring(lua_State* L, int narg, size_t* len)
+{
+    const char* s = lua_tolstring(L, narg, len);
+    if (!s)
+        tag_error(L, narg, LUA_TSTRING);
+    return s;
+}
+
+const char* luaL_optlstring(lua_State* L, int narg, const char* def, size_t* len)
+{
+    if (lua_isnoneornil(L, narg))
+    {
+        if (len)
+            *len = (def ? strlen(def) : 0);
+        return def;
+    }
+    else
+        return luaL_checklstring(L, narg, len);
+}
+
+double luaL_checknumber(lua_State* L, int narg)
+{
+    int isnum;
+    double d = lua_tonumberx(L, narg, &isnum);
+    if (!isnum)
+        tag_error(L, narg, LUA_TNUMBER);
+    return d;
+}
+
+double luaL_optnumber(lua_State* L, int narg, double def)
+{
+    return luaL_opt(L, luaL_checknumber, narg, def);
+}
+
+int luaL_checkboolean(lua_State* L, int narg)
+{
+    // This checks specifically for boolean values, ignoring
+    // all other truthy/falsy values. If the desired result
+    // is true if value is present then lua_toboolean should
+    // directly be used instead.
+    if (!lua_isboolean(L, narg))
+        tag_error(L, narg, LUA_TBOOLEAN);
+    return lua_toboolean(L, narg);
+}
+
+int luaL_optboolean(lua_State* L, int narg, int def)
+{
+    return luaL_opt(L, luaL_checkboolean, narg, def);
+}
+
+int luaL_checkinteger(lua_State* L, int narg)
+{
+    int isnum;
+    int d = lua_tointegerx(L, narg, &isnum);
+    if (!isnum)
+        tag_error(L, narg, LUA_TNUMBER);
+    return d;
+}
+
+int luaL_optinteger(lua_State* L, int narg, int def)
+{
+    return luaL_opt(L, luaL_checkinteger, narg, def);
+}
+
+unsigned luaL_checkunsigned(lua_State* L, int narg)
+{
+    int isnum;
+    unsigned d = lua_tounsignedx(L, narg, &isnum);
+    if (!isnum)
+        tag_error(L, narg, LUA_TNUMBER);
+    return d;
+}
+
+unsigned luaL_optunsigned(lua_State* L, int narg, unsigned def)
+{
+    return luaL_opt(L, luaL_checkunsigned, narg, def);
+}
+
+const float* luaL_checkvector(lua_State* L, int narg)
+{
+    const float* v = lua_tovector(L, narg);
+    if (!v)
+        tag_error(L, narg, LUA_TVECTOR);
+    return v;
+}
+
+const float* luaL_optvector(lua_State* L, int narg, const float* def)
+{
+    return luaL_opt(L, luaL_checkvector, narg, def);
+}
+
+int luaL_getmetafield(lua_State* L, int obj, const char* event)
+{
+    if (!lua_getmetatable(L, obj)) // no metatable?
+        return 0;
+    lua_pushstring(L, event);
+    lua_rawget(L, -2);
+    if (lua_isnil(L, -1))
+    {
+        lua_pop(L, 2); // remove metatable and metafield
+        return 0;
+    }
+    else
+    {
+        lua_remove(L, -2); // remove only metatable
+        return 1;
+    }
+}
+
+int luaL_callmeta(lua_State* L, int obj, const char* event)
+{
+    obj = abs_index(L, obj);
+    if (!luaL_getmetafield(L, obj, event)) // no metafield?
+        return 0;
+    lua_pushvalue(L, obj);
+    lua_call(L, 1, 1);
+    return 1;
+}
+
+static int libsize(const luaL_Reg* l)
+{
+    int size = 0;
+    for (; l->name; l++)
+        size++;
+    return size;
+}
+
+void luaL_register(lua_State* L, const char* libname, const luaL_Reg* l)
+{
+    if (libname)
+    {
+        int size = libsize(l);
+        // check whether lib already exists
+        luaL_findtable(L, LUA_REGISTRYINDEX, "_LOADED", 1);
+        lua_getfield(L, -1, libname); // get _LOADED[libname]
+        if (!lua_istable(L, -1))
+        {                  // not found?
+            lua_pop(L, 1); // remove previous result
+            // try global variable (and create one if it does not exist)
+            if (luaL_findtable(L, LUA_GLOBALSINDEX, libname, size) != NULL)
+                luaL_error(L, "name conflict for module '%s'", libname);
+            lua_pushvalue(L, -1);
+            lua_setfield(L, -3, libname); // _LOADED[libname] = new table
+        }
+        lua_remove(L, -2); // remove _LOADED table
+    }
+    for (; l->name; l++)
+    {
+        lua_pushcfunction(L, l->func, l->name);
+        lua_setfield(L, -2, l->name);
+    }
+}
+
+const char* luaL_findtable(lua_State* L, int idx, const char* fname, int szhint)
+{
+    const char* e;
+    lua_pushvalue(L, idx);
+    do
+    {
+        e = strchr(fname, '.');
+        if (e == NULL)
+            e = fname + strlen(fname);
+        lua_pushlstring(L, fname, e - fname);
+        lua_rawget(L, -2);
+        if (lua_isnil(L, -1))
+        {                                                    // no such field?
+            lua_pop(L, 1);                                   // remove this nil
+            lua_createtable(L, 0, (*e == '.' ? 1 : szhint)); // new table for field
+            lua_pushlstring(L, fname, e - fname);
+            lua_pushvalue(L, -2);
+            lua_settable(L, -4); // set new table into field
+        }
+        else if (!lua_istable(L, -1))
+        {                  // field has a non-table value?
+            lua_pop(L, 2); // remove table and value
+            return fname;  // return problematic part of the name
+        }
+        lua_remove(L, -2); // remove previous table
+        fname = e + 1;
+    } while (*e == '.');
+    return NULL;
+}
+
+const char* luaL_typename(lua_State* L, int idx)
+{
+    const TValue* obj = luaA_toobject(L, idx);
+    return obj ? luaT_objtypename(L, obj) : "no value";
+}
+
+/*
+** {======================================================
+** Generic Buffer manipulation
+** =======================================================
+*/
+
+static size_t getnextbuffersize(lua_State* L, size_t currentsize, size_t desiredsize)
+{
+    size_t newsize = currentsize + currentsize / 2;
+
+    // check for size overflow
+    if (SIZE_MAX - desiredsize < currentsize)
+        luaL_error(L, "buffer too large");
+
+    // growth factor might not be enough to satisfy the desired size
+    if (newsize < desiredsize)
+        newsize = desiredsize;
+
+    return newsize;
+}
+
+static char* extendstrbuf(luaL_Strbuf* B, size_t additionalsize, int boxloc)
+{
+    lua_State* L = B->L;
+
+    if (B->storage)
+        LUAU_ASSERT(B->storage == tsvalue(L->top + boxloc));
+
+    char* base = B->storage ? B->storage->data : B->buffer;
+
+    size_t capacity = B->end - base;
+    size_t nextsize = getnextbuffersize(B->L, capacity, capacity + additionalsize);
+
+    TString* newStorage = luaS_bufstart(L, nextsize);
+
+    memcpy(newStorage->data, base, B->p - base);
+
+    // place the string storage at the expected position in the stack
+    if (base == B->buffer)
+    {
+        lua_pushnil(L);
+        lua_insert(L, boxloc);
+    }
+
+    setsvalue(L, L->top + boxloc, newStorage);
+    B->p = newStorage->data + (B->p - base);
+    B->end = newStorage->data + nextsize;
+    B->storage = newStorage;
+
+    return B->p;
+}
+
+void luaL_buffinit(lua_State* L, luaL_Strbuf* B)
+{
+    // start with an internal buffer
+    B->p = B->buffer;
+    B->end = B->p + LUA_BUFFERSIZE;
+
+    B->L = L;
+    B->storage = nullptr;
+}
+
+char* luaL_buffinitsize(lua_State* L, luaL_Strbuf* B, size_t size)
+{
+    luaL_buffinit(L, B);
+    return luaL_prepbuffsize(B, size);
+}
+
+char* luaL_prepbuffsize(luaL_Strbuf* B, size_t size)
+{
+    if (size_t(B->end - B->p) < size)
+        return extendstrbuf(B, size - (B->end - B->p), -1);
+    return B->p;
+}
+
+void luaL_addlstring(luaL_Strbuf* B, const char* s, size_t len)
+{
+    if (size_t(B->end - B->p) < len)
+        extendstrbuf(B, len - (B->end - B->p), -1);
+
+    memcpy(B->p, s, len);
+    B->p += len;
+}
+
+void luaL_addvalue(luaL_Strbuf* B)
+{
+    lua_State* L = B->L;
+
+    size_t vl;
+    if (const char* s = lua_tolstring(L, -1, &vl))
+    {
+        if (size_t(B->end - B->p) < vl)
+            extendstrbuf(B, vl - (B->end - B->p), -2);
+
+        memcpy(B->p, s, vl);
+        B->p += vl;
+
+        lua_pop(L, 1);
+    }
+}
+
+void luaL_addvalueany(luaL_Strbuf* B, int idx)
+{
+    lua_State* L = B->L;
+
+    switch (lua_type(L, idx))
+    {
+    case LUA_TNONE:
+    {
+        LUAU_ASSERT(!"expected value");
+        break;
+    }
+    case LUA_TNIL:
+        luaL_addstring(B, "nil");
+        break;
+    case LUA_TBOOLEAN:
+        if (lua_toboolean(L, idx))
+            luaL_addstring(B, "true");
+        else
+            luaL_addstring(B, "false");
+        break;
+    case LUA_TNUMBER:
+    {
+        double n = lua_tonumber(L, idx);
+        char s[LUAI_MAXNUM2STR];
+        char* e = luai_num2str(s, n);
+        luaL_addlstring(B, s, e - s);
+        break;
+    }
+    case LUA_TSTRING:
+    {
+        size_t len;
+        const char* s = lua_tolstring(L, idx, &len);
+        luaL_addlstring(B, s, len);
+        break;
+    }
+    default:
+    {
+        size_t len;
+        luaL_tolstring(L, idx, &len);
+
+        // note: luaL_addlstring assumes box is stored at top of stack, so we can't call it here
+        // instead we use luaL_addvalue which will take the string from the top of the stack and add that
+        luaL_addvalue(B);
+    }
+    }
+}
+
+void luaL_pushresult(luaL_Strbuf* B)
+{
+    lua_State* L = B->L;
+
+    if (TString* storage = B->storage)
+    {
+        luaC_checkGC(L);
+
+        // if we finished just at the end of the string buffer, we can convert it to a mutable stirng without a copy
+        if (B->p == B->end)
+        {
+            setsvalue(L, L->top - 1, luaS_buffinish(L, storage));
+        }
+        else
+        {
+            setsvalue(L, L->top - 1, luaS_newlstr(L, storage->data, B->p - storage->data));
+        }
+    }
+    else
+    {
+        lua_pushlstring(L, B->buffer, B->p - B->buffer);
+    }
+}
+
+void luaL_pushresultsize(luaL_Strbuf* B, size_t size)
+{
+    B->p += size;
+    luaL_pushresult(B);
+}
+
+// }======================================================
+
+const char* luaL_tolstring(lua_State* L, int idx, size_t* len)
+{
+    if (luaL_callmeta(L, idx, "__tostring")) // is there a metafield?
+    {
+        const char* s = lua_tolstring(L, -1, len);
+        if (!s)
+            luaL_error(L, "'__tostring' must return a string");
+        return s;
+    }
+
+    switch (lua_type(L, idx))
+    {
+    case LUA_TNIL:
+        lua_pushliteral(L, "nil");
+        break;
+    case LUA_TBOOLEAN:
+        lua_pushstring(L, (lua_toboolean(L, idx) ? "true" : "false"));
+        break;
+    case LUA_TNUMBER:
+    {
+        double n = lua_tonumber(L, idx);
+        char s[LUAI_MAXNUM2STR];
+        char* e = luai_num2str(s, n);
+        lua_pushlstring(L, s, e - s);
+        break;
+    }
+    case LUA_TVECTOR:
+    {
+        const float* v = lua_tovector(L, idx);
+
+        char s[LUAI_MAXNUM2STR * LUA_VECTOR_SIZE];
+        char* e = s;
+        for (int i = 0; i < LUA_VECTOR_SIZE; ++i)
+        {
+            if (i != 0)
+            {
+                *e++ = ',';
+                *e++ = ' ';
+            }
+            e = luai_num2str(e, v[i]);
+        }
+        lua_pushlstring(L, s, e - s);
+        break;
+    }
+    case LUA_TSTRING:
+        lua_pushvalue(L, idx);
+        break;
+    default:
+    {
+        const void* ptr = lua_topointer(L, idx);
+        unsigned long long enc = lua_encodepointer(L, uintptr_t(ptr));
+        lua_pushfstring(L, "%s: 0x%016llx", luaL_typename(L, idx), enc);
+        break;
+    }
+    }
+    return lua_tolstring(L, -1, len);
+}

--- a/lib/luau/VM/src/lbaselib.cpp
+++ b/lib/luau/VM/src/lbaselib.cpp
@@ -1,0 +1,480 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lstate.h"
+#include "lapi.h"
+#include "ldo.h"
+#include "ludata.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void writestring(const char* s, size_t l)
+{
+    fwrite(s, 1, l, stdout);
+}
+
+static int luaB_print(lua_State* L)
+{
+    int n = lua_gettop(L); // number of arguments
+    for (int i = 1; i <= n; i++)
+    {
+        size_t l;
+        const char* s = luaL_tolstring(L, i, &l); // convert to string using __tostring et al
+        if (i > 1)
+            writestring("\t", 1);
+        writestring(s, l);
+        lua_pop(L, 1); // pop result
+    }
+    writestring("\n", 1);
+    return 0;
+}
+
+static int luaB_tonumber(lua_State* L)
+{
+    int base = luaL_optinteger(L, 2, 10);
+    if (base == 10)
+    { // standard conversion
+        int isnum = 0;
+        double n = lua_tonumberx(L, 1, &isnum);
+        if (isnum)
+        {
+            lua_pushnumber(L, n);
+            return 1;
+        }
+        luaL_checkany(L, 1); // error if we don't have any argument
+    }
+    else
+    {
+        const char* s1 = luaL_checkstring(L, 1);
+        luaL_argcheck(L, 2 <= base && base <= 36, 2, "base out of range");
+        char* s2;
+        unsigned long long n;
+        n = strtoull(s1, &s2, base);
+        if (s1 != s2)
+        { // at least one valid digit?
+            while (isspace((unsigned char)(*s2)))
+                s2++; // skip trailing spaces
+            if (*s2 == '\0')
+            { // no invalid trailing characters?
+                lua_pushnumber(L, (double)n);
+                return 1;
+            }
+        }
+    }
+    lua_pushnil(L); // else not a number
+    return 1;
+}
+
+static int luaB_error(lua_State* L)
+{
+    int level = luaL_optinteger(L, 2, 1);
+    lua_settop(L, 1);
+    if (lua_isstring(L, 1) && level > 0)
+    { // add extra information?
+        luaL_where(L, level);
+        lua_pushvalue(L, 1);
+        lua_concat(L, 2);
+    }
+    lua_error(L);
+}
+
+static int luaB_getmetatable(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    if (!lua_getmetatable(L, 1))
+    {
+        lua_pushnil(L);
+        return 1; // no metatable
+    }
+    luaL_getmetafield(L, 1, "__metatable");
+    return 1; // returns either __metatable field (if present) or metatable
+}
+
+static int luaB_setmetatable(lua_State* L)
+{
+    int t = lua_type(L, 2);
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_argexpected(L, t == LUA_TNIL || t == LUA_TTABLE, 2, "nil or table");
+    if (luaL_getmetafield(L, 1, "__metatable"))
+        luaL_error(L, "cannot change a protected metatable");
+    lua_settop(L, 2);
+    lua_setmetatable(L, 1);
+    return 1;
+}
+
+static void getfunc(lua_State* L, int opt)
+{
+    if (lua_isfunction(L, 1))
+        lua_pushvalue(L, 1);
+    else
+    {
+        lua_Debug ar;
+        int level = opt ? luaL_optinteger(L, 1, 1) : luaL_checkinteger(L, 1);
+        luaL_argcheck(L, level >= 0, 1, "level must be non-negative");
+        if (lua_getinfo(L, level, "f", &ar) == 0)
+            luaL_argerror(L, 1, "invalid level");
+        if (lua_isnil(L, -1))
+            luaL_error(L, "no function environment for tail call at level %d", level);
+    }
+}
+
+static int luaB_getfenv(lua_State* L)
+{
+    getfunc(L, 1);
+    if (lua_iscfunction(L, -1))             // is a C function?
+        lua_pushvalue(L, LUA_GLOBALSINDEX); // return the thread's global env.
+    else
+        lua_getfenv(L, -1);
+    lua_setsafeenv(L, -1, false);
+    return 1;
+}
+
+static int luaB_setfenv(lua_State* L)
+{
+    luaL_checktype(L, 2, LUA_TTABLE);
+    getfunc(L, 0);
+    lua_pushvalue(L, 2);
+    lua_setsafeenv(L, -1, false);
+    if (lua_isnumber(L, 1) && lua_tonumber(L, 1) == 0)
+    {
+        // change environment of current thread
+        lua_pushthread(L);
+        lua_insert(L, -2);
+        lua_setfenv(L, -2);
+        return 0;
+    }
+    else if (lua_iscfunction(L, -2) || lua_setfenv(L, -2) == 0)
+        luaL_error(L, "'setfenv' cannot change environment of given object");
+    return 1;
+}
+
+static int luaB_rawequal(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    luaL_checkany(L, 2);
+    lua_pushboolean(L, lua_rawequal(L, 1, 2));
+    return 1;
+}
+
+static int luaB_rawget(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checkany(L, 2);
+    lua_settop(L, 2);
+    lua_rawget(L, 1);
+    return 1;
+}
+
+static int luaB_rawset(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checkany(L, 2);
+    luaL_checkany(L, 3);
+    lua_settop(L, 3);
+    lua_rawset(L, 1);
+    return 1;
+}
+
+static int luaB_rawlen(lua_State* L)
+{
+    int tt = lua_type(L, 1);
+    luaL_argcheck(L, tt == LUA_TTABLE || tt == LUA_TSTRING, 1, "table or string expected");
+    int len = lua_objlen(L, 1);
+    lua_pushinteger(L, len);
+    return 1;
+}
+
+static int luaB_gcinfo(lua_State* L)
+{
+    lua_pushinteger(L, lua_gc(L, LUA_GCCOUNT, 0));
+    return 1;
+}
+
+static int luaB_type(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    // resulting name doesn't differentiate between userdata types
+    lua_pushstring(L, lua_typename(L, lua_type(L, 1)));
+    return 1;
+}
+
+static int luaB_typeof(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    // resulting name returns __type if specified unless the input is a newproxy-created userdata
+    lua_pushstring(L, luaL_typename(L, 1));
+    return 1;
+}
+
+int luaB_next(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_settop(L, 2); // create a 2nd argument if there isn't one
+    if (lua_next(L, 1))
+        return 2;
+    else
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+}
+
+static int luaB_pairs(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_pushvalue(L, lua_upvalueindex(1)); // return generator,
+    lua_pushvalue(L, 1);                   // state,
+    lua_pushnil(L);                        // and initial value
+    return 3;
+}
+
+int luaB_inext(lua_State* L)
+{
+    int i = luaL_checkinteger(L, 2);
+    luaL_checktype(L, 1, LUA_TTABLE);
+    i++; // next value
+    lua_pushinteger(L, i);
+    lua_rawgeti(L, 1, i);
+    return (lua_isnil(L, -1)) ? 0 : 2;
+}
+
+static int luaB_ipairs(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_pushvalue(L, lua_upvalueindex(1)); // return generator,
+    lua_pushvalue(L, 1);                   // state,
+    lua_pushinteger(L, 0);                 // and initial value
+    return 3;
+}
+
+static int luaB_assert(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    if (!lua_toboolean(L, 1))
+        luaL_error(L, "%s", luaL_optstring(L, 2, "assertion failed!"));
+    return lua_gettop(L);
+}
+
+static int luaB_select(lua_State* L)
+{
+    int n = lua_gettop(L);
+    if (lua_type(L, 1) == LUA_TSTRING && *lua_tostring(L, 1) == '#')
+    {
+        lua_pushinteger(L, n - 1);
+        return 1;
+    }
+    else
+    {
+        int i = luaL_checkinteger(L, 1);
+        if (i < 0)
+            i = n + i;
+        else if (i > n)
+            i = n;
+        luaL_argcheck(L, 1 <= i, 1, "index out of range");
+        return n - i;
+    }
+}
+
+static void luaB_pcallrun(lua_State* L, void* ud)
+{
+    StkId func = (StkId)ud;
+
+    luaD_call(L, func, LUA_MULTRET);
+}
+
+static int luaB_pcally(lua_State* L)
+{
+    luaL_checkany(L, 1);
+
+    StkId func = L->base;
+
+    // any errors from this point on are handled by continuation
+    L->ci->flags |= LUA_CALLINFO_HANDLE;
+
+    // maintain yieldable invariant (baseCcalls <= nCcalls)
+    L->baseCcalls++;
+    int status = luaD_pcall(L, luaB_pcallrun, func, savestack(L, func), 0);
+    L->baseCcalls--;
+
+    // necessary to accomodate functions that return lots of values
+    expandstacklimit(L, L->top);
+
+    // yielding means we need to propagate yield; resume will call continuation function later
+    if (status == 0 && (L->status == LUA_YIELD || L->status == LUA_BREAK))
+        return -1; // -1 is a marker for yielding from C
+
+    // immediate return (error or success)
+    lua_rawcheckstack(L, 1);
+    lua_pushboolean(L, status == 0);
+    lua_insert(L, 1);
+    return lua_gettop(L); // return status + all results
+}
+
+static int luaB_pcallcont(lua_State* L, int status)
+{
+    if (status == 0)
+    {
+        lua_rawcheckstack(L, 1);
+        lua_pushboolean(L, true);
+        lua_insert(L, 1); // insert status before all results
+        return lua_gettop(L);
+    }
+    else
+    {
+        lua_rawcheckstack(L, 1);
+        lua_pushboolean(L, false);
+        lua_insert(L, -2); // insert status before error object
+        return 2;
+    }
+}
+
+static int luaB_xpcally(lua_State* L)
+{
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+
+    // swap function & error function
+    lua_pushvalue(L, 1);
+    lua_pushvalue(L, 2);
+    lua_replace(L, 1);
+    lua_replace(L, 2);
+    // at this point the stack looks like err, f, args
+
+    // any errors from this point on are handled by continuation
+    L->ci->flags |= LUA_CALLINFO_HANDLE;
+
+    StkId errf = L->base;
+    StkId func = L->base + 1;
+
+    // maintain yieldable invariant (baseCcalls <= nCcalls)
+    L->baseCcalls++;
+    int status = luaD_pcall(L, luaB_pcallrun, func, savestack(L, func), savestack(L, errf));
+    L->baseCcalls--;
+
+    // necessary to accomodate functions that return lots of values
+    expandstacklimit(L, L->top);
+
+    // yielding means we need to propagate yield; resume will call continuation function later
+    if (status == 0 && (L->status == LUA_YIELD || L->status == LUA_BREAK))
+        return -1; // -1 is a marker for yielding from C
+
+    // immediate return (error or success)
+    lua_rawcheckstack(L, 1);
+    lua_pushboolean(L, status == 0);
+    lua_replace(L, 1);    // replace error function with status
+    return lua_gettop(L); // return status + all results
+}
+
+static void luaB_xpcallerr(lua_State* L, void* ud)
+{
+    StkId func = (StkId)ud;
+
+    luaD_call(L, func, 1);
+}
+
+static int luaB_xpcallcont(lua_State* L, int status)
+{
+    if (status == 0)
+    {
+        lua_rawcheckstack(L, 1);
+        lua_pushboolean(L, true);
+        lua_replace(L, 1);    // replace error function with status
+        return lua_gettop(L); // return status + all results
+    }
+    else
+    {
+        lua_rawcheckstack(L, 3);
+        lua_pushboolean(L, false);
+        lua_pushvalue(L, 1);  // push error function on top of the stack
+        lua_pushvalue(L, -3); // push error object (that was on top of the stack before)
+
+        StkId res = L->top - 3;
+        StkId errf = L->top - 2;
+
+        // note: we pass res as errfunc as a short cut; if errf generates an error, we'll try to execute res (boolean) and fail
+        luaD_pcall(L, luaB_xpcallerr, errf, savestack(L, errf), savestack(L, res));
+
+        return 2;
+    }
+}
+
+static int luaB_tostring(lua_State* L)
+{
+    luaL_checkany(L, 1);
+    luaL_tolstring(L, 1, NULL);
+    return 1;
+}
+
+static int luaB_newproxy(lua_State* L)
+{
+    int t = lua_type(L, 1);
+    luaL_argexpected(L, t == LUA_TNONE || t == LUA_TNIL || t == LUA_TBOOLEAN, 1, "nil or boolean");
+
+    bool needsmt = lua_toboolean(L, 1);
+
+    lua_newuserdatatagged(L, 0, UTAG_PROXY);
+
+    if (needsmt)
+    {
+        lua_newtable(L);
+        lua_setmetatable(L, -2);
+    }
+
+    return 1;
+}
+
+static const luaL_Reg base_funcs[] = {
+    {"assert", luaB_assert},
+    {"error", luaB_error},
+    {"gcinfo", luaB_gcinfo},
+    {"getfenv", luaB_getfenv},
+    {"getmetatable", luaB_getmetatable},
+    {"next", luaB_next},
+    {"newproxy", luaB_newproxy},
+    {"print", luaB_print},
+    {"rawequal", luaB_rawequal},
+    {"rawget", luaB_rawget},
+    {"rawset", luaB_rawset},
+    {"rawlen", luaB_rawlen},
+    {"select", luaB_select},
+    {"setfenv", luaB_setfenv},
+    {"setmetatable", luaB_setmetatable},
+    {"tonumber", luaB_tonumber},
+    {"tostring", luaB_tostring},
+    {"type", luaB_type},
+    {"typeof", luaB_typeof},
+    {NULL, NULL},
+};
+
+static void auxopen(lua_State* L, const char* name, lua_CFunction f, lua_CFunction u)
+{
+    lua_pushcfunction(L, u, NULL);
+    lua_pushcclosure(L, f, name, 1);
+    lua_setfield(L, -2, name);
+}
+
+int luaopen_base(lua_State* L)
+{
+    // set global _G
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    lua_setglobal(L, "_G");
+
+    // open lib into global table
+    luaL_register(L, "_G", base_funcs);
+    lua_pushliteral(L, "Luau");
+    lua_setglobal(L, "_VERSION"); // set global _VERSION
+
+    // `ipairs' and `pairs' need auxiliary functions as upvalues
+    auxopen(L, "ipairs", luaB_ipairs, luaB_inext);
+    auxopen(L, "pairs", luaB_pairs, luaB_next);
+
+    lua_pushcclosurek(L, luaB_pcally, "pcall", 0, luaB_pcallcont);
+    lua_setfield(L, -2, "pcall");
+
+    lua_pushcclosurek(L, luaB_xpcally, "xpcall", 0, luaB_xpcallcont);
+    lua_setfield(L, -2, "xpcall");
+
+    return 1;
+}

--- a/lib/luau/VM/src/lbitlib.cpp
+++ b/lib/luau/VM/src/lbitlib.cpp
@@ -1,0 +1,251 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lcommon.h"
+#include "lnumutils.h"
+
+LUAU_FASTFLAGVARIABLE(LuauBit32Byteswap, false)
+
+#define ALLONES ~0u
+#define NBITS int(8 * sizeof(unsigned))
+
+// macro to trim extra bits
+#define trim(x) ((x)&ALLONES)
+
+// builds a number with 'n' ones (1 <= n <= NBITS)
+#define mask(n) (~((ALLONES << 1) << ((n)-1)))
+
+typedef unsigned b_uint;
+
+static b_uint andaux(lua_State* L)
+{
+    int i, n = lua_gettop(L);
+    b_uint r = ~(b_uint)0;
+    for (i = 1; i <= n; i++)
+        r &= luaL_checkunsigned(L, i);
+    return trim(r);
+}
+
+static int b_and(lua_State* L)
+{
+    b_uint r = andaux(L);
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_test(lua_State* L)
+{
+    b_uint r = andaux(L);
+    lua_pushboolean(L, r != 0);
+    return 1;
+}
+
+static int b_or(lua_State* L)
+{
+    int i, n = lua_gettop(L);
+    b_uint r = 0;
+    for (i = 1; i <= n; i++)
+        r |= luaL_checkunsigned(L, i);
+    lua_pushunsigned(L, trim(r));
+    return 1;
+}
+
+static int b_xor(lua_State* L)
+{
+    int i, n = lua_gettop(L);
+    b_uint r = 0;
+    for (i = 1; i <= n; i++)
+        r ^= luaL_checkunsigned(L, i);
+    lua_pushunsigned(L, trim(r));
+    return 1;
+}
+
+static int b_not(lua_State* L)
+{
+    b_uint r = ~luaL_checkunsigned(L, 1);
+    lua_pushunsigned(L, trim(r));
+    return 1;
+}
+
+static int b_shift(lua_State* L, b_uint r, int i)
+{
+    if (i < 0)
+    { // shift right?
+        i = -i;
+        r = trim(r);
+        if (i >= NBITS)
+            r = 0;
+        else
+            r >>= i;
+    }
+    else
+    { // shift left
+        if (i >= NBITS)
+            r = 0;
+        else
+            r <<= i;
+        r = trim(r);
+    }
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_lshift(lua_State* L)
+{
+    return b_shift(L, luaL_checkunsigned(L, 1), luaL_checkinteger(L, 2));
+}
+
+static int b_rshift(lua_State* L)
+{
+    return b_shift(L, luaL_checkunsigned(L, 1), -luaL_checkinteger(L, 2));
+}
+
+static int b_arshift(lua_State* L)
+{
+    b_uint r = luaL_checkunsigned(L, 1);
+    int i = luaL_checkinteger(L, 2);
+    if (i < 0 || !(r & ((b_uint)1 << (NBITS - 1))))
+        return b_shift(L, r, -i);
+    else
+    { // arithmetic shift for 'negative' number
+        if (i >= NBITS)
+            r = ALLONES;
+        else
+            r = trim((r >> i) | ~(~(b_uint)0 >> i)); // add signal bit
+        lua_pushunsigned(L, r);
+        return 1;
+    }
+}
+
+static int b_rot(lua_State* L, int i)
+{
+    b_uint r = luaL_checkunsigned(L, 1);
+    i &= (NBITS - 1); // i = i % NBITS
+    r = trim(r);
+    if (i != 0) // avoid undefined shift of NBITS when i == 0
+        r = (r << i) | (r >> (NBITS - i));
+    lua_pushunsigned(L, trim(r));
+    return 1;
+}
+
+static int b_lrot(lua_State* L)
+{
+    return b_rot(L, luaL_checkinteger(L, 2));
+}
+
+static int b_rrot(lua_State* L)
+{
+    return b_rot(L, -luaL_checkinteger(L, 2));
+}
+
+/*
+** get field and width arguments for field-manipulation functions,
+** checking whether they are valid.
+** ('luaL_error' called without 'return' to avoid later warnings about
+** 'width' being used uninitialized.)
+*/
+static int fieldargs(lua_State* L, int farg, int* width)
+{
+    int f = luaL_checkinteger(L, farg);
+    int w = luaL_optinteger(L, farg + 1, 1);
+    luaL_argcheck(L, 0 <= f, farg, "field cannot be negative");
+    luaL_argcheck(L, 0 < w, farg + 1, "width must be positive");
+    if (f + w > NBITS)
+        luaL_error(L, "trying to access non-existent bits");
+    *width = w;
+    return f;
+}
+
+static int b_extract(lua_State* L)
+{
+    int w;
+    b_uint r = luaL_checkunsigned(L, 1);
+    int f = fieldargs(L, 2, &w);
+    r = (r >> f) & mask(w);
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_replace(lua_State* L)
+{
+    int w;
+    b_uint r = luaL_checkunsigned(L, 1);
+    b_uint v = luaL_checkunsigned(L, 2);
+    int f = fieldargs(L, 3, &w);
+    int m = mask(w);
+    v &= m; // erase bits outside given width
+    r = (r & ~(m << f)) | (v << f);
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_countlz(lua_State* L)
+{
+    b_uint v = luaL_checkunsigned(L, 1);
+
+    b_uint r = NBITS;
+    for (int i = 0; i < NBITS; ++i)
+        if (v & (1u << (NBITS - 1 - i)))
+        {
+            r = i;
+            break;
+        }
+
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_countrz(lua_State* L)
+{
+    b_uint v = luaL_checkunsigned(L, 1);
+
+    b_uint r = NBITS;
+    for (int i = 0; i < NBITS; ++i)
+        if (v & (1u << i))
+        {
+            r = i;
+            break;
+        }
+
+    lua_pushunsigned(L, r);
+    return 1;
+}
+
+static int b_swap(lua_State* L)
+{
+    if (!FFlag::LuauBit32Byteswap)
+        luaL_error(L, "bit32.byteswap isn't enabled");
+
+    b_uint n = luaL_checkunsigned(L, 1);
+    n = (n << 24) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | (n >> 24);
+
+    lua_pushunsigned(L, n);
+    return 1;
+}
+
+static const luaL_Reg bitlib[] = {
+    {"arshift", b_arshift},
+    {"band", b_and},
+    {"bnot", b_not},
+    {"bor", b_or},
+    {"bxor", b_xor},
+    {"btest", b_test},
+    {"extract", b_extract},
+    {"lrotate", b_lrot},
+    {"lshift", b_lshift},
+    {"replace", b_replace},
+    {"rrotate", b_rrot},
+    {"rshift", b_rshift},
+    {"countlz", b_countlz},
+    {"countrz", b_countrz},
+    {"byteswap", b_swap},
+    {NULL, NULL},
+};
+
+int luaopen_bit32(lua_State* L)
+{
+    luaL_register(L, LUA_BITLIBNAME, bitlib);
+
+    return 1;
+}

--- a/lib/luau/VM/src/lbuffer.cpp
+++ b/lib/luau/VM/src/lbuffer.cpp
@@ -1,0 +1,24 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "lbuffer.h"
+
+#include "lgc.h"
+#include "lmem.h"
+
+#include <string.h>
+
+Buffer* luaB_newbuffer(lua_State* L, size_t s)
+{
+    if (s > MAX_BUFFER_SIZE)
+        luaM_toobig(L);
+
+    Buffer* b = luaM_newgco(L, Buffer, sizebuffer(s), L->activememcat);
+    luaC_init(L, b, LUA_TBUFFER);
+    b->len = unsigned(s);
+    memset(b->data, 0, b->len);
+    return b;
+}
+
+void luaB_freebuffer(lua_State* L, Buffer* b, lua_Page* page)
+{
+    luaM_freegco(L, b, sizebuffer(b->len), b->memcat, page);
+}

--- a/lib/luau/VM/src/lbuffer.h
+++ b/lib/luau/VM/src/lbuffer.h
@@ -1,0 +1,13 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+// buffer size limit
+#define MAX_BUFFER_SIZE (1 << 30)
+
+// GCObject size has to be at least 16 bytes, so a minimum of 8 bytes is always reserved
+#define sizebuffer(len) (offsetof(Buffer, data) + ((len) < 8 ? 8 : (len)))
+
+LUAI_FUNC Buffer* luaB_newbuffer(lua_State* L, size_t s);
+LUAI_FUNC void luaB_freebuffer(lua_State* L, Buffer* u, struct lua_Page* page);

--- a/lib/luau/VM/src/lbuflib.cpp
+++ b/lib/luau/VM/src/lbuflib.cpp
@@ -1,0 +1,309 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "lualib.h"
+
+#include "lcommon.h"
+#include "lbuffer.h"
+
+#if defined(LUAU_BIG_ENDIAN)
+#include <endian.h>
+#endif
+
+#include <string.h>
+
+LUAU_FASTFLAGVARIABLE(LuauBufferBetterMsg, false)
+
+// while C API returns 'size_t' for binary compatibility in case of future extensions,
+// in the current implementation, length and offset are limited to 31 bits
+// because offset is limited to an integer, a single 64bit comparison can be used and will not overflow
+#define isoutofbounds(offset, len, accessize) (uint64_t(unsigned(offset)) + (accessize) > uint64_t(len))
+
+static_assert(MAX_BUFFER_SIZE <= INT_MAX, "current implementation can't handle a larger limit");
+
+#if defined(LUAU_BIG_ENDIAN)
+template<typename T>
+inline T buffer_swapbe(T v)
+{
+    if (sizeof(T) == 8)
+        return htole64(v);
+    else if (sizeof(T) == 4)
+        return htole32(v);
+    else if (sizeof(T) == 2)
+        return htole16(v);
+    else
+        return v;
+}
+#endif
+
+static int buffer_create(lua_State* L)
+{
+    int size = luaL_checkinteger(L, 1);
+
+    if (FFlag::LuauBufferBetterMsg)
+    {
+        luaL_argcheck(L, size >= 0, 1, "size");
+    }
+    else
+    {
+        if (size < 0)
+            luaL_error(L, "invalid size");
+    }
+
+    lua_newbuffer(L, size);
+    return 1;
+}
+
+static int buffer_fromstring(lua_State* L)
+{
+    size_t len = 0;
+    const char* val = luaL_checklstring(L, 1, &len);
+
+    void* data = lua_newbuffer(L, len);
+    memcpy(data, val, len);
+    return 1;
+}
+
+static int buffer_tostring(lua_State* L)
+{
+    size_t len = 0;
+    void* data = luaL_checkbuffer(L, 1, &len);
+
+    lua_pushlstring(L, (char*)data, len);
+    return 1;
+}
+
+template<typename T>
+static int buffer_readinteger(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+
+    if (isoutofbounds(offset, len, sizeof(T)))
+        luaL_error(L, "buffer access out of bounds");
+
+    T val;
+    memcpy(&val, (char*)buf + offset, sizeof(T));
+
+#if defined(LUAU_BIG_ENDIAN)
+    val = buffer_swapbe(val);
+#endif
+
+    lua_pushnumber(L, double(val));
+    return 1;
+}
+
+template<typename T>
+static int buffer_writeinteger(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+    int value = luaL_checkunsigned(L, 3);
+
+    if (isoutofbounds(offset, len, sizeof(T)))
+        luaL_error(L, "buffer access out of bounds");
+
+    T val = T(value);
+
+#if defined(LUAU_BIG_ENDIAN)
+    val = buffer_swapbe(val);
+#endif
+
+    memcpy((char*)buf + offset, &val, sizeof(T));
+    return 0;
+}
+
+template<typename T, typename StorageType>
+static int buffer_readfp(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+
+    if (isoutofbounds(offset, len, sizeof(T)))
+        luaL_error(L, "buffer access out of bounds");
+
+    T val;
+
+#if defined(LUAU_BIG_ENDIAN)
+    static_assert(sizeof(T) == sizeof(StorageType), "type size must match to reinterpret data");
+    StorageType tmp;
+    memcpy(&tmp, (char*)buf + offset, sizeof(tmp));
+    tmp = buffer_swapbe(tmp);
+
+    memcpy(&val, &tmp, sizeof(tmp));
+#else
+    memcpy(&val, (char*)buf + offset, sizeof(T));
+#endif
+
+    lua_pushnumber(L, double(val));
+    return 1;
+}
+
+template<typename T, typename StorageType>
+static int buffer_writefp(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+    double value = luaL_checknumber(L, 3);
+
+    if (isoutofbounds(offset, len, sizeof(T)))
+        luaL_error(L, "buffer access out of bounds");
+
+    T val = T(value);
+
+#if defined(LUAU_BIG_ENDIAN)
+    static_assert(sizeof(T) == sizeof(StorageType), "type size must match to reinterpret data");
+    StorageType tmp;
+    memcpy(&tmp, &val, sizeof(tmp));
+    tmp = buffer_swapbe(tmp);
+
+    memcpy((char*)buf + offset, &tmp, sizeof(tmp));
+#else
+    memcpy((char*)buf + offset, &val, sizeof(T));
+#endif
+
+    return 0;
+}
+
+static int buffer_readstring(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+    int size = luaL_checkinteger(L, 3);
+
+    if (FFlag::LuauBufferBetterMsg)
+    {
+        luaL_argcheck(L, size >= 0, 3, "size");
+    }
+    else
+    {
+        if (size < 0)
+            luaL_error(L, "invalid size");
+    }
+
+    if (isoutofbounds(offset, len, unsigned(size)))
+        luaL_error(L, "buffer access out of bounds");
+
+    lua_pushlstring(L, (char*)buf + offset, size);
+    return 1;
+}
+
+static int buffer_writestring(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+    size_t size = 0;
+    const char* val = luaL_checklstring(L, 3, &size);
+    int count = luaL_optinteger(L, 4, int(size));
+
+    if (FFlag::LuauBufferBetterMsg)
+    {
+        luaL_argcheck(L, count >= 0, 4, "count");
+    }
+    else
+    {
+        if (count < 0)
+            luaL_error(L, "invalid count");
+    }
+
+    if (size_t(count) > size)
+        luaL_error(L, "string length overflow");
+
+    // string size can't exceed INT_MAX at this point
+    if (isoutofbounds(offset, len, unsigned(count)))
+        luaL_error(L, "buffer access out of bounds");
+
+    memcpy((char*)buf + offset, val, count);
+    return 0;
+}
+
+static int buffer_len(lua_State* L)
+{
+    size_t len = 0;
+    luaL_checkbuffer(L, 1, &len);
+
+    lua_pushnumber(L, double(unsigned(len)));
+    return 1;
+}
+
+static int buffer_copy(lua_State* L)
+{
+    size_t tlen = 0;
+    void* tbuf = luaL_checkbuffer(L, 1, &tlen);
+    int toffset = luaL_checkinteger(L, 2);
+
+    size_t slen = 0;
+    void* sbuf = luaL_checkbuffer(L, 3, &slen);
+    int soffset = luaL_optinteger(L, 4, 0);
+
+    int size = luaL_optinteger(L, 5, int(slen) - soffset);
+
+    if (size < 0)
+        luaL_error(L, "buffer access out of bounds");
+
+    if (isoutofbounds(soffset, slen, unsigned(size)))
+        luaL_error(L, "buffer access out of bounds");
+
+    if (isoutofbounds(toffset, tlen, unsigned(size)))
+        luaL_error(L, "buffer access out of bounds");
+
+    memmove((char*)tbuf + toffset, (char*)sbuf + soffset, size);
+    return 0;
+}
+
+static int buffer_fill(lua_State* L)
+{
+    size_t len = 0;
+    void* buf = luaL_checkbuffer(L, 1, &len);
+    int offset = luaL_checkinteger(L, 2);
+    unsigned value = luaL_checkunsigned(L, 3);
+    int size = luaL_optinteger(L, 4, int(len) - offset);
+
+    if (size < 0)
+        luaL_error(L, "buffer access out of bounds");
+
+    if (isoutofbounds(offset, len, unsigned(size)))
+        luaL_error(L, "buffer access out of bounds");
+
+    memset((char*)buf + offset, value & 0xff, size);
+    return 0;
+}
+
+static const luaL_Reg bufferlib[] = {
+    {"create", buffer_create},
+    {"fromstring", buffer_fromstring},
+    {"tostring", buffer_tostring},
+    {"readi8", buffer_readinteger<int8_t>},
+    {"readu8", buffer_readinteger<uint8_t>},
+    {"readi16", buffer_readinteger<int16_t>},
+    {"readu16", buffer_readinteger<uint16_t>},
+    {"readi32", buffer_readinteger<int32_t>},
+    {"readu32", buffer_readinteger<uint32_t>},
+    {"readf32", buffer_readfp<float, uint32_t>},
+    {"readf64", buffer_readfp<double, uint64_t>},
+    {"writei8", buffer_writeinteger<int8_t>},
+    {"writeu8", buffer_writeinteger<uint8_t>},
+    {"writei16", buffer_writeinteger<int16_t>},
+    {"writeu16", buffer_writeinteger<uint16_t>},
+    {"writei32", buffer_writeinteger<int32_t>},
+    {"writeu32", buffer_writeinteger<uint32_t>},
+    {"writef32", buffer_writefp<float, uint32_t>},
+    {"writef64", buffer_writefp<double, uint64_t>},
+    {"readstring", buffer_readstring},
+    {"writestring", buffer_writestring},
+    {"len", buffer_len},
+    {"copy", buffer_copy},
+    {"fill", buffer_fill},
+    {NULL, NULL},
+};
+
+int luaopen_buffer(lua_State* L)
+{
+    luaL_register(L, LUA_BUFFERLIBNAME, bufferlib);
+
+    return 1;
+}

--- a/lib/luau/VM/src/lbuiltins.cpp
+++ b/lib/luau/VM/src/lbuiltins.cpp
@@ -1,0 +1,1638 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lbuiltins.h"
+
+#include "lstate.h"
+#include "lstring.h"
+#include "ltable.h"
+#include "lgc.h"
+#include "lnumutils.h"
+#include "ldo.h"
+#include "lbuffer.h"
+
+#include <math.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+#ifdef LUAU_TARGET_SSE41
+#include <smmintrin.h>
+
+#ifndef _MSC_VER
+#include <cpuid.h> // on MSVC this comes from intrin.h
+#endif
+#endif
+
+// luauF functions implement FASTCALL instruction that performs a direct execution of some builtin functions from the VM
+// The rule of thumb is that FASTCALL functions can not call user code, yield, fail, or reallocate stack.
+// If types of the arguments mismatch, luauF_* needs to return -1 and the execution will fall back to the usual call path
+// If luauF_* succeeds, it needs to return *all* requested arguments, filling results with nil as appropriate.
+// On input, nparams refers to the actual number of arguments (0+), whereas nresults contains LUA_MULTRET for arbitrary returns or 0+ for a
+// fixed-length return
+// Because of this, and the fact that "extra" returned values will be ignored, implementations below typically check that nresults is <= expected
+// number, which covers the LUA_MULTRET case.
+
+static int luauF_assert(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults == 0 && !l_isfalse(arg0))
+    {
+        return 0;
+    }
+
+    return -1;
+}
+
+static int luauF_abs(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, fabs(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_acos(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, acos(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_asin(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, asin(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_atan2(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+        setnvalue(res, atan2(a1, a2));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_atan(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, atan(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_FASTMATH_BEGIN
+static int luauF_ceil(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, ceil(a1));
+        return 1;
+    }
+
+    return -1;
+}
+LUAU_FASTMATH_END
+
+static int luauF_cosh(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, cosh(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_cos(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, cos(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_deg(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        const double rpd = (3.14159265358979323846 / 180.0);
+        setnvalue(res, a1 / rpd);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_exp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, exp(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_FASTMATH_BEGIN
+static int luauF_floor(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, floor(a1));
+        return 1;
+    }
+
+    return -1;
+}
+LUAU_FASTMATH_END
+
+static int luauF_fmod(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+        setnvalue(res, fmod(a1, a2));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_frexp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 2 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        int e;
+        double f = frexp(a1, &e);
+        setnvalue(res, f);
+        setnvalue(res + 1, double(e));
+        return 2;
+    }
+
+    return -1;
+}
+
+static int luauF_ldexp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+        setnvalue(res, ldexp(a1, int(a2)));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_log10(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, log10(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_log(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+
+        if (nparams == 1)
+        {
+            setnvalue(res, log(a1));
+            return 1;
+        }
+        else if (ttisnumber(args))
+        {
+            double a2 = nvalue(args);
+
+            if (a2 == 2.0)
+            {
+                setnvalue(res, log2(a1));
+                return 1;
+            }
+            else if (a2 == 10.0)
+            {
+                setnvalue(res, log10(a1));
+                return 1;
+            }
+            else
+            {
+                setnvalue(res, log(a1) / log(a2));
+                return 1;
+            }
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_max(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        double r = (a2 > a1) ? a2 : a1;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+
+            r = (a > r) ? a : r;
+        }
+
+        setnvalue(res, r);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_min(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        double r = (a2 < a1) ? a2 : a1;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+
+            r = (a < r) ? a : r;
+        }
+
+        setnvalue(res, r);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_modf(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 2 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        double ip;
+        double fp = modf(a1, &ip);
+        setnvalue(res, ip);
+        setnvalue(res + 1, fp);
+        return 2;
+    }
+
+    return -1;
+}
+
+static int luauF_pow(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+        setnvalue(res, pow(a1, a2));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_rad(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        const double rpd = (3.14159265358979323846 / 180.0);
+        setnvalue(res, a1 * rpd);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_sinh(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, sinh(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_sin(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, sin(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_FASTMATH_BEGIN
+static int luauF_sqrt(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, sqrt(a1));
+        return 1;
+    }
+
+    return -1;
+}
+LUAU_FASTMATH_END
+
+static int luauF_tanh(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, tanh(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_tan(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, tan(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_arshift(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u;
+        luai_num2unsigned(u, a1);
+        int s = int(a2);
+
+        // note: we only specialize fast-path that doesn't require further conditionals (negative shifts and shifts greater or equal to bit width can
+        // be handled generically)
+        if (unsigned(s) < 32)
+        {
+            // note: technically right shift of negative values is UB, but this behavior is getting defined in C++20 and all compilers do the right
+            // (shift) thing.
+            uint32_t r = int32_t(u) >> s;
+
+            setnvalue(res, double(r));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_band(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u1, u2;
+        luai_num2unsigned(u1, a1);
+        luai_num2unsigned(u2, a2);
+
+        uint32_t r = u1 & u2;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+            unsigned u;
+            luai_num2unsigned(u, a);
+
+            r &= u;
+        }
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_bnot(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        unsigned u;
+        luai_num2unsigned(u, a1);
+
+        uint32_t r = ~u;
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_bor(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u1, u2;
+        luai_num2unsigned(u1, a1);
+        luai_num2unsigned(u2, a2);
+
+        uint32_t r = u1 | u2;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+            unsigned u;
+            luai_num2unsigned(u, a);
+
+            r |= u;
+        }
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_bxor(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u1, u2;
+        luai_num2unsigned(u1, a1);
+        luai_num2unsigned(u2, a2);
+
+        uint32_t r = u1 ^ u2;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+            unsigned u;
+            luai_num2unsigned(u, a);
+
+            r ^= u;
+        }
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_btest(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u1, u2;
+        luai_num2unsigned(u1, a1);
+        luai_num2unsigned(u2, a2);
+
+        uint32_t r = u1 & u2;
+
+        for (int i = 3; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            double a = nvalue(args + (i - 2));
+            unsigned u;
+            luai_num2unsigned(u, a);
+
+            r &= u;
+        }
+
+        setbvalue(res, r != 0);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_extract(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned n;
+        luai_num2unsigned(n, a1);
+        int f = int(a2);
+
+        if (nparams == 2)
+        {
+            if (unsigned(f) < 32)
+            {
+                uint32_t m = 1;
+                uint32_t r = (n >> f) & m;
+
+                setnvalue(res, double(r));
+                return 1;
+            }
+        }
+        else if (ttisnumber(args + 1))
+        {
+            double a3 = nvalue(args + 1);
+            int w = int(a3);
+
+            if (f >= 0 && w > 0 && f + w <= 32)
+            {
+                uint32_t m = ~(0xfffffffeu << (w - 1));
+                uint32_t r = (n >> f) & m;
+
+                setnvalue(res, double(r));
+                return 1;
+            }
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_lrotate(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u;
+        luai_num2unsigned(u, a1);
+        int s = int(a2);
+
+        // MSVC doesn't recognize the rotate form that is UB-safe
+#ifdef _MSC_VER
+        uint32_t r = _rotl(u, s);
+#else
+        uint32_t r = (u << (s & 31)) | (u >> ((32 - s) & 31));
+#endif
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_lshift(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u;
+        luai_num2unsigned(u, a1);
+        int s = int(a2);
+
+        // note: we only specialize fast-path that doesn't require further conditionals (negative shifts and shifts greater or equal to bit width can
+        // be handled generically)
+        if (unsigned(s) < 32)
+        {
+            uint32_t r = u << s;
+
+            setnvalue(res, double(r));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_replace(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+        double a3 = nvalue(args + 1);
+
+        unsigned n, v;
+        luai_num2unsigned(n, a1);
+        luai_num2unsigned(v, a2);
+        int f = int(a3);
+
+        if (nparams == 3)
+        {
+            if (unsigned(f) < 32)
+            {
+                uint32_t m = 1;
+                uint32_t r = (n & ~(m << f)) | ((v & m) << f);
+
+                setnvalue(res, double(r));
+                return 1;
+            }
+        }
+        else if (ttisnumber(args + 2))
+        {
+            double a4 = nvalue(args + 2);
+            int w = int(a4);
+
+            if (f >= 0 && w > 0 && f + w <= 32)
+            {
+                uint32_t m = ~(0xfffffffeu << (w - 1));
+                uint32_t r = (n & ~(m << f)) | ((v & m) << f);
+
+                setnvalue(res, double(r));
+                return 1;
+            }
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_rrotate(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u;
+        luai_num2unsigned(u, a1);
+        int s = int(a2);
+
+        // MSVC doesn't recognize the rotate form that is UB-safe
+#ifdef _MSC_VER
+        uint32_t r = _rotr(u, s);
+#else
+        uint32_t r = (u >> (s & 31)) | (u << ((32 - s) & 31));
+#endif
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_rshift(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned u;
+        luai_num2unsigned(u, a1);
+        int s = int(a2);
+
+        // note: we only specialize fast-path that doesn't require further conditionals (negative shifts and shifts greater or equal to bit width can
+        // be handled generically)
+        if (unsigned(s) < 32)
+        {
+            uint32_t r = u >> s;
+
+            setnvalue(res, double(r));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_type(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1)
+    {
+        int tt = ttype(arg0);
+        TString* ttname = L->global->ttname[tt];
+
+        setsvalue(L, res, ttname);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_byte(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && ttisstring(arg0) && ttisnumber(args))
+    {
+        TString* ts = tsvalue(arg0);
+        int i = int(nvalue(args));
+        int j = (nparams >= 3) ? (ttisnumber(args + 1) ? int(nvalue(args + 1)) : 0) : i;
+
+        if (i >= 1 && j >= i && j <= int(ts->len))
+        {
+            int c = j - i + 1;
+            const char* s = getstr(ts);
+
+            // for vararg returns, we only support a single result
+            // this is because this frees us from concerns about stack space
+            if (c == (nresults < 0 ? 1 : nresults))
+            {
+                for (int k = 0; k < c; ++k)
+                {
+                    setnvalue(res + k, uint8_t(s[i + k - 1]));
+                }
+
+                return c;
+            }
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_char(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    char buffer[8];
+
+    if (nparams < int(sizeof(buffer)) && nresults <= 1)
+    {
+        if (luaC_needsGC(L))
+            return -1; // we can't call luaC_checkGC so fall back to C implementation
+
+        if (nparams >= 1)
+        {
+            if (!ttisnumber(arg0))
+                return -1;
+
+            int ch = int(nvalue(arg0));
+
+            if ((unsigned char)(ch) != ch)
+                return -1;
+
+            buffer[0] = ch;
+        }
+
+        for (int i = 2; i <= nparams; ++i)
+        {
+            if (!ttisnumber(args + (i - 2)))
+                return -1;
+
+            int ch = int(nvalue(args + (i - 2)));
+
+            if ((unsigned char)(ch) != ch)
+                return -1;
+
+            buffer[i - 1] = ch;
+        }
+
+        buffer[nparams] = 0;
+
+        setsvalue(L, res, luaS_newlstr(L, buffer, nparams));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_len(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisstring(arg0))
+    {
+        TString* ts = tsvalue(arg0);
+
+        setnvalue(res, int(ts->len));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_typeof(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1)
+    {
+        const TString* ttname = luaT_objtypenamestr(L, arg0);
+
+        setsvalue(L, res, ttname);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_sub(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttisstring(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        TString* ts = tsvalue(arg0);
+        int i = int(nvalue(args));
+        int j = int(nvalue(args + 1));
+
+        if (luaC_needsGC(L))
+            return -1; // we can't call luaC_checkGC so fall back to C implementation
+
+        if (i >= 1 && j >= i && unsigned(j - 1) < unsigned(ts->len))
+        {
+            setsvalue(L, res, luaS_newlstr(L, getstr(ts) + (i - 1), j - i + 1));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_clamp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        double v = nvalue(arg0);
+        double min = nvalue(args);
+        double max = nvalue(args + 1);
+
+        if (min <= max)
+        {
+            double r = v < min ? min : v;
+            r = r > max ? max : r;
+
+            setnvalue(res, r);
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_sign(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double v = nvalue(arg0);
+        setnvalue(res, v > 0.0 ? 1.0 : v < 0.0 ? -1.0 : 0.0);
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_FASTMATH_BEGIN
+static int luauF_round(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double v = nvalue(arg0);
+        setnvalue(res, round(v));
+        return 1;
+    }
+
+    return -1;
+}
+LUAU_FASTMATH_END
+
+static int luauF_rawequal(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1)
+    {
+        setbvalue(res, luaO_rawequalObj(arg0, args));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_rawget(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 2 && nresults <= 1 && ttistable(arg0))
+    {
+        setobj2s(L, res, luaH_get(hvalue(arg0), args));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_rawset(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttistable(arg0))
+    {
+        const TValue* key = args;
+        if (ttisnil(key))
+            return -1;
+        else if (ttisnumber(key) && luai_numisnan(nvalue(key)))
+            return -1;
+        else if (ttisvector(key) && luai_vecisnan(vvalue(key)))
+            return -1;
+
+        Table* t = hvalue(arg0);
+        if (t->readonly)
+            return -1;
+
+        setobj2s(L, res, arg0);
+        setobj2t(L, luaH_set(L, t, args), args + 1);
+        luaC_barriert(L, t, args + 1);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_tinsert(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams == 2 && nresults <= 0 && ttistable(arg0))
+    {
+        Table* t = hvalue(arg0);
+        if (t->readonly)
+            return -1;
+
+        int pos = luaH_getn(t) + 1;
+        setobj2t(L, luaH_setnum(L, t, pos), args);
+        luaC_barriert(L, t, args);
+        return 0;
+    }
+
+    return -1;
+}
+
+static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults < 0 && ttistable(arg0))
+    {
+        Table* t = hvalue(arg0);
+        int n = -1;
+
+        if (nparams == 1)
+            n = luaH_getn(t);
+        else if (nparams == 3 && ttisnumber(args) && ttisnumber(args + 1) && nvalue(args) == 1.0)
+            n = int(nvalue(args + 1));
+
+        if (n >= 0 && n <= t->sizearray && cast_int(L->stack_last - res) >= n && n + nparams <= LUAI_MAXCSTACK)
+        {
+            TValue* array = t->array;
+            for (int i = 0; i < n; ++i)
+                setobj2s(L, res + i, array + i);
+            expandstacklimit(L, res + n);
+            return n;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        double x = nvalue(arg0);
+        double y = nvalue(args);
+        double z = nvalue(args + 1);
+
+#if LUA_VECTOR_SIZE == 4
+        double w = 0.0;
+        if (nparams >= 4)
+        {
+            if (!ttisnumber(args + 2))
+                return -1;
+            w = nvalue(args + 2);
+        }
+        setvvalue(res, float(x), float(y), float(z), float(w));
+#else
+        setvvalue(res, float(x), float(y), float(z), 0.0f);
+#endif
+
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_countlz(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+
+        unsigned n;
+        luai_num2unsigned(n, a1);
+
+#ifdef _MSC_VER
+        unsigned long rl;
+        int r = _BitScanReverse(&rl, n) ? 31 - int(rl) : 32;
+#else
+        int r = n == 0 ? 32 : __builtin_clz(n);
+#endif
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_countrz(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+
+        unsigned n;
+        luai_num2unsigned(n, a1);
+
+#ifdef _MSC_VER
+        unsigned long rl;
+        int r = _BitScanForward(&rl, n) ? int(rl) : 32;
+#else
+        int r = n == 0 ? 32 : __builtin_ctz(n);
+#endif
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_select(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams == 1 && nresults == 1)
+    {
+        int n = cast_int(L->base - L->ci->func) - clvalue(L->ci->func)->l.p->numparams - 1;
+
+        if (ttisnumber(arg0))
+        {
+            int i = int(nvalue(arg0));
+
+            // i >= 1 && i <= n
+            if (unsigned(i - 1) < unsigned(n))
+            {
+                setobj2s(L, res, L->base - n + (i - 1));
+                return 1;
+            }
+            // note: for now we don't handle negative case (wrap around) and defer to fallback
+        }
+        else if (ttisstring(arg0) && *svalue(arg0) == '#')
+        {
+            setnvalue(res, double(n));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_rawlen(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1)
+    {
+        if (ttistable(arg0))
+        {
+            Table* h = hvalue(arg0);
+            setnvalue(res, double(luaH_getn(h)));
+            return 1;
+        }
+        else if (ttisstring(arg0))
+        {
+            TString* ts = tsvalue(arg0);
+            setnvalue(res, double(ts->len));
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_extractk(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    // args is known to contain a number constant with packed in-range f/w
+    if (nparams >= 2 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        double a2 = nvalue(args);
+
+        unsigned n;
+        luai_num2unsigned(n, a1);
+        int fw = int(a2);
+
+        int f = fw & 31;
+        int w1 = fw >> 5;
+
+        uint32_t m = ~(0xfffffffeu << w1);
+        uint32_t r = (n >> f) & m;
+
+        setnvalue(res, double(r));
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_getmetatable(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1)
+    {
+        Table* mt = NULL;
+        if (ttistable(arg0))
+            mt = hvalue(arg0)->metatable;
+        else if (ttisuserdata(arg0))
+            mt = uvalue(arg0)->metatable;
+        else
+            mt = L->global->mt[ttype(arg0)];
+
+        const TValue* mtv = mt ? luaH_getstr(mt, L->global->tmname[TM_METATABLE]) : luaO_nilobject;
+        if (!ttisnil(mtv))
+        {
+            setobj2s(L, res, mtv);
+            return 1;
+        }
+
+        if (mt)
+        {
+            sethvalue(L, res, mt);
+            return 1;
+        }
+        else
+        {
+            setnilvalue(res);
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_setmetatable(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    // note: setmetatable(_, nil) is rare so we use fallback for it to optimize the fast path
+    if (nparams >= 2 && nresults <= 1 && ttistable(arg0) && ttistable(args))
+    {
+        Table* t = hvalue(arg0);
+        if (t->readonly || t->metatable != NULL)
+            return -1; // note: overwriting non-null metatable is very rare but it requires __metatable check
+
+        Table* mt = hvalue(args);
+        t->metatable = mt;
+        luaC_objbarrier(L, t, mt);
+
+        sethvalue(L, res, t);
+        return 1;
+    }
+
+    return -1;
+}
+
+static int luauF_tonumber(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams == 1 && nresults <= 1)
+    {
+        double num;
+
+        if (ttisnumber(arg0))
+        {
+            setnvalue(res, nvalue(arg0));
+            return 1;
+        }
+        else if (ttisstring(arg0) && luaO_str2d(svalue(arg0), &num))
+        {
+            setnvalue(res, num);
+            return 1;
+        }
+        else
+        {
+            setnilvalue(res);
+            return 1;
+        }
+    }
+
+    return -1;
+}
+
+static int luauF_tostring(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1)
+    {
+        switch (ttype(arg0))
+        {
+        case LUA_TNIL:
+        {
+            TString* s = L->global->ttname[LUA_TNIL];
+            setsvalue(L, res, s);
+            return 1;
+        }
+        case LUA_TBOOLEAN:
+        {
+            TString* s = bvalue(arg0) ? luaS_newliteral(L, "true") : luaS_newliteral(L, "false");
+            setsvalue(L, res, s);
+            return 1;
+        }
+        case LUA_TNUMBER:
+        {
+            if (luaC_needsGC(L))
+                return -1; // we can't call luaC_checkGC so fall back to C implementation
+
+            char s[LUAI_MAXNUM2STR];
+            char* e = luai_num2str(s, nvalue(arg0));
+            setsvalue(L, res, luaS_newlstr(L, s, e - s));
+            return 1;
+        }
+        case LUA_TSTRING:
+        {
+            setsvalue(L, res, tsvalue(arg0));
+            return 1;
+        }
+        }
+
+        // fall back to generic C implementation
+    }
+
+    return -1;
+}
+
+static int luauF_byteswap(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        unsigned n;
+        luai_num2unsigned(n, a1);
+
+        n = (n << 24) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | (n >> 24);
+
+        setnvalue(res, double(n));
+        return 1;
+    }
+
+    return -1;
+}
+
+// because offset is limited to an integer, a single 64bit comparison can be used and will not overflow
+#define checkoutofbounds(offset, len, accessize) (uint64_t(unsigned(offset)) + (accessize - 1) >= uint64_t(len))
+
+template<typename T>
+static int luauF_readinteger(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+#if !defined(LUAU_BIG_ENDIAN)
+    if (nparams >= 2 && nresults <= 1 && ttisbuffer(arg0) && ttisnumber(args))
+    {
+        int offset;
+        luai_num2int(offset, nvalue(args));
+        if (checkoutofbounds(offset, bufvalue(arg0)->len, sizeof(T)))
+            return -1;
+
+        T val;
+        memcpy(&val, (char*)bufvalue(arg0)->data + unsigned(offset), sizeof(T));
+        setnvalue(res, double(val));
+        return 1;
+    }
+#endif
+
+    return -1;
+}
+
+template<typename T>
+static int luauF_writeinteger(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+#if !defined(LUAU_BIG_ENDIAN)
+    if (nparams >= 3 && nresults <= 0 && ttisbuffer(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        int offset;
+        luai_num2int(offset, nvalue(args));
+        if (checkoutofbounds(offset, bufvalue(arg0)->len, sizeof(T)))
+            return -1;
+
+        unsigned value;
+        double incoming = nvalue(args + 1);
+        luai_num2unsigned(value, incoming);
+
+        T val = T(value);
+        memcpy((char*)bufvalue(arg0)->data + unsigned(offset), &val, sizeof(T));
+        return 0;
+    }
+#endif
+
+    return -1;
+}
+
+template<typename T>
+static int luauF_readfp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+#if !defined(LUAU_BIG_ENDIAN)
+    if (nparams >= 2 && nresults <= 1 && ttisbuffer(arg0) && ttisnumber(args))
+    {
+        int offset;
+        luai_num2int(offset, nvalue(args));
+        if (checkoutofbounds(offset, bufvalue(arg0)->len, sizeof(T)))
+            return -1;
+
+        T val;
+#ifdef _MSC_VER
+        // avoid memcpy path on MSVC because it results in integer stack copy + floating-point ops on stack
+        val = *(T*)((char*)bufvalue(arg0)->data + unsigned(offset));
+#else
+        memcpy(&val, (char*)bufvalue(arg0)->data + unsigned(offset), sizeof(T));
+#endif
+        setnvalue(res, double(val));
+        return 1;
+    }
+#endif
+
+    return -1;
+}
+
+template<typename T>
+static int luauF_writefp(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+#if !defined(LUAU_BIG_ENDIAN)
+    if (nparams >= 3 && nresults <= 0 && ttisbuffer(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+    {
+        int offset;
+        luai_num2int(offset, nvalue(args));
+        if (checkoutofbounds(offset, bufvalue(arg0)->len, sizeof(T)))
+            return -1;
+
+        T val = T(nvalue(args + 1));
+#ifdef _MSC_VER
+        // avoid memcpy path on MSVC because it results in integer stack copy + floating-point ops on stack
+        *(T*)((char*)bufvalue(arg0)->data + unsigned(offset)) = val;
+#else
+        memcpy((char*)bufvalue(arg0)->data + unsigned(offset), &val, sizeof(T));
+#endif
+        return 0;
+    }
+#endif
+
+    return -1;
+}
+
+static int luauF_missing(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    return -1;
+}
+
+#ifdef LUAU_TARGET_SSE41
+template<int Rounding>
+LUAU_TARGET_SSE41 inline double roundsd_sse41(double v)
+{
+    __m128d av = _mm_set_sd(v);
+    __m128d rv = _mm_round_sd(av, av, Rounding | _MM_FROUND_NO_EXC);
+    return _mm_cvtsd_f64(rv);
+}
+
+LUAU_TARGET_SSE41 static int luauF_floor_sse41(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, roundsd_sse41<_MM_FROUND_TO_NEG_INF>(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_TARGET_SSE41 static int luauF_ceil_sse41(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        setnvalue(res, roundsd_sse41<_MM_FROUND_TO_POS_INF>(a1));
+        return 1;
+    }
+
+    return -1;
+}
+
+LUAU_TARGET_SSE41 static int luauF_round_sse41(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        // roundsd only supports bankers rounding natively, so we need to emulate rounding by using truncation
+        // offset is prevfloat(0.5), which is important so that we round prevfloat(0.5) to 0.
+        const double offset = 0.49999999999999994;
+        setnvalue(res, roundsd_sse41<_MM_FROUND_TO_ZERO>(a1 + (a1 < 0 ? -offset : offset)));
+        return 1;
+    }
+
+    return -1;
+}
+
+static bool luau_hassse41()
+{
+    int cpuinfo[4] = {};
+#ifdef _MSC_VER
+    __cpuid(cpuinfo, 1);
+#else
+    __cpuid(1, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
+#endif
+
+    // We requre SSE4.1 support for ROUNDSD
+    // https://en.wikipedia.org/wiki/CPUID#EAX=1:_Processor_Info_and_Feature_Bits
+    return (cpuinfo[2] & (1 << 19)) != 0;
+}
+#endif
+
+const luau_FastFunction luauF_table[256] = {
+    NULL,
+    luauF_assert,
+
+    luauF_abs,
+    luauF_acos,
+    luauF_asin,
+    luauF_atan2,
+    luauF_atan,
+
+#ifdef LUAU_TARGET_SSE41
+    luau_hassse41() ? luauF_ceil_sse41 : luauF_ceil,
+#else
+    luauF_ceil,
+#endif
+
+    luauF_cosh,
+    luauF_cos,
+    luauF_deg,
+    luauF_exp,
+
+#ifdef LUAU_TARGET_SSE41
+    luau_hassse41() ? luauF_floor_sse41 : luauF_floor,
+#else
+    luauF_floor,
+#endif
+
+    luauF_fmod,
+    luauF_frexp,
+    luauF_ldexp,
+    luauF_log10,
+    luauF_log,
+    luauF_max,
+    luauF_min,
+    luauF_modf,
+    luauF_pow,
+    luauF_rad,
+    luauF_sinh,
+    luauF_sin,
+    luauF_sqrt,
+    luauF_tanh,
+    luauF_tan,
+
+    luauF_arshift,
+    luauF_band,
+    luauF_bnot,
+    luauF_bor,
+    luauF_bxor,
+    luauF_btest,
+    luauF_extract,
+    luauF_lrotate,
+    luauF_lshift,
+    luauF_replace,
+    luauF_rrotate,
+    luauF_rshift,
+
+    luauF_type,
+
+    luauF_byte,
+    luauF_char,
+    luauF_len,
+
+    luauF_typeof,
+
+    luauF_sub,
+
+    luauF_clamp,
+    luauF_sign,
+
+#ifdef LUAU_TARGET_SSE41
+    luau_hassse41() ? luauF_round_sse41 : luauF_round,
+#else
+    luauF_round,
+#endif
+
+    luauF_rawset,
+    luauF_rawget,
+    luauF_rawequal,
+
+    luauF_tinsert,
+    luauF_tunpack,
+
+    luauF_vector,
+
+    luauF_countlz,
+    luauF_countrz,
+
+    luauF_select,
+
+    luauF_rawlen,
+
+    luauF_extractk,
+
+    luauF_getmetatable,
+    luauF_setmetatable,
+
+    luauF_tonumber,
+    luauF_tostring,
+
+    luauF_byteswap,
+
+    luauF_readinteger<int8_t>,
+    luauF_readinteger<uint8_t>,
+    luauF_writeinteger<uint8_t>,
+    luauF_readinteger<int16_t>,
+    luauF_readinteger<uint16_t>,
+    luauF_writeinteger<uint16_t>,
+    luauF_readinteger<int32_t>,
+    luauF_readinteger<uint32_t>,
+    luauF_writeinteger<uint32_t>,
+    luauF_readfp<float>,
+    luauF_writefp<float>,
+    luauF_readfp<double>,
+    luauF_writefp<double>,
+
+// When adding builtins, add them above this line; what follows is 64 "dummy" entries with luauF_missing fallback.
+// This is important so that older versions of the runtime that don't support newer builtins automatically fall back via luauF_missing.
+// Given the builtin addition velocity this should always provide a larger compatibility window than bytecode versions suggest.
+#define MISSING8 luauF_missing, luauF_missing, luauF_missing, luauF_missing, luauF_missing, luauF_missing, luauF_missing, luauF_missing
+
+    MISSING8,
+    MISSING8,
+    MISSING8,
+    MISSING8,
+    MISSING8,
+    MISSING8,
+    MISSING8,
+    MISSING8,
+
+#undef MISSING8
+};

--- a/lib/luau/VM/src/lbuiltins.h
+++ b/lib/luau/VM/src/lbuiltins.h
@@ -1,0 +1,9 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+typedef int (*luau_FastFunction)(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams);
+
+extern const luau_FastFunction luauF_table[256];

--- a/lib/luau/VM/src/lbytecode.h
+++ b/lib/luau/VM/src/lbytecode.h
@@ -1,0 +1,6 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+// This is a forwarding header for Luau bytecode definition
+#include "Luau/Bytecode.h"

--- a/lib/luau/VM/src/lcommon.h
+++ b/lib/luau/VM/src/lcommon.h
@@ -1,0 +1,48 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include <limits.h>
+#include <stdint.h>
+
+#include "luaconf.h"
+
+#include "Luau/Common.h"
+
+typedef LUAI_USER_ALIGNMENT_T L_Umaxalign;
+
+// internal assertions for in-house debugging
+#define check_exp(c, e) (LUAU_ASSERT(c), (e))
+#define api_check(l, e) LUAU_ASSERT(e)
+
+#ifndef cast_to
+#define cast_to(t, exp) ((t)(exp))
+#endif
+
+#define cast_byte(i) cast_to(uint8_t, (i))
+#define cast_num(i) cast_to(double, (i))
+#define cast_int(i) cast_to(int, (i))
+
+/*
+** type for virtual-machine instructions
+** must be an unsigned with (at least) 4 bytes (see details in lopcodes.h)
+*/
+typedef uint32_t Instruction;
+
+/*
+** macro to control inclusion of some hard tests on stack reallocation
+*/
+#if defined(HARDSTACKTESTS) && HARDSTACKTESTS
+#define condhardstacktests(x) (x)
+#else
+#define condhardstacktests(x) ((void)0)
+#endif
+
+/*
+** macro to control inclusion of some hard tests on garbage collection
+*/
+#if defined(HARDMEMTESTS) && HARDMEMTESTS
+#define condhardmemtests(x, l) (HARDMEMTESTS >= l ? (x) : (void)0)
+#else
+#define condhardmemtests(x, l) ((void)0)
+#endif

--- a/lib/luau/VM/src/lcorolib.cpp
+++ b/lib/luau/VM/src/lcorolib.cpp
@@ -1,0 +1,256 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lstate.h"
+#include "lvm.h"
+
+#define CO_STATUS_ERROR -1
+#define CO_STATUS_BREAK -2
+
+static const char* const statnames[] = {"running", "suspended", "normal", "dead", "dead"}; // dead appears twice for LUA_COERR and LUA_COFIN
+
+static int costatus(lua_State* L)
+{
+    lua_State* co = lua_tothread(L, 1);
+    luaL_argexpected(L, co, 1, "thread");
+    lua_pushstring(L, statnames[lua_costatus(L, co)]);
+    return 1;
+}
+
+static int auxresume(lua_State* L, lua_State* co, int narg)
+{
+    // error handling for edge cases
+    if (co->status != LUA_YIELD)
+    {
+        int status = lua_costatus(L, co);
+        if (status != LUA_COSUS)
+        {
+            lua_pushfstring(L, "cannot resume %s coroutine", statnames[status]);
+            return CO_STATUS_ERROR;
+        }
+    }
+
+    if (narg)
+    {
+        if (!lua_checkstack(co, narg))
+            luaL_error(L, "too many arguments to resume");
+        lua_xmove(L, co, narg);
+    }
+
+    co->singlestep = L->singlestep;
+
+    int status = lua_resume(co, L, narg);
+    if (status == 0 || status == LUA_YIELD)
+    {
+        int nres = cast_int(co->top - co->base);
+        if (nres)
+        {
+            // +1 accounts for true/false status in resumefinish
+            if (nres + 1 > LUA_MINSTACK && !lua_checkstack(L, nres + 1))
+                luaL_error(L, "too many results to resume");
+            lua_xmove(co, L, nres); // move yielded values
+        }
+        return nres;
+    }
+    else if (status == LUA_BREAK)
+    {
+        return CO_STATUS_BREAK;
+    }
+    else
+    {
+        lua_xmove(co, L, 1); // move error message
+        return CO_STATUS_ERROR;
+    }
+}
+
+static int interruptThread(lua_State* L, lua_State* co)
+{
+    // notify the debugger that the thread was suspended
+    if (L->global->cb.debuginterrupt)
+        luau_callhook(L, L->global->cb.debuginterrupt, co);
+
+    return lua_break(L);
+}
+
+static int auxresumecont(lua_State* L, lua_State* co)
+{
+    if (co->status == 0 || co->status == LUA_YIELD)
+    {
+        int nres = cast_int(co->top - co->base);
+        if (!lua_checkstack(L, nres + 1))
+            luaL_error(L, "too many results to resume");
+        lua_xmove(co, L, nres); // move yielded values
+        return nres;
+    }
+    else
+    {
+        lua_rawcheckstack(L, 2);
+        lua_xmove(co, L, 1); // move error message
+        return CO_STATUS_ERROR;
+    }
+}
+
+static int coresumefinish(lua_State* L, int r)
+{
+    if (r < 0)
+    {
+        lua_pushboolean(L, 0);
+        lua_insert(L, -2);
+        return 2; // return false + error message
+    }
+    else
+    {
+        lua_pushboolean(L, 1);
+        lua_insert(L, -(r + 1));
+        return r + 1; // return true + `resume' returns
+    }
+}
+
+static int coresumey(lua_State* L)
+{
+    lua_State* co = lua_tothread(L, 1);
+    luaL_argexpected(L, co, 1, "thread");
+    int narg = cast_int(L->top - L->base) - 1;
+    int r = auxresume(L, co, narg);
+
+    if (r == CO_STATUS_BREAK)
+        return interruptThread(L, co);
+
+    return coresumefinish(L, r);
+}
+
+static int coresumecont(lua_State* L, int status)
+{
+    lua_State* co = lua_tothread(L, 1);
+    luaL_argexpected(L, co, 1, "thread");
+
+    // if coroutine still hasn't yielded after the break, break current thread again
+    if (co->status == LUA_BREAK)
+        return interruptThread(L, co);
+
+    int r = auxresumecont(L, co);
+
+    return coresumefinish(L, r);
+}
+
+static int auxwrapfinish(lua_State* L, int r)
+{
+    if (r < 0)
+    {
+        if (lua_isstring(L, -1))
+        {                     // error object is a string?
+            luaL_where(L, 1); // add extra info
+            lua_insert(L, -2);
+            lua_concat(L, 2);
+        }
+        lua_error(L); // propagate error
+    }
+    return r;
+}
+
+static int auxwrapy(lua_State* L)
+{
+    lua_State* co = lua_tothread(L, lua_upvalueindex(1));
+    int narg = cast_int(L->top - L->base);
+    int r = auxresume(L, co, narg);
+
+    if (r == CO_STATUS_BREAK)
+        return interruptThread(L, co);
+
+    return auxwrapfinish(L, r);
+}
+
+static int auxwrapcont(lua_State* L, int status)
+{
+    lua_State* co = lua_tothread(L, lua_upvalueindex(1));
+
+    // if coroutine still hasn't yielded after the break, break current thread again
+    if (co->status == LUA_BREAK)
+        return interruptThread(L, co);
+
+    int r = auxresumecont(L, co);
+
+    return auxwrapfinish(L, r);
+}
+
+static int cocreate(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+    lua_State* NL = lua_newthread(L);
+    lua_xpush(L, NL, 1); // push function on top of NL
+    return 1;
+}
+
+static int cowrap(lua_State* L)
+{
+    cocreate(L);
+
+    lua_pushcclosurek(L, auxwrapy, NULL, 1, auxwrapcont);
+    return 1;
+}
+
+static int coyield(lua_State* L)
+{
+    int nres = cast_int(L->top - L->base);
+    return lua_yield(L, nres);
+}
+
+static int corunning(lua_State* L)
+{
+    if (lua_pushthread(L))
+        lua_pushnil(L); // main thread is not a coroutine
+    return 1;
+}
+
+static int coyieldable(lua_State* L)
+{
+    lua_pushboolean(L, lua_isyieldable(L));
+    return 1;
+}
+
+static int coclose(lua_State* L)
+{
+    lua_State* co = lua_tothread(L, 1);
+    luaL_argexpected(L, co, 1, "thread");
+
+    int status = lua_costatus(L, co);
+    if (status != LUA_COFIN && status != LUA_COERR && status != LUA_COSUS)
+        luaL_error(L, "cannot close %s coroutine", statnames[status]);
+
+    if (co->status == LUA_OK || co->status == LUA_YIELD)
+    {
+        lua_pushboolean(L, true);
+        lua_resetthread(co);
+        return 1;
+    }
+    else
+    {
+        lua_pushboolean(L, false);
+        if (lua_gettop(co))
+            lua_xmove(co, L, 1); // move error message
+        lua_resetthread(co);
+        return 2;
+    }
+}
+
+static const luaL_Reg co_funcs[] = {
+    {"create", cocreate},
+    {"running", corunning},
+    {"status", costatus},
+    {"wrap", cowrap},
+    {"yield", coyield},
+    {"isyieldable", coyieldable},
+    {"close", coclose},
+    {NULL, NULL},
+};
+
+int luaopen_coroutine(lua_State* L)
+{
+    luaL_register(L, LUA_COLIBNAME, co_funcs);
+
+    lua_pushcclosurek(L, coresumey, "resume", 0, coresumecont);
+    lua_setfield(L, -2, "resume");
+
+    return 1;
+}

--- a/lib/luau/VM/src/ldblib.cpp
+++ b/lib/luau/VM/src/ldblib.cpp
@@ -1,0 +1,166 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lvm.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static lua_State* getthread(lua_State* L, int* arg)
+{
+    if (lua_isthread(L, 1))
+    {
+        *arg = 1;
+        return lua_tothread(L, 1);
+    }
+    else
+    {
+        *arg = 0;
+        return L;
+    }
+}
+
+static int db_info(lua_State* L)
+{
+    int arg;
+    lua_State* L1 = getthread(L, &arg);
+
+    // If L1 != L, L1 can be in any state, and therefore there are no guarantees about its stack space
+    if (L != L1)
+        lua_rawcheckstack(L1, 1); // for 'f' option
+
+    int level;
+    if (lua_isnumber(L, arg + 1))
+    {
+        level = (int)lua_tointeger(L, arg + 1);
+        luaL_argcheck(L, level >= 0, arg + 1, "level can't be negative");
+    }
+    else if (arg == 0 && lua_isfunction(L, 1))
+    {
+        // convert absolute index to relative index
+        level = -lua_gettop(L);
+    }
+    else
+        luaL_argerror(L, arg + 1, "function or level expected");
+
+    const char* options = luaL_checkstring(L, arg + 2);
+
+    lua_Debug ar;
+    if (!lua_getinfo(L1, level, options, &ar))
+        return 0;
+
+    int results = 0;
+    bool occurs[26] = {};
+
+    for (const char* it = options; *it; ++it)
+    {
+        if (unsigned(*it - 'a') < 26)
+        {
+            if (occurs[*it - 'a'])
+                luaL_argerror(L, arg + 2, "duplicate option");
+            occurs[*it - 'a'] = true;
+        }
+
+        switch (*it)
+        {
+        case 's':
+            lua_pushstring(L, ar.short_src);
+            results++;
+            break;
+
+        case 'l':
+            lua_pushinteger(L, ar.currentline);
+            results++;
+            break;
+
+        case 'n':
+            lua_pushstring(L, ar.name ? ar.name : "");
+            results++;
+            break;
+
+        case 'f':
+            if (L1 == L)
+                lua_pushvalue(L, -1 - results); // function is right before results
+            else
+                lua_xmove(L1, L, 1); // function is at top of L1
+            results++;
+            break;
+
+        case 'a':
+            lua_pushinteger(L, ar.nparams);
+            lua_pushboolean(L, ar.isvararg);
+            results += 2;
+            break;
+
+        default:
+            luaL_argerror(L, arg + 2, "invalid option");
+        }
+    }
+
+    return results;
+}
+
+static int db_traceback(lua_State* L)
+{
+    int arg;
+    lua_State* L1 = getthread(L, &arg);
+    const char* msg = luaL_optstring(L, arg + 1, NULL);
+    int level = luaL_optinteger(L, arg + 2, (L == L1) ? 1 : 0);
+    luaL_argcheck(L, level >= 0, arg + 2, "level can't be negative");
+
+    luaL_Strbuf buf;
+    luaL_buffinit(L, &buf);
+
+    if (msg)
+    {
+        luaL_addstring(&buf, msg);
+        luaL_addstring(&buf, "\n");
+    }
+
+    lua_Debug ar;
+    for (int i = level; lua_getinfo(L1, i, "sln", &ar); ++i)
+    {
+        if (strcmp(ar.what, "C") == 0)
+            continue;
+
+        if (ar.source)
+            luaL_addstring(&buf, ar.short_src);
+
+        if (ar.currentline > 0)
+        {
+            char line[32]; // manual conversion for performance
+            char* lineend = line + sizeof(line);
+            char* lineptr = lineend;
+            for (unsigned int r = ar.currentline; r > 0; r /= 10)
+                *--lineptr = '0' + (r % 10);
+
+            luaL_addchar(&buf, ':');
+            luaL_addlstring(&buf, lineptr, lineend - lineptr);
+        }
+
+        if (ar.name)
+        {
+            luaL_addstring(&buf, " function ");
+            luaL_addstring(&buf, ar.name);
+        }
+
+        luaL_addchar(&buf, '\n');
+    }
+
+    luaL_pushresult(&buf);
+    return 1;
+}
+
+static const luaL_Reg dblib[] = {
+    {"info", db_info},
+    {"traceback", db_traceback},
+    {NULL, NULL},
+};
+
+int luaopen_debug(lua_State* L)
+{
+    luaL_register(L, LUA_DBLIBNAME, dblib);
+    return 1;
+}

--- a/lib/luau/VM/src/ldebug.cpp
+++ b/lib/luau/VM/src/ldebug.cpp
@@ -1,0 +1,582 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "ldebug.h"
+
+#include "lapi.h"
+#include "lfunc.h"
+#include "lmem.h"
+#include "lgc.h"
+#include "ldo.h"
+#include "lbytecode.h"
+
+#include <string.h>
+#include <stdio.h>
+
+static const char* getfuncname(Closure* f);
+
+static int currentpc(lua_State* L, CallInfo* ci)
+{
+    return pcRel(ci->savedpc, ci_func(ci)->l.p);
+}
+
+static int currentline(lua_State* L, CallInfo* ci)
+{
+    return luaG_getline(ci_func(ci)->l.p, currentpc(L, ci));
+}
+
+static Proto* getluaproto(CallInfo* ci)
+{
+    return (isLua(ci) ? cast_to(Proto*, ci_func(ci)->l.p) : NULL);
+}
+
+int lua_getargument(lua_State* L, int level, int n)
+{
+    if (unsigned(level) >= unsigned(L->ci - L->base_ci))
+        return 0;
+
+    CallInfo* ci = L->ci - level;
+    // changing tables in native functions externally may invalidate safety contracts wrt table state (metatable/size/readonly)
+    if (ci->flags & LUA_CALLINFO_NATIVE)
+        return 0;
+
+    Proto* fp = getluaproto(ci);
+    int res = 0;
+
+    if (fp && n > 0)
+    {
+        if (n <= fp->numparams)
+        {
+            luaC_threadbarrier(L);
+            luaA_pushobject(L, ci->base + (n - 1));
+            res = 1;
+        }
+        else if (fp->is_vararg && n < ci->base - ci->func)
+        {
+            luaC_threadbarrier(L);
+            luaA_pushobject(L, ci->func + n);
+            res = 1;
+        }
+    }
+
+    return res;
+}
+
+const char* lua_getlocal(lua_State* L, int level, int n)
+{
+    if (unsigned(level) >= unsigned(L->ci - L->base_ci))
+        return NULL;
+
+    CallInfo* ci = L->ci - level;
+    // changing tables in native functions externally may invalidate safety contracts wrt table state (metatable/size/readonly)
+    if (ci->flags & LUA_CALLINFO_NATIVE)
+        return NULL;
+
+    Proto* fp = getluaproto(ci);
+    const LocVar* var = fp ? luaF_getlocal(fp, n, currentpc(L, ci)) : NULL;
+    if (var)
+    {
+        luaC_threadbarrier(L);
+        luaA_pushobject(L, ci->base + var->reg);
+    }
+    const char* name = var ? getstr(var->varname) : NULL;
+    return name;
+}
+
+const char* lua_setlocal(lua_State* L, int level, int n)
+{
+    if (unsigned(level) >= unsigned(L->ci - L->base_ci))
+        return NULL;
+
+    CallInfo* ci = L->ci - level;
+    // changing registers in native functions externally may invalidate safety contracts wrt register type tags
+    if (ci->flags & LUA_CALLINFO_NATIVE)
+        return NULL;
+
+    Proto* fp = getluaproto(ci);
+    const LocVar* var = fp ? luaF_getlocal(fp, n, currentpc(L, ci)) : NULL;
+    if (var)
+        setobj2s(L, ci->base + var->reg, L->top - 1);
+    L->top--; // pop value
+    const char* name = var ? getstr(var->varname) : NULL;
+    return name;
+}
+
+static Closure* auxgetinfo(lua_State* L, const char* what, lua_Debug* ar, Closure* f, CallInfo* ci)
+{
+    Closure* cl = NULL;
+    for (; *what; what++)
+    {
+        switch (*what)
+        {
+        case 's':
+        {
+            if (f->isC)
+            {
+                ar->source = "=[C]";
+                ar->what = "C";
+                ar->linedefined = -1;
+                ar->short_src = "[C]";
+            }
+            else
+            {
+                TString* source = f->l.p->source;
+                ar->source = getstr(source);
+                ar->what = "Lua";
+                ar->linedefined = f->l.p->linedefined;
+                ar->short_src = luaO_chunkid(ar->ssbuf, sizeof(ar->ssbuf), getstr(source), source->len);
+            }
+            break;
+        }
+        case 'l':
+        {
+            if (ci)
+            {
+                ar->currentline = isLua(ci) ? currentline(L, ci) : -1;
+            }
+            else
+            {
+                ar->currentline = f->isC ? -1 : f->l.p->linedefined;
+            }
+
+            break;
+        }
+        case 'u':
+        {
+            ar->nupvals = f->nupvalues;
+            break;
+        }
+        case 'a':
+        {
+            if (f->isC)
+            {
+                ar->isvararg = 1;
+                ar->nparams = 0;
+            }
+            else
+            {
+                ar->isvararg = f->l.p->is_vararg;
+                ar->nparams = f->l.p->numparams;
+            }
+            break;
+        }
+        case 'n':
+        {
+            ar->name = ci ? getfuncname(ci_func(ci)) : getfuncname(f);
+            break;
+        }
+        case 'f':
+        {
+            cl = f;
+            break;
+        }
+        default:;
+        }
+    }
+    return cl;
+}
+
+int lua_stackdepth(lua_State* L)
+{
+    return int(L->ci - L->base_ci);
+}
+
+int lua_getinfo(lua_State* L, int level, const char* what, lua_Debug* ar)
+{
+    Closure* f = NULL;
+    CallInfo* ci = NULL;
+    if (level < 0)
+    {
+        const TValue* func = luaA_toobject(L, level);
+        api_check(L, ttisfunction(func));
+        f = clvalue(func);
+    }
+    else if (unsigned(level) < unsigned(L->ci - L->base_ci))
+    {
+        ci = L->ci - level;
+        LUAU_ASSERT(ttisfunction(ci->func));
+        f = clvalue(ci->func);
+    }
+    if (f)
+    {
+        // auxgetinfo fills ar and optionally requests to put closure on stack
+        if (Closure* fcl = auxgetinfo(L, what, ar, f, ci))
+        {
+            luaC_threadbarrier(L);
+            setclvalue(L, L->top, fcl);
+            incr_top(L);
+        }
+    }
+    return f ? 1 : 0;
+}
+
+static const char* getfuncname(Closure* cl)
+{
+    if (cl->isC)
+    {
+        if (cl->c.debugname)
+        {
+            return cl->c.debugname;
+        }
+    }
+    else
+    {
+        Proto* p = cl->l.p;
+
+        if (p->debugname)
+        {
+            return getstr(p->debugname);
+        }
+    }
+    return nullptr;
+}
+
+l_noret luaG_typeerrorL(lua_State* L, const TValue* o, const char* op)
+{
+    const char* t = luaT_objtypename(L, o);
+
+    luaG_runerror(L, "attempt to %s a %s value", op, t);
+}
+
+l_noret luaG_forerrorL(lua_State* L, const TValue* o, const char* what)
+{
+    const char* t = luaT_objtypename(L, o);
+
+    luaG_runerror(L, "invalid 'for' %s (number expected, got %s)", what, t);
+}
+
+l_noret luaG_concaterror(lua_State* L, StkId p1, StkId p2)
+{
+    const char* t1 = luaT_objtypename(L, p1);
+    const char* t2 = luaT_objtypename(L, p2);
+
+    luaG_runerror(L, "attempt to concatenate %s with %s", t1, t2);
+}
+
+l_noret luaG_aritherror(lua_State* L, const TValue* p1, const TValue* p2, TMS op)
+{
+    const char* t1 = luaT_objtypename(L, p1);
+    const char* t2 = luaT_objtypename(L, p2);
+    const char* opname = luaT_eventname[op] + 2; // skip __ from metamethod name
+
+    if (t1 == t2)
+        luaG_runerror(L, "attempt to perform arithmetic (%s) on %s", opname, t1);
+    else
+        luaG_runerror(L, "attempt to perform arithmetic (%s) on %s and %s", opname, t1, t2);
+}
+
+l_noret luaG_ordererror(lua_State* L, const TValue* p1, const TValue* p2, TMS op)
+{
+    const char* t1 = luaT_objtypename(L, p1);
+    const char* t2 = luaT_objtypename(L, p2);
+    const char* opname = (op == TM_LT) ? "<" : (op == TM_LE) ? "<=" : "==";
+
+    luaG_runerror(L, "attempt to compare %s %s %s", t1, opname, t2);
+}
+
+l_noret luaG_indexerror(lua_State* L, const TValue* p1, const TValue* p2)
+{
+    const char* t1 = luaT_objtypename(L, p1);
+    const char* t2 = luaT_objtypename(L, p2);
+    const TString* key = ttisstring(p2) ? tsvalue(p2) : 0;
+
+    if (key && key->len <= 64) // limit length to make sure we don't generate very long error messages for very long keys
+        luaG_runerror(L, "attempt to index %s with '%s'", t1, getstr(key));
+    else
+        luaG_runerror(L, "attempt to index %s with %s", t1, t2);
+}
+
+l_noret luaG_methoderror(lua_State* L, const TValue* p1, const TString* p2)
+{
+    const char* t1 = luaT_objtypename(L, p1);
+
+    luaG_runerror(L, "attempt to call missing method '%s' of %s", getstr(p2), t1);
+}
+
+l_noret luaG_readonlyerror(lua_State* L)
+{
+    luaG_runerror(L, "attempt to modify a readonly table");
+}
+
+static void pusherror(lua_State* L, const char* msg)
+{
+    CallInfo* ci = L->ci;
+    if (isLua(ci))
+    {
+        TString* source = getluaproto(ci)->source;
+        char chunkbuf[LUA_IDSIZE]; // add file:line information
+        const char* chunkid = luaO_chunkid(chunkbuf, sizeof(chunkbuf), getstr(source), source->len);
+        int line = currentline(L, ci);
+        luaO_pushfstring(L, "%s:%d: %s", chunkid, line, msg);
+    }
+    else
+    {
+        lua_pushstring(L, msg);
+    }
+}
+
+l_noret luaG_runerrorL(lua_State* L, const char* fmt, ...)
+{
+    va_list argp;
+    va_start(argp, fmt);
+    char result[LUA_BUFFERSIZE];
+    vsnprintf(result, sizeof(result), fmt, argp);
+    va_end(argp);
+
+    pusherror(L, result);
+    luaD_throw(L, LUA_ERRRUN);
+}
+
+void luaG_pusherror(lua_State* L, const char* error)
+{
+    pusherror(L, error);
+}
+
+void luaG_breakpoint(lua_State* L, Proto* p, int line, bool enable)
+{
+    // since native code doesn't support breakpoints, we would need to update all call frames with LUAU_CALLINFO_NATIVE that refer to p
+    if (p->lineinfo && !p->execdata)
+    {
+        for (int i = 0; i < p->sizecode; ++i)
+        {
+            // note: we keep prologue as is, instead opting to break at the first meaningful instruction
+            if (LUAU_INSN_OP(p->code[i]) == LOP_PREPVARARGS)
+                continue;
+
+            if (luaG_getline(p, i) != line)
+                continue;
+
+            // lazy copy of the original opcode array; done when the first breakpoint is set
+            if (!p->debuginsn)
+            {
+                p->debuginsn = luaM_newarray(L, p->sizecode, uint8_t, p->memcat);
+                for (int j = 0; j < p->sizecode; ++j)
+                    p->debuginsn[j] = LUAU_INSN_OP(p->code[j]);
+            }
+
+            uint8_t op = enable ? LOP_BREAK : LUAU_INSN_OP(p->debuginsn[i]);
+
+            // patch just the opcode byte, leave arguments alone
+            p->code[i] &= ~0xff;
+            p->code[i] |= op;
+            LUAU_ASSERT(LUAU_INSN_OP(p->code[i]) == op);
+
+            // note: this is important!
+            // we only patch the *first* instruction in each proto that's attributed to a given line
+            // this can be changed, but if requires making patching a bit more nuanced so that we don't patch AUX words
+            break;
+        }
+    }
+
+    for (int i = 0; i < p->sizep; ++i)
+    {
+        luaG_breakpoint(L, p->p[i], line, enable);
+    }
+}
+
+bool luaG_onbreak(lua_State* L)
+{
+    if (L->ci == L->base_ci)
+        return false;
+
+    if (!isLua(L->ci))
+        return false;
+
+    return LUAU_INSN_OP(*L->ci->savedpc) == LOP_BREAK;
+}
+
+int luaG_getline(Proto* p, int pc)
+{
+    LUAU_ASSERT(pc >= 0 && pc < p->sizecode);
+
+    if (!p->lineinfo)
+        return 0;
+
+    return p->abslineinfo[pc >> p->linegaplog2] + p->lineinfo[pc];
+}
+
+int luaG_isnative(lua_State* L, int level)
+{
+    if (unsigned(level) >= unsigned(L->ci - L->base_ci))
+        return 0;
+
+    CallInfo* ci = L->ci - level;
+    return (ci->flags & LUA_CALLINFO_NATIVE) != 0 ? 1 : 0;
+}
+
+void lua_singlestep(lua_State* L, int enabled)
+{
+    L->singlestep = bool(enabled);
+}
+
+static int getmaxline(Proto* p)
+{
+    int result = -1;
+
+    for (int i = 0; i < p->sizecode; ++i)
+    {
+        int line = luaG_getline(p, i);
+        result = result < line ? line : result;
+    }
+
+    for (int i = 0; i < p->sizep; ++i)
+    {
+        int psize = getmaxline(p->p[i]);
+        result = result < psize ? psize : result;
+    }
+
+    return result;
+}
+
+// Find the line number with instructions. If the provided line doesn't have any instruction, it should return the next valid line number.
+static int getnextline(Proto* p, int line)
+{
+    int closest = -1;
+
+    if (p->lineinfo)
+    {
+        for (int i = 0; i < p->sizecode; ++i)
+        {
+            // note: we keep prologue as is, instead opting to break at the first meaningful instruction
+            if (LUAU_INSN_OP(p->code[i]) == LOP_PREPVARARGS)
+                continue;
+
+            int candidate = luaG_getline(p, i);
+
+            if (candidate == line)
+                return line;
+
+            if (candidate > line && (closest == -1 || candidate < closest))
+                closest = candidate;
+        }
+    }
+
+    for (int i = 0; i < p->sizep; ++i)
+    {
+        int candidate = getnextline(p->p[i], line);
+
+        if (candidate == line)
+            return line;
+
+        if (candidate > line && (closest == -1 || candidate < closest))
+            closest = candidate;
+    }
+
+    return closest;
+}
+
+int lua_breakpoint(lua_State* L, int funcindex, int line, int enabled)
+{
+    const TValue* func = luaA_toobject(L, funcindex);
+    api_check(L, ttisfunction(func) && !clvalue(func)->isC);
+
+    Proto* p = clvalue(func)->l.p;
+
+    // set the breakpoint to the next closest line with valid instructions
+    int target = getnextline(p, line);
+
+    if (target != -1)
+        luaG_breakpoint(L, p, target, bool(enabled));
+
+    return target;
+}
+
+static void getcoverage(Proto* p, int depth, int* buffer, size_t size, void* context, lua_Coverage callback)
+{
+    memset(buffer, -1, size * sizeof(int));
+
+    for (int i = 0; i < p->sizecode; ++i)
+    {
+        Instruction insn = p->code[i];
+        if (LUAU_INSN_OP(insn) != LOP_COVERAGE)
+            continue;
+
+        int line = luaG_getline(p, i);
+        int hits = LUAU_INSN_E(insn);
+
+        LUAU_ASSERT(size_t(line) < size);
+        buffer[line] = buffer[line] < hits ? hits : buffer[line];
+    }
+
+    const char* debugname = p->debugname ? getstr(p->debugname) : NULL;
+    int linedefined = p->linedefined;
+
+    callback(context, debugname, linedefined, depth, buffer, size);
+
+    for (int i = 0; i < p->sizep; ++i)
+        getcoverage(p->p[i], depth + 1, buffer, size, context, callback);
+}
+
+void lua_getcoverage(lua_State* L, int funcindex, void* context, lua_Coverage callback)
+{
+    const TValue* func = luaA_toobject(L, funcindex);
+    api_check(L, ttisfunction(func) && !clvalue(func)->isC);
+
+    Proto* p = clvalue(func)->l.p;
+
+    size_t size = getmaxline(p) + 1;
+    if (size == 0)
+        return;
+
+    int* buffer = luaM_newarray(L, size, int, 0);
+
+    getcoverage(p, 0, buffer, size, context, callback);
+
+    luaM_freearray(L, buffer, size, int, 0);
+}
+
+static size_t append(char* buf, size_t bufsize, size_t offset, const char* data)
+{
+    size_t size = strlen(data);
+    size_t copy = offset + size >= bufsize ? bufsize - offset - 1 : size;
+    memcpy(buf + offset, data, copy);
+    return offset + copy;
+}
+
+const char* lua_debugtrace(lua_State* L)
+{
+    static char buf[4096];
+
+    const int limit1 = 10;
+    const int limit2 = 10;
+
+    int depth = int(L->ci - L->base_ci);
+    size_t offset = 0;
+
+    lua_Debug ar;
+    for (int level = 0; lua_getinfo(L, level, "sln", &ar); ++level)
+    {
+        if (ar.source)
+            offset = append(buf, sizeof(buf), offset, ar.short_src);
+
+        if (ar.currentline > 0)
+        {
+            char line[32];
+            snprintf(line, sizeof(line), ":%d", ar.currentline);
+
+            offset = append(buf, sizeof(buf), offset, line);
+        }
+
+        if (ar.name)
+        {
+            offset = append(buf, sizeof(buf), offset, " function ");
+            offset = append(buf, sizeof(buf), offset, ar.name);
+        }
+
+        offset = append(buf, sizeof(buf), offset, "\n");
+
+        if (depth > limit1 + limit2 && level == limit1 - 1)
+        {
+            char skip[32];
+            snprintf(skip, sizeof(skip), "... (+%d frames)\n", int(depth - limit1 - limit2));
+
+            offset = append(buf, sizeof(buf), offset, skip);
+
+            level = depth - limit2 - 1;
+        }
+    }
+
+    LUAU_ASSERT(offset < sizeof(buf));
+    buf[offset] = '\0';
+
+    return buf;
+}

--- a/lib/luau/VM/src/ldebug.h
+++ b/lib/luau/VM/src/ldebug.h
@@ -1,0 +1,33 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lstate.h"
+
+#define pcRel(pc, p) ((pc) ? cast_to(int, (pc) - (p)->code) - 1 : 0)
+
+#define luaG_typeerror(L, o, opname) luaG_typeerrorL(L, o, opname)
+#define luaG_forerror(L, o, what) luaG_forerrorL(L, o, what)
+#define luaG_runerror(L, fmt, ...) luaG_runerrorL(L, fmt, ##__VA_ARGS__)
+
+#define LUA_MEMERRMSG "not enough memory"
+#define LUA_ERRERRMSG "error in error handling"
+
+LUAI_FUNC l_noret luaG_typeerrorL(lua_State* L, const TValue* o, const char* opname);
+LUAI_FUNC l_noret luaG_forerrorL(lua_State* L, const TValue* o, const char* what);
+LUAI_FUNC l_noret luaG_concaterror(lua_State* L, StkId p1, StkId p2);
+LUAI_FUNC l_noret luaG_aritherror(lua_State* L, const TValue* p1, const TValue* p2, TMS op);
+LUAI_FUNC l_noret luaG_ordererror(lua_State* L, const TValue* p1, const TValue* p2, TMS op);
+LUAI_FUNC l_noret luaG_indexerror(lua_State* L, const TValue* p1, const TValue* p2);
+LUAI_FUNC l_noret luaG_methoderror(lua_State* L, const TValue* p1, const TString* p2);
+LUAI_FUNC l_noret luaG_readonlyerror(lua_State* L);
+
+LUAI_FUNC LUA_PRINTF_ATTR(2, 3) l_noret luaG_runerrorL(lua_State* L, const char* fmt, ...);
+LUAI_FUNC void luaG_pusherror(lua_State* L, const char* error);
+
+LUAI_FUNC void luaG_breakpoint(lua_State* L, Proto* p, int line, bool enable);
+LUAI_FUNC bool luaG_onbreak(lua_State* L);
+
+LUAI_FUNC int luaG_getline(Proto* p, int pc);
+
+LUAI_FUNC int luaG_isnative(lua_State* L, int level);

--- a/lib/luau/VM/src/ldo.cpp
+++ b/lib/luau/VM/src/ldo.cpp
@@ -1,0 +1,602 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "ldo.h"
+
+#include "lstring.h"
+#include "lfunc.h"
+#include "lgc.h"
+#include "lmem.h"
+#include "lvm.h"
+
+#if LUA_USE_LONGJMP
+#include <setjmp.h>
+#include <stdlib.h>
+#else
+#include <stdexcept>
+#endif
+
+#include <string.h>
+
+/*
+** {======================================================
+** Error-recovery functions
+** =======================================================
+*/
+
+#if LUA_USE_LONGJMP
+struct lua_jmpbuf
+{
+    lua_jmpbuf* volatile prev;
+    volatile int status;
+    jmp_buf buf;
+};
+
+// use POSIX versions of setjmp/longjmp if possible: they don't save/restore signal mask and are therefore faster
+#if defined(__linux__) || defined(__APPLE__)
+#define LUAU_SETJMP(buf) _setjmp(buf)
+#define LUAU_LONGJMP(buf, code) _longjmp(buf, code)
+#else
+#define LUAU_SETJMP(buf) setjmp(buf)
+#define LUAU_LONGJMP(buf, code) longjmp(buf, code)
+#endif
+
+int luaD_rawrunprotected(lua_State* L, Pfunc f, void* ud)
+{
+    lua_jmpbuf jb;
+    jb.prev = L->global->errorjmp;
+    jb.status = 0;
+    L->global->errorjmp = &jb;
+
+    if (LUAU_SETJMP(jb.buf) == 0)
+        f(L, ud);
+
+    L->global->errorjmp = jb.prev;
+    return jb.status;
+}
+
+l_noret luaD_throw(lua_State* L, int errcode)
+{
+    if (lua_jmpbuf* jb = L->global->errorjmp)
+    {
+        jb->status = errcode;
+        LUAU_LONGJMP(jb->buf, 1);
+    }
+
+    if (L->global->cb.panic)
+        L->global->cb.panic(L, errcode);
+
+    abort();
+}
+#else
+class lua_exception : public std::exception
+{
+public:
+    lua_exception(lua_State* L, int status)
+        : L(L)
+        , status(status)
+    {
+    }
+
+    const char* what() const throw() override
+    {
+        // LUA_ERRRUN passes error object on the stack
+        if (status == LUA_ERRRUN)
+            if (const char* str = lua_tostring(L, -1))
+                return str;
+
+        switch (status)
+        {
+        case LUA_ERRRUN:
+            return "lua_exception: runtime error";
+        case LUA_ERRSYNTAX:
+            return "lua_exception: syntax error";
+        case LUA_ERRMEM:
+            return "lua_exception: " LUA_MEMERRMSG;
+        case LUA_ERRERR:
+            return "lua_exception: " LUA_ERRERRMSG;
+        default:
+            return "lua_exception: unexpected exception status";
+        }
+    }
+
+    int getStatus() const
+    {
+        return status;
+    }
+
+private:
+    lua_State* L;
+    int status;
+};
+
+int luaD_rawrunprotected(lua_State* L, Pfunc f, void* ud)
+{
+    int status = 0;
+
+    try
+    {
+        f(L, ud);
+        return 0;
+    }
+    catch (lua_exception& e)
+    {
+        // lua_exception means that luaD_throw was called and an exception object is on stack if status is ERRRUN
+        status = e.getStatus();
+    }
+    catch (std::exception& e)
+    {
+        // Luau will never throw this, but this can catch exceptions that escape from C++ implementations of external functions
+        try
+        {
+            // there's no exception object on stack; let's push the error on stack so that error handling below can proceed
+            luaG_pusherror(L, e.what());
+            status = LUA_ERRRUN;
+        }
+        catch (std::exception&)
+        {
+            // out of memory while allocating error string
+            status = LUA_ERRMEM;
+        }
+    }
+
+    return status;
+}
+
+l_noret luaD_throw(lua_State* L, int errcode)
+{
+    throw lua_exception(L, errcode);
+}
+#endif
+
+// }======================================================
+
+static void correctstack(lua_State* L, TValue* oldstack)
+{
+    L->top = (L->top - oldstack) + L->stack;
+    for (UpVal* up = L->openupval; up != NULL; up = up->u.open.threadnext)
+        up->v = (up->v - oldstack) + L->stack;
+    for (CallInfo* ci = L->base_ci; ci <= L->ci; ci++)
+    {
+        ci->top = (ci->top - oldstack) + L->stack;
+        ci->base = (ci->base - oldstack) + L->stack;
+        ci->func = (ci->func - oldstack) + L->stack;
+    }
+    L->base = (L->base - oldstack) + L->stack;
+}
+
+void luaD_reallocstack(lua_State* L, int newsize)
+{
+    TValue* oldstack = L->stack;
+    int realsize = newsize + EXTRA_STACK;
+    LUAU_ASSERT(L->stack_last - L->stack == L->stacksize - EXTRA_STACK);
+    luaM_reallocarray(L, L->stack, L->stacksize, realsize, TValue, L->memcat);
+    TValue* newstack = L->stack;
+    for (int i = L->stacksize; i < realsize; i++)
+        setnilvalue(newstack + i); // erase new segment
+    L->stacksize = realsize;
+    L->stack_last = newstack + newsize;
+    correctstack(L, oldstack);
+}
+
+void luaD_reallocCI(lua_State* L, int newsize)
+{
+    CallInfo* oldci = L->base_ci;
+    luaM_reallocarray(L, L->base_ci, L->size_ci, newsize, CallInfo, L->memcat);
+    L->size_ci = newsize;
+    L->ci = (L->ci - oldci) + L->base_ci;
+    L->end_ci = L->base_ci + L->size_ci - 1;
+}
+
+void luaD_growstack(lua_State* L, int n)
+{
+    if (n <= L->stacksize) // double size is enough?
+        luaD_reallocstack(L, 2 * L->stacksize);
+    else
+        luaD_reallocstack(L, L->stacksize + n);
+}
+
+CallInfo* luaD_growCI(lua_State* L)
+{
+    // allow extra stack space to handle stack overflow in xpcall
+    const int hardlimit = LUAI_MAXCALLS + (LUAI_MAXCALLS >> 3);
+
+    if (L->size_ci >= hardlimit)
+        luaD_throw(L, LUA_ERRERR); // error while handling stack error
+
+    int request = L->size_ci * 2;
+    luaD_reallocCI(L, L->size_ci >= LUAI_MAXCALLS ? hardlimit : request < LUAI_MAXCALLS ? request : LUAI_MAXCALLS);
+
+    if (L->size_ci > LUAI_MAXCALLS)
+        luaG_runerror(L, "stack overflow");
+
+    return ++L->ci;
+}
+
+void luaD_checkCstack(lua_State* L)
+{
+    // allow extra stack space to handle stack overflow in xpcall
+    const int hardlimit = LUAI_MAXCCALLS + (LUAI_MAXCCALLS >> 3);
+
+    if (L->nCcalls == LUAI_MAXCCALLS)
+        luaG_runerror(L, "C stack overflow");
+    else if (L->nCcalls >= hardlimit)
+        luaD_throw(L, LUA_ERRERR); // error while handling stack error
+}
+
+/*
+** Call a function (C or Lua). The function to be called is at *func.
+** The arguments are on the stack, right after the function.
+** When returns, all the results are on the stack, starting at the original
+** function position.
+*/
+void luaD_call(lua_State* L, StkId func, int nresults)
+{
+    if (++L->nCcalls >= LUAI_MAXCCALLS)
+        luaD_checkCstack(L);
+
+    ptrdiff_t old_func = savestack(L, func);
+
+    if (luau_precall(L, func, nresults) == PCRLUA)
+    {                                        // is a Lua function?
+        L->ci->flags |= LUA_CALLINFO_RETURN; // luau_execute will stop after returning from the stack frame
+
+        bool oldactive = L->isactive;
+        L->isactive = true;
+        luaC_threadbarrier(L);
+
+        luau_execute(L); // call it
+
+        if (!oldactive)
+            L->isactive = false;
+    }
+
+    if (nresults != LUA_MULTRET)
+        L->top = restorestack(L, old_func) + nresults;
+
+    L->nCcalls--;
+    luaC_checkGC(L);
+}
+
+static void seterrorobj(lua_State* L, int errcode, StkId oldtop)
+{
+    switch (errcode)
+    {
+    case LUA_ERRMEM:
+    {
+        setsvalue(L, oldtop, luaS_newliteral(L, LUA_MEMERRMSG)); // can not fail because string is pinned in luaopen
+        break;
+    }
+    case LUA_ERRERR:
+    {
+        setsvalue(L, oldtop, luaS_newliteral(L, LUA_ERRERRMSG)); // can not fail because string is pinned in luaopen
+        break;
+    }
+    case LUA_ERRSYNTAX:
+    case LUA_ERRRUN:
+    {
+        setobj2s(L, oldtop, L->top - 1); // error message on current top
+        break;
+    }
+    }
+    L->top = oldtop + 1;
+}
+
+static void resume_continue(lua_State* L)
+{
+    // unroll Lua/C combined stack, processing continuations
+    while (L->status == 0 && L->ci > L->base_ci)
+    {
+        LUAU_ASSERT(L->baseCcalls == L->nCcalls);
+
+        Closure* cl = curr_func(L);
+
+        if (cl->isC)
+        {
+            LUAU_ASSERT(cl->c.cont);
+
+            // C continuation; we expect this to be followed by Lua continuations
+            int n = cl->c.cont(L, 0);
+
+            // Continuation can break again
+            if (L->status == LUA_BREAK)
+                break;
+
+            luau_poscall(L, L->top - n);
+        }
+        else
+        {
+            // Lua continuation; it terminates at the end of the stack or at another C continuation
+            luau_execute(L);
+        }
+    }
+}
+
+static void resume(lua_State* L, void* ud)
+{
+    StkId firstArg = cast_to(StkId, ud);
+
+    if (L->status == 0)
+    {
+        // start coroutine
+        LUAU_ASSERT(L->ci == L->base_ci && firstArg >= L->base);
+        if (firstArg == L->base)
+            luaG_runerror(L, "cannot resume dead coroutine");
+
+        if (luau_precall(L, firstArg - 1, LUA_MULTRET) != PCRLUA)
+            return;
+
+        L->ci->flags |= LUA_CALLINFO_RETURN;
+    }
+    else
+    {
+        // resume from previous yield or break
+        LUAU_ASSERT(L->status == LUA_YIELD || L->status == LUA_BREAK);
+        L->status = 0;
+
+        Closure* cl = curr_func(L);
+
+        if (cl->isC)
+        {
+            // if the top stack frame is a C call continuation, resume_continue will handle that case
+            if (!cl->c.cont)
+            {
+                // finish interrupted execution of `OP_CALL'
+                luau_poscall(L, firstArg);
+            }
+        }
+        else
+        {
+            // yielded inside a hook: just continue its execution
+            L->base = L->ci->base;
+        }
+    }
+
+    // run continuations from the stack; typically resumes Lua code and pcalls
+    resume_continue(L);
+}
+
+static CallInfo* resume_findhandler(lua_State* L)
+{
+    CallInfo* ci = L->ci;
+
+    while (ci > L->base_ci)
+    {
+        if (ci->flags & LUA_CALLINFO_HANDLE)
+            return ci;
+
+        ci--;
+    }
+
+    return NULL;
+}
+
+static void resume_handle(lua_State* L, void* ud)
+{
+    CallInfo* ci = (CallInfo*)ud;
+    Closure* cl = ci_func(ci);
+
+    LUAU_ASSERT(ci->flags & LUA_CALLINFO_HANDLE);
+    LUAU_ASSERT(cl->isC && cl->c.cont);
+    LUAU_ASSERT(L->status != 0);
+
+    // restore nCcalls back to base since this might not have happened during error handling
+    L->nCcalls = L->baseCcalls;
+
+    // make sure we don't run the handler the second time
+    ci->flags &= ~LUA_CALLINFO_HANDLE;
+
+    // restore thread status to 0 since we're handling the error
+    int status = L->status;
+    L->status = 0;
+
+    // push error object to stack top if it's not already there
+    if (status != LUA_ERRRUN)
+        seterrorobj(L, status, L->top);
+
+    // adjust the stack frame for ci to prepare for cont call
+    L->base = ci->base;
+    ci->top = L->top;
+
+    // save ci pointer - it will be invalidated by cont call!
+    ptrdiff_t old_ci = saveci(L, ci);
+
+    // handle the error in continuation; note that this executes on top of original stack!
+    int n = cl->c.cont(L, status);
+
+    // restore the stack frame to the frame with continuation
+    L->ci = restoreci(L, old_ci);
+
+    // close eventual pending closures; this means it's now safe to restore stack
+    luaF_close(L, L->ci->base);
+
+    // finish cont call and restore stack to previous ci top
+    luau_poscall(L, L->top - n);
+
+    // run remaining continuations from the stack; typically resumes pcalls
+    resume_continue(L);
+}
+
+static int resume_error(lua_State* L, const char* msg)
+{
+    L->top = L->ci->base;
+    setsvalue(L, L->top, luaS_new(L, msg));
+    incr_top(L);
+    return LUA_ERRRUN;
+}
+
+static void resume_finish(lua_State* L, int status)
+{
+    L->nCcalls = L->baseCcalls;
+    L->isactive = false;
+
+    if (status != 0)
+    {                                  // error?
+        L->status = cast_byte(status); // mark thread as `dead'
+        seterrorobj(L, status, L->top);
+        L->ci->top = L->top;
+    }
+    else if (L->status == 0)
+    {
+        expandstacklimit(L, L->top);
+    }
+}
+
+int lua_resume(lua_State* L, lua_State* from, int nargs)
+{
+    int status;
+    if (L->status != LUA_YIELD && L->status != LUA_BREAK && (L->status != 0 || L->ci != L->base_ci))
+        return resume_error(L, "cannot resume non-suspended coroutine");
+
+    L->nCcalls = from ? from->nCcalls : 0;
+    if (L->nCcalls >= LUAI_MAXCCALLS)
+        return resume_error(L, "C stack overflow");
+
+    L->baseCcalls = ++L->nCcalls;
+    L->isactive = true;
+
+    luaC_threadbarrier(L);
+
+    status = luaD_rawrunprotected(L, resume, L->top - nargs);
+
+    CallInfo* ch = NULL;
+    while (status != 0 && (ch = resume_findhandler(L)) != NULL)
+    {
+        L->status = cast_byte(status);
+        status = luaD_rawrunprotected(L, resume_handle, ch);
+    }
+
+    resume_finish(L, status);
+    --L->nCcalls;
+    return L->status;
+}
+
+int lua_resumeerror(lua_State* L, lua_State* from)
+{
+    int status;
+    if (L->status != LUA_YIELD && L->status != LUA_BREAK && (L->status != 0 || L->ci != L->base_ci))
+        return resume_error(L, "cannot resume non-suspended coroutine");
+
+    L->nCcalls = from ? from->nCcalls : 0;
+    if (L->nCcalls >= LUAI_MAXCCALLS)
+        return resume_error(L, "C stack overflow");
+
+    L->baseCcalls = ++L->nCcalls;
+    L->isactive = true;
+
+    luaC_threadbarrier(L);
+
+    status = LUA_ERRRUN;
+
+    CallInfo* ch = NULL;
+    while (status != 0 && (ch = resume_findhandler(L)) != NULL)
+    {
+        L->status = cast_byte(status);
+        status = luaD_rawrunprotected(L, resume_handle, ch);
+    }
+
+    resume_finish(L, status);
+    --L->nCcalls;
+    return L->status;
+}
+
+int lua_yield(lua_State* L, int nresults)
+{
+    if (L->nCcalls > L->baseCcalls)
+        luaG_runerror(L, "attempt to yield across metamethod/C-call boundary");
+    L->base = L->top - nresults; // protect stack slots below
+    L->status = LUA_YIELD;
+    return -1;
+}
+
+int lua_break(lua_State* L)
+{
+    if (L->nCcalls > L->baseCcalls)
+        luaG_runerror(L, "attempt to break across metamethod/C-call boundary");
+    L->status = LUA_BREAK;
+    return -1;
+}
+
+int lua_isyieldable(lua_State* L)
+{
+    return (L->nCcalls <= L->baseCcalls);
+}
+
+static void callerrfunc(lua_State* L, void* ud)
+{
+    StkId errfunc = cast_to(StkId, ud);
+
+    setobj2s(L, L->top, L->top - 1);
+    setobj2s(L, L->top - 1, errfunc);
+    incr_top(L);
+    luaD_call(L, L->top - 2, 1);
+}
+
+static void restore_stack_limit(lua_State* L)
+{
+    LUAU_ASSERT(L->stack_last - L->stack == L->stacksize - EXTRA_STACK);
+    if (L->size_ci > LUAI_MAXCALLS)
+    { // there was an overflow?
+        int inuse = cast_int(L->ci - L->base_ci);
+        if (inuse + 1 < LUAI_MAXCALLS) // can `undo' overflow?
+            luaD_reallocCI(L, LUAI_MAXCALLS);
+    }
+}
+
+int luaD_pcall(lua_State* L, Pfunc func, void* u, ptrdiff_t old_top, ptrdiff_t ef)
+{
+    unsigned short oldnCcalls = L->nCcalls;
+    ptrdiff_t old_ci = saveci(L, L->ci);
+    bool oldactive = L->isactive;
+    int status = luaD_rawrunprotected(L, func, u);
+    if (status != 0)
+    {
+        int errstatus = status;
+
+        // call user-defined error function (used in xpcall)
+        if (ef)
+        {
+            // push error object to stack top if it's not already there
+            if (status != LUA_ERRRUN)
+                seterrorobj(L, status, L->top);
+
+            // if errfunc fails, we fail with "error in error handling" or "not enough memory"
+            int err = luaD_rawrunprotected(L, callerrfunc, restorestack(L, ef));
+
+            // in general we preserve the status, except for cases when the error handler fails
+            // out of memory is treated specially because it's common for it to be cascading, in which case we preserve the code
+            if (err == 0)
+                errstatus = LUA_ERRRUN;
+            else if (status == LUA_ERRMEM && err == LUA_ERRMEM)
+                errstatus = LUA_ERRMEM;
+            else
+                errstatus = status = LUA_ERRERR;
+        }
+
+        // since the call failed with an error, we might have to reset the 'active' thread state
+        if (!oldactive)
+            L->isactive = false;
+
+        bool yieldable = L->nCcalls <= L->baseCcalls; // Inlined logic from 'lua_isyieldable' to avoid potential for an out of line call.
+
+        // restore nCcalls before calling the debugprotectederror callback which may rely on the proper value to have been restored.
+        L->nCcalls = oldnCcalls;
+
+        // an error occurred, check if we have a protected error callback
+        if (yieldable && L->global->cb.debugprotectederror)
+        {
+            L->global->cb.debugprotectederror(L);
+
+            // debug hook is only allowed to break
+            if (L->status == LUA_BREAK)
+                return 0;
+        }
+
+        StkId oldtop = restorestack(L, old_top);
+        luaF_close(L, oldtop); // close eventual pending closures
+        seterrorobj(L, errstatus, oldtop);
+        L->ci = restoreci(L, old_ci);
+        L->base = L->ci->base;
+        restore_stack_limit(L);
+    }
+    return status;
+}

--- a/lib/luau/VM/src/ldo.h
+++ b/lib/luau/VM/src/ldo.h
@@ -1,0 +1,55 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+#include "lstate.h"
+#include "luaconf.h"
+#include "ldebug.h"
+
+#define luaD_checkstack(L, n) \
+    if ((char*)L->stack_last - (char*)L->top <= (n) * (int)sizeof(TValue)) \
+        luaD_growstack(L, n); \
+    else \
+        condhardstacktests(luaD_reallocstack(L, L->stacksize - EXTRA_STACK));
+
+#define incr_top(L) \
+    { \
+        luaD_checkstack(L, 1); \
+        L->top++; \
+    }
+
+#define savestack(L, p) ((char*)(p) - (char*)L->stack)
+#define restorestack(L, n) ((TValue*)((char*)L->stack + (n)))
+
+#define expandstacklimit(L, p) \
+    { \
+        LUAU_ASSERT((p) <= (L)->stack_last); \
+        if ((L)->ci->top < (p)) \
+            (L)->ci->top = (p); \
+    }
+
+#define incr_ci(L) ((L->ci == L->end_ci) ? luaD_growCI(L) : (condhardstacktests(luaD_reallocCI(L, L->size_ci)), ++L->ci))
+
+#define saveci(L, p) ((char*)(p) - (char*)L->base_ci)
+#define restoreci(L, n) ((CallInfo*)((char*)L->base_ci + (n)))
+
+// results from luaD_precall
+#define PCRLUA 0   // initiated a call to a Lua function
+#define PCRC 1     // did a call to a C function
+#define PCRYIELD 2 // C function yielded
+
+// type of protected functions, to be ran by `runprotected'
+typedef void (*Pfunc)(lua_State* L, void* ud);
+
+LUAI_FUNC CallInfo* luaD_growCI(lua_State* L);
+
+LUAI_FUNC void luaD_call(lua_State* L, StkId func, int nresults);
+LUAI_FUNC int luaD_pcall(lua_State* L, Pfunc func, void* u, ptrdiff_t oldtop, ptrdiff_t ef);
+LUAI_FUNC void luaD_reallocCI(lua_State* L, int newsize);
+LUAI_FUNC void luaD_reallocstack(lua_State* L, int newsize);
+LUAI_FUNC void luaD_growstack(lua_State* L, int n);
+LUAI_FUNC void luaD_checkCstack(lua_State* L);
+
+LUAI_FUNC l_noret luaD_throw(lua_State* L, int errcode);
+LUAI_FUNC int luaD_rawrunprotected(lua_State* L, Pfunc f, void* ud);

--- a/lib/luau/VM/src/lfunc.cpp
+++ b/lib/luau/VM/src/lfunc.cpp
@@ -1,0 +1,197 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lfunc.h"
+
+#include "lstate.h"
+#include "lmem.h"
+#include "lgc.h"
+
+Proto* luaF_newproto(lua_State* L)
+{
+    Proto* f = luaM_newgco(L, Proto, sizeof(Proto), L->activememcat);
+    luaC_init(L, f, LUA_TPROTO);
+    f->k = NULL;
+    f->sizek = 0;
+    f->p = NULL;
+    f->sizep = 0;
+    f->code = NULL;
+    f->sizecode = 0;
+    f->sizeupvalues = 0;
+    f->nups = 0;
+    f->upvalues = NULL;
+    f->numparams = 0;
+    f->is_vararg = 0;
+    f->maxstacksize = 0;
+    f->flags = 0;
+    f->sizelineinfo = 0;
+    f->linegaplog2 = 0;
+    f->lineinfo = NULL;
+    f->abslineinfo = NULL;
+    f->sizelocvars = 0;
+    f->locvars = NULL;
+    f->source = NULL;
+    f->debugname = NULL;
+    f->debuginsn = NULL;
+    f->codeentry = NULL;
+    f->execdata = NULL;
+    f->exectarget = 0;
+    f->typeinfo = NULL;
+    f->userdata = NULL;
+
+    return f;
+}
+
+Closure* luaF_newLclosure(lua_State* L, int nelems, Table* e, Proto* p)
+{
+    Closure* c = luaM_newgco(L, Closure, sizeLclosure(nelems), L->activememcat);
+    luaC_init(L, c, LUA_TFUNCTION);
+    c->isC = 0;
+    c->env = e;
+    c->nupvalues = cast_byte(nelems);
+    c->stacksize = p->maxstacksize;
+    c->preload = 0;
+    c->l.p = p;
+    for (int i = 0; i < nelems; ++i)
+        setnilvalue(&c->l.uprefs[i]);
+    return c;
+}
+
+Closure* luaF_newCclosure(lua_State* L, int nelems, Table* e)
+{
+    Closure* c = luaM_newgco(L, Closure, sizeCclosure(nelems), L->activememcat);
+    luaC_init(L, c, LUA_TFUNCTION);
+    c->isC = 1;
+    c->env = e;
+    c->nupvalues = cast_byte(nelems);
+    c->stacksize = LUA_MINSTACK;
+    c->preload = 0;
+    c->c.f = NULL;
+    c->c.cont = NULL;
+    c->c.debugname = NULL;
+    return c;
+}
+
+UpVal* luaF_findupval(lua_State* L, StkId level)
+{
+    global_State* g = L->global;
+    UpVal** pp = &L->openupval;
+    UpVal* p;
+    while (*pp != NULL && (p = *pp)->v >= level)
+    {
+        LUAU_ASSERT(!isdead(g, obj2gco(p)));
+        LUAU_ASSERT(upisopen(p));
+        if (p->v == level)
+            return p;
+
+        pp = &p->u.open.threadnext;
+    }
+
+    LUAU_ASSERT(L->isactive);
+    LUAU_ASSERT(!isblack(obj2gco(L))); // we don't use luaC_threadbarrier because active threads never turn black
+
+    UpVal* uv = luaM_newgco(L, UpVal, sizeof(UpVal), L->activememcat); // not found: create a new one
+    luaC_init(L, uv, LUA_TUPVAL);
+    uv->markedopen = 0;
+    uv->v = level; // current value lives in the stack
+
+    // chain the upvalue in the threads open upvalue list at the proper position
+    uv->u.open.threadnext = *pp;
+    *pp = uv;
+
+    // double link the upvalue in the global open upvalue list
+    uv->u.open.prev = &g->uvhead;
+    uv->u.open.next = g->uvhead.u.open.next;
+    uv->u.open.next->u.open.prev = uv;
+    g->uvhead.u.open.next = uv;
+    LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+
+    return uv;
+}
+
+void luaF_freeupval(lua_State* L, UpVal* uv, lua_Page* page)
+{
+    luaM_freegco(L, uv, sizeof(UpVal), uv->memcat, page); // free upvalue
+}
+
+void luaF_close(lua_State* L, StkId level)
+{
+    global_State* g = L->global;
+    UpVal* uv;
+    while (L->openupval != NULL && (uv = L->openupval)->v >= level)
+    {
+        GCObject* o = obj2gco(uv);
+        LUAU_ASSERT(!isblack(o) && upisopen(uv));
+        LUAU_ASSERT(!isdead(g, o));
+
+        // unlink value *before* closing it since value storage overlaps
+        L->openupval = uv->u.open.threadnext;
+
+        luaF_closeupval(L, uv, /* dead= */ false);
+    }
+}
+
+void luaF_closeupval(lua_State* L, UpVal* uv, bool dead)
+{
+    // unlink value from all lists *before* closing it since value storage overlaps
+    LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+    uv->u.open.next->u.open.prev = uv->u.open.prev;
+    uv->u.open.prev->u.open.next = uv->u.open.next;
+
+    if (dead)
+        return;
+
+    setobj(L, &uv->u.value, uv->v);
+    uv->v = &uv->u.value;
+    luaC_upvalclosed(L, uv);
+}
+
+void luaF_freeproto(lua_State* L, Proto* f, lua_Page* page)
+{
+    luaM_freearray(L, f->code, f->sizecode, Instruction, f->memcat);
+    luaM_freearray(L, f->p, f->sizep, Proto*, f->memcat);
+    luaM_freearray(L, f->k, f->sizek, TValue, f->memcat);
+    if (f->lineinfo)
+        luaM_freearray(L, f->lineinfo, f->sizelineinfo, uint8_t, f->memcat);
+    luaM_freearray(L, f->locvars, f->sizelocvars, struct LocVar, f->memcat);
+    luaM_freearray(L, f->upvalues, f->sizeupvalues, TString*, f->memcat);
+    if (f->debuginsn)
+        luaM_freearray(L, f->debuginsn, f->sizecode, uint8_t, f->memcat);
+
+    if (f->execdata)
+        L->global->ecb.destroy(L, f);
+
+    if (f->typeinfo)
+        luaM_freearray(L, f->typeinfo, f->numparams + 2, uint8_t, f->memcat);
+
+    luaM_freegco(L, f, sizeof(Proto), f->memcat, page);
+}
+
+void luaF_freeclosure(lua_State* L, Closure* c, lua_Page* page)
+{
+    int size = c->isC ? sizeCclosure(c->nupvalues) : sizeLclosure(c->nupvalues);
+    luaM_freegco(L, c, size, c->memcat, page);
+}
+
+const LocVar* luaF_getlocal(const Proto* f, int local_number, int pc)
+{
+    for (int i = 0; i < f->sizelocvars; i++)
+    {
+        if (pc >= f->locvars[i].startpc && pc < f->locvars[i].endpc)
+        { // is variable active?
+            local_number--;
+            if (local_number == 0)
+                return &f->locvars[i];
+        }
+    }
+
+    return NULL; // not found
+}
+
+const LocVar* luaF_findlocal(const Proto* f, int local_reg, int pc)
+{
+    for (int i = 0; i < f->sizelocvars; i++)
+        if (local_reg == f->locvars[i].reg && pc >= f->locvars[i].startpc && pc < f->locvars[i].endpc)
+            return &f->locvars[i];
+
+    return NULL; // not found
+}

--- a/lib/luau/VM/src/lfunc.h
+++ b/lib/luau/VM/src/lfunc.h
@@ -1,0 +1,20 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+#define sizeCclosure(n) (offsetof(Closure, c.upvals) + sizeof(TValue) * (n))
+#define sizeLclosure(n) (offsetof(Closure, l.uprefs) + sizeof(TValue) * (n))
+
+LUAI_FUNC Proto* luaF_newproto(lua_State* L);
+LUAI_FUNC Closure* luaF_newLclosure(lua_State* L, int nelems, Table* e, Proto* p);
+LUAI_FUNC Closure* luaF_newCclosure(lua_State* L, int nelems, Table* e);
+LUAI_FUNC UpVal* luaF_findupval(lua_State* L, StkId level);
+LUAI_FUNC void luaF_close(lua_State* L, StkId level);
+LUAI_FUNC void luaF_closeupval(lua_State* L, UpVal* uv, bool dead);
+LUAI_FUNC void luaF_freeproto(lua_State* L, Proto* f, struct lua_Page* page);
+LUAI_FUNC void luaF_freeclosure(lua_State* L, Closure* c, struct lua_Page* page);
+LUAI_FUNC void luaF_freeupval(lua_State* L, UpVal* uv, struct lua_Page* page);
+LUAI_FUNC const LocVar* luaF_getlocal(const Proto* func, int local_number, int pc);
+LUAI_FUNC const LocVar* luaF_findlocal(const Proto* func, int local_reg, int pc);

--- a/lib/luau/VM/src/lgc.cpp
+++ b/lib/luau/VM/src/lgc.cpp
@@ -1,0 +1,1256 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lgc.h"
+
+#include "lobject.h"
+#include "lstate.h"
+#include "ltable.h"
+#include "lfunc.h"
+#include "lstring.h"
+#include "ldo.h"
+#include "lmem.h"
+#include "ludata.h"
+#include "lbuffer.h"
+
+#include <string.h>
+
+/*
+ * Luau uses an incremental non-generational non-moving mark&sweep garbage collector.
+ *
+ * The collector runs in three stages: mark, atomic and sweep. Mark and sweep are incremental and try to do a limited amount
+ * of work every GC step; atomic is ran once per the GC cycle and is indivisible. In either case, the work happens during GC
+ * steps that are "scheduled" by the GC pacing algorithm - the steps happen either from explicit calls to lua_gc, or after
+ * the mutator (aka application) allocates some amount of memory, which is known as "GC assist". In either case, GC steps
+ * can't happen concurrently with other access to VM state.
+ *
+ * Current GC stage is stored in global_State::gcstate, and has two additional stages for pause and second-phase mark, explained below.
+ *
+ * GC pacer is an algorithm that tries to ensure that GC can always catch up to the application allocating garbage, but do this
+ * with minimal amount of effort. To configure the pacer Luau provides control over three variables: GC goal, defined as the
+ * target heap size during atomic phase in relation to live heap size (e.g. 200% goal means the heap's worst case size is double
+ * the total size of alive objects), step size (how many kilobytes should the application allocate for GC step to trigger), and
+ * GC multiplier (how much should the GC try to mark relative to how much the application allocated). It's critical that step
+ * multiplier is significantly above 1, as this is what allows the GC to catch up to the application's allocation rate, and
+ * GC goal and GC multiplier are linked in subtle ways, described in lua.h comments for LUA_GCSETGOAL.
+ *
+ * During mark, GC tries to identify all reachable objects and mark them as reachable, while keeping unreachable objects unmarked.
+ * During sweep, GC tries to sweep all objects that were not reachable at the end of mark. The atomic phase is needed to ensure
+ * that all pending marking has completed and all objects that are still marked as unreachable are, in fact, unreachable.
+ *
+ * Notably, during mark GC doesn't free any objects, and so the heap size constantly grows; during sweep, GC doesn't do any marking
+ * work, so it can't immediately free objects that became unreachable after sweeping started.
+ *
+ * Every collectable object has one of three colors at any given point in time: white, gray or black. This coloring scheme
+ * is necessary to implement incremental marking: white objects have not been marked and may be unreachable, black objects
+ * have been marked and will not be marked again if they stay black, and gray objects have been marked but may contain unmarked
+ * references.
+ *
+ * Objects are allocated as white; however, during sweep, we need to differentiate between objects that remained white in the mark
+ * phase (these are not reachable and can be freed) and objects that were allocated after the mark phase ended. Because of this, the
+ * colors are encoded using three bits inside GCheader::marked: white0, white1 and black (so technically we use a four-color scheme:
+ * any object can be white0, white1, gray or black). All bits are exclusive, and gray objects have all three bits unset. This allows
+ * us to have the "current" white bit, which is flipped during atomic stage - during sweeping, objects that have the white color from
+ * the previous mark may be deleted, and all other objects may or may not be reachable, and will be changed to the current white color,
+ * so that the next mark can start coloring objects from scratch again.
+ *
+ * Crucially, the coloring scheme comes with what's known as a tri-color invariant: a black object may never point to a white object.
+ *
+ * At the end of atomic stage, the expectation is that there are no gray objects anymore, which means all objects are either black
+ * (reachable) or white (unreachable = dead). Tri-color invariant is maintained throughout mark and atomic phase. To uphold this
+ * invariant, every modification of an object needs to check if the object is black and the new referent is white; if so, we
+ * need to either mark the referent, making it non-white (known as a forward barrier), or mark the object as gray and queue it
+ * for additional marking (known as a backward barrier).
+ *
+ * Luau uses both types of barriers. Forward barriers advance GC progress, since they don't create new outstanding work for GC,
+ * but they may be expensive when an object is modified many times in succession. Backward barriers are cheaper, as they defer
+ * most of the work until "later", but they require queueing the object for a rescan which isn't always possible. Table writes usually
+ * use backward barriers (but switch to forward barriers during second-phase mark), whereas upvalue writes and setmetatable use forward
+ * barriers.
+ *
+ * Since marking is incremental, it needs a way to track progress, which is implemented as a gray set: at any point, objects that
+ * are gray need to mark their white references, objects that are black have no pending work, and objects that are white have not yet
+ * been reached. Once the gray set is empty, the work completes; as such, incremental marking is as simple as removing an object from
+ * the gray set, and turning it to black (which requires turning all its white references to gray). The gray set is implemented as
+ * an intrusive singly linked list, using `gclist` field in multiple objects (functions, tables, threads and protos). When an object
+ * doesn't have gclist field, the marking of that object needs to be "immediate", changing the colors of all references in one go.
+ *
+ * When a black object is modified, it needs to become gray again. Objects like this are placed on a separate `grayagain` list by a
+ * barrier - this is important because it allows us to have a mark stage that terminates when the gray set is empty even if the mutator
+ * is constantly changing existing objects to gray. After mark stage finishes traversing `gray` list, we copy `grayagain` list to `gray`
+ * once and incrementally mark it again. During this phase of marking, we may get more objects marked as `grayagain`, so after we finish
+ * emptying out the `gray` list the second time, we finish the mark stage and do final marking of `grayagain` during atomic phase.
+ * GC works correctly without this second-phase mark (called GCSpropagateagain), but it reduces the time spent during atomic phase.
+ *
+ * Sweeping is also incremental, but instead of working at a granularity of an object, it works at a granularity of a page: all GC
+ * objects are allocated in special pages (see lmem.cpp for details), and sweeper traverses all objects in one page in one incremental
+ * step, freeing objects that aren't reachable (old white), and recoloring all other objects with the new white to prepare them for next
+ * mark. During sweeping we don't need to maintain the GC invariant, because our goal is to paint all objects with current white -
+ * however, some barriers will still trigger (because some reachable objects are still black as sweeping didn't get to them yet), and
+ * some barriers will proactively mark black objects as white to avoid extra barriers from triggering excessively.
+ *
+ * Most references that GC deals with are strong, and as such they fit neatly into the incremental marking scheme. Some, however, are
+ * weak - notably, tables can be marked as having weak keys/values (using __mode metafield). During incremental marking, we don't know
+ * for certain if a given object is alive - if it's marked as black, it definitely was reachable during marking, but if it's marked as
+ * white, we don't know if it's actually unreachable. Because of this, we need to defer weak table handling to the atomic phase; after
+ * all objects are marked, we traverse all weak tables (that are linked into special weak table lists using `gclist` during marking),
+ * and remove all entries that have white keys or values. If keys or values are strong, they are marked normally.
+ *
+ * The simplified scheme described above isn't fully accurate because of threads, upvalues and strings.
+ *
+ * Strings are semantically black (they are initially white, and when the mark stage reaches a string, it changes its color and never
+ * touches the object again), but they are technically marked as gray - the black bit is never set on a string object. This behavior
+ * is inherited from Lua 5.1 GC, but doesn't have a clear rationale - effectively, strings are marked as gray but are never part of
+ * a gray list.
+ *
+ * Threads are hard to deal with because for them to fit into the white-gray-black scheme, writes to thread stacks need to have barriers
+ * that turn the thread from black (already scanned) to gray - but this is very expensive because stack writes are very common. To
+ * get around this problem, threads have an "active" state which means that a thread is actively executing code. When GC reaches an active
+ * thread, it keeps it as gray, and rescans it during atomic phase. When a thread is inactive, GC instead paints the thread black. All
+ * API calls that can write to thread stacks outside of execution (which implies active) uses a thread barrier that checks if the thread is
+ * black, and if it is it marks it as gray and puts it on a gray list to be rescanned during atomic phase.
+ *
+ * Upvalues are special objects that can be closed, in which case they contain the value (acting as a reference cell) and can be dealt
+ * with using the regular algorithm, or open, in which case they refer to a stack slot in some other thread. These are difficult to deal
+ * with because the stack writes are not monitored. Because of this open upvalues are treated in a somewhat special way: they are never marked
+ * as black (doing so would violate the GC invariant), and they are kept in a special global list (global_State::uvhead) which is traversed
+ * during atomic phase. This is needed because an open upvalue might point to a stack location in a dead thread that never marked the stack
+ * slot - upvalues like this are identified since they don't have `markedopen` bit set during thread traversal and closed in `clearupvals`.
+ */
+
+#define GC_SWEEPPAGESTEPCOST 16
+
+#define GC_INTERRUPT(state) \
+    { \
+        void (*interrupt)(lua_State*, int) = g->cb.interrupt; \
+        if (LUAU_UNLIKELY(!!interrupt)) \
+            interrupt(L, state); \
+    }
+
+#define maskmarks cast_byte(~(bitmask(BLACKBIT) | WHITEBITS))
+
+#define makewhite(g, x) ((x)->gch.marked = cast_byte(((x)->gch.marked & maskmarks) | luaC_white(g)))
+
+#define white2gray(x) reset2bits((x)->gch.marked, WHITE0BIT, WHITE1BIT)
+#define black2gray(x) resetbit((x)->gch.marked, BLACKBIT)
+
+#define stringmark(s) reset2bits((s)->marked, WHITE0BIT, WHITE1BIT)
+
+#define markvalue(g, o) \
+    { \
+        checkconsistency(o); \
+        if (iscollectable(o) && iswhite(gcvalue(o))) \
+            reallymarkobject(g, gcvalue(o)); \
+    }
+
+#define markobject(g, t) \
+    { \
+        if (iswhite(obj2gco(t))) \
+            reallymarkobject(g, obj2gco(t)); \
+    }
+
+#ifdef LUAI_GCMETRICS
+static void recordGcStateStep(global_State* g, int startgcstate, double seconds, bool assist, size_t work)
+{
+    switch (startgcstate)
+    {
+    case GCSpause:
+        // record root mark time if we have switched to next state
+        if (g->gcstate == GCSpropagate)
+        {
+            g->gcmetrics.currcycle.marktime += seconds;
+
+            if (assist)
+                g->gcmetrics.currcycle.markassisttime += seconds;
+        }
+        break;
+    case GCSpropagate:
+    case GCSpropagateagain:
+        g->gcmetrics.currcycle.marktime += seconds;
+        g->gcmetrics.currcycle.markwork += work;
+
+        if (assist)
+            g->gcmetrics.currcycle.markassisttime += seconds;
+        break;
+    case GCSatomic:
+        g->gcmetrics.currcycle.atomictime += seconds;
+        break;
+    case GCSsweep:
+        g->gcmetrics.currcycle.sweeptime += seconds;
+        g->gcmetrics.currcycle.sweepwork += work;
+
+        if (assist)
+            g->gcmetrics.currcycle.sweepassisttime += seconds;
+        break;
+    default:
+        LUAU_ASSERT(!"Unexpected GC state");
+    }
+
+    if (assist)
+    {
+        g->gcmetrics.stepassisttimeacc += seconds;
+        g->gcmetrics.currcycle.assistwork += work;
+    }
+    else
+    {
+        g->gcmetrics.stepexplicittimeacc += seconds;
+        g->gcmetrics.currcycle.explicitwork += work;
+    }
+}
+
+static double recordGcDeltaTime(double& timer)
+{
+    double now = lua_clock();
+    double delta = now - timer;
+    timer = now;
+    return delta;
+}
+
+static void startGcCycleMetrics(global_State* g)
+{
+    g->gcmetrics.currcycle.starttimestamp = lua_clock();
+    g->gcmetrics.currcycle.pausetime = g->gcmetrics.currcycle.starttimestamp - g->gcmetrics.lastcycle.endtimestamp;
+}
+
+static void finishGcCycleMetrics(global_State* g)
+{
+    g->gcmetrics.currcycle.endtimestamp = lua_clock();
+    g->gcmetrics.currcycle.endtotalsizebytes = g->totalbytes;
+
+    g->gcmetrics.completedcycles++;
+    g->gcmetrics.lastcycle = g->gcmetrics.currcycle;
+    g->gcmetrics.currcycle = GCCycleMetrics();
+
+    g->gcmetrics.currcycle.starttotalsizebytes = g->totalbytes;
+    g->gcmetrics.currcycle.heaptriggersizebytes = g->GCthreshold;
+}
+#endif
+
+static void removeentry(LuaNode* n)
+{
+    LUAU_ASSERT(ttisnil(gval(n)));
+    if (iscollectable(gkey(n)))
+        setttype(gkey(n), LUA_TDEADKEY); // dead key; remove it
+}
+
+static void reallymarkobject(global_State* g, GCObject* o)
+{
+    LUAU_ASSERT(iswhite(o) && !isdead(g, o));
+    white2gray(o);
+    switch (o->gch.tt)
+    {
+    case LUA_TSTRING:
+    {
+        return;
+    }
+    case LUA_TUSERDATA:
+    {
+        Table* mt = gco2u(o)->metatable;
+        gray2black(o); // udata are never gray
+        if (mt)
+            markobject(g, mt);
+        return;
+    }
+    case LUA_TUPVAL:
+    {
+        UpVal* uv = gco2uv(o);
+        markvalue(g, uv->v);
+        if (!upisopen(uv)) // closed?
+            gray2black(o); // open upvalues are never black
+        return;
+    }
+    case LUA_TFUNCTION:
+    {
+        gco2cl(o)->gclist = g->gray;
+        g->gray = o;
+        break;
+    }
+    case LUA_TTABLE:
+    {
+        gco2h(o)->gclist = g->gray;
+        g->gray = o;
+        break;
+    }
+    case LUA_TTHREAD:
+    {
+        gco2th(o)->gclist = g->gray;
+        g->gray = o;
+        break;
+    }
+    case LUA_TBUFFER:
+    {
+        gray2black(o); // buffers are never gray
+        return;
+    }
+    case LUA_TPROTO:
+    {
+        gco2p(o)->gclist = g->gray;
+        g->gray = o;
+        break;
+    }
+    default:
+        LUAU_ASSERT(0);
+    }
+}
+
+static const char* gettablemode(global_State* g, Table* h)
+{
+    const TValue* mode = gfasttm(g, h->metatable, TM_MODE);
+
+    if (mode && ttisstring(mode))
+        return svalue(mode);
+
+    return NULL;
+}
+
+static int traversetable(global_State* g, Table* h)
+{
+    int i;
+    int weakkey = 0;
+    int weakvalue = 0;
+    if (h->metatable)
+        markobject(g, cast_to(Table*, h->metatable));
+
+    // is there a weak mode?
+    if (const char* modev = gettablemode(g, h))
+    {
+        weakkey = (strchr(modev, 'k') != NULL);
+        weakvalue = (strchr(modev, 'v') != NULL);
+        if (weakkey || weakvalue)
+        {                         // is really weak?
+            h->gclist = g->weak;  // must be cleared after GC, ...
+            g->weak = obj2gco(h); // ... so put in the appropriate list
+        }
+    }
+
+    if (weakkey && weakvalue)
+        return 1;
+    if (!weakvalue)
+    {
+        i = h->sizearray;
+        while (i--)
+            markvalue(g, &h->array[i]);
+    }
+    i = sizenode(h);
+    while (i--)
+    {
+        LuaNode* n = gnode(h, i);
+        LUAU_ASSERT(ttype(gkey(n)) != LUA_TDEADKEY || ttisnil(gval(n)));
+        if (ttisnil(gval(n)))
+            removeentry(n); // remove empty entries
+        else
+        {
+            LUAU_ASSERT(!ttisnil(gkey(n)));
+            if (!weakkey)
+                markvalue(g, gkey(n));
+            if (!weakvalue)
+                markvalue(g, gval(n));
+        }
+    }
+    return weakkey || weakvalue;
+}
+
+/*
+** All marks are conditional because a GC may happen while the
+** prototype is still being created
+*/
+static void traverseproto(global_State* g, Proto* f)
+{
+    int i;
+    if (f->source)
+        stringmark(f->source);
+    if (f->debugname)
+        stringmark(f->debugname);
+    for (i = 0; i < f->sizek; i++) // mark literals
+        markvalue(g, &f->k[i]);
+    for (i = 0; i < f->sizeupvalues; i++)
+    { // mark upvalue names
+        if (f->upvalues[i])
+            stringmark(f->upvalues[i]);
+    }
+    for (i = 0; i < f->sizep; i++)
+    { // mark nested protos
+        if (f->p[i])
+            markobject(g, f->p[i]);
+    }
+    for (i = 0; i < f->sizelocvars; i++)
+    { // mark local-variable names
+        if (f->locvars[i].varname)
+            stringmark(f->locvars[i].varname);
+    }
+}
+
+static void traverseclosure(global_State* g, Closure* cl)
+{
+    markobject(g, cl->env);
+    if (cl->isC)
+    {
+        int i;
+        for (i = 0; i < cl->nupvalues; i++) // mark its upvalues
+            markvalue(g, &cl->c.upvals[i]);
+    }
+    else
+    {
+        int i;
+        LUAU_ASSERT(cl->nupvalues == cl->l.p->nups);
+        markobject(g, cast_to(Proto*, cl->l.p));
+        for (i = 0; i < cl->nupvalues; i++) // mark its upvalues
+            markvalue(g, &cl->l.uprefs[i]);
+    }
+}
+
+static void traversestack(global_State* g, lua_State* l)
+{
+    markobject(g, l->gt);
+    if (l->namecall)
+        stringmark(l->namecall);
+    for (StkId o = l->stack; o < l->top; o++)
+        markvalue(g, o);
+    for (UpVal* uv = l->openupval; uv; uv = uv->u.open.threadnext)
+    {
+        LUAU_ASSERT(upisopen(uv));
+        uv->markedopen = 1;
+        markobject(g, uv);
+    }
+}
+
+static void clearstack(lua_State* l)
+{
+    StkId stack_end = l->stack + l->stacksize;
+    for (StkId o = l->top; o < stack_end; o++) // clear not-marked stack slice
+        setnilvalue(o);
+}
+
+static void shrinkstack(lua_State* L)
+{
+    // compute used stack - note that we can't use th->top if we're in the middle of vararg call
+    StkId lim = L->top;
+    for (CallInfo* ci = L->base_ci; ci <= L->ci; ci++)
+    {
+        LUAU_ASSERT(ci->top <= L->stack_last);
+        if (lim < ci->top)
+            lim = ci->top;
+    }
+
+    // shrink stack and callinfo arrays if we aren't using most of the space
+    int ci_used = cast_int(L->ci - L->base_ci); // number of `ci' in use
+    int s_used = cast_int(lim - L->stack);      // part of stack in use
+    if (L->size_ci > LUAI_MAXCALLS)             // handling overflow?
+        return;                                 // do not touch the stacks
+    if (3 * ci_used < L->size_ci && 2 * BASIC_CI_SIZE < L->size_ci)
+        luaD_reallocCI(L, L->size_ci / 2); // still big enough...
+    condhardstacktests(luaD_reallocCI(L, ci_used + 1));
+    if (3 * s_used < L->stacksize && 2 * (BASIC_STACK_SIZE + EXTRA_STACK) < L->stacksize)
+        luaD_reallocstack(L, L->stacksize / 2); // still big enough...
+    condhardstacktests(luaD_reallocstack(L, s_used));
+}
+
+/*
+** traverse one gray object, turning it to black.
+** Returns `quantity' traversed.
+*/
+static size_t propagatemark(global_State* g)
+{
+    GCObject* o = g->gray;
+    LUAU_ASSERT(isgray(o));
+    gray2black(o);
+    switch (o->gch.tt)
+    {
+    case LUA_TTABLE:
+    {
+        Table* h = gco2h(o);
+        g->gray = h->gclist;
+        if (traversetable(g, h)) // table is weak?
+            black2gray(o);       // keep it gray
+        return sizeof(Table) + sizeof(TValue) * h->sizearray + sizeof(LuaNode) * sizenode(h);
+    }
+    case LUA_TFUNCTION:
+    {
+        Closure* cl = gco2cl(o);
+        g->gray = cl->gclist;
+        traverseclosure(g, cl);
+        return cl->isC ? sizeCclosure(cl->nupvalues) : sizeLclosure(cl->nupvalues);
+    }
+    case LUA_TTHREAD:
+    {
+        lua_State* th = gco2th(o);
+        g->gray = th->gclist;
+
+        bool active = th->isactive || th == th->global->mainthread;
+
+        traversestack(g, th);
+
+        // active threads will need to be rescanned later to mark new stack writes so we mark them gray again
+        if (active)
+        {
+            th->gclist = g->grayagain;
+            g->grayagain = o;
+
+            black2gray(o);
+        }
+
+        // the stack needs to be cleared after the last modification of the thread state before sweep begins
+        // if the thread is inactive, we might not see the thread in this cycle so we must clear it now
+        if (!active || g->gcstate == GCSatomic)
+            clearstack(th);
+
+        // we could shrink stack at any time but we opt to do it during initial mark to do that just once per cycle
+        if (g->gcstate == GCSpropagate)
+            shrinkstack(th);
+
+        return sizeof(lua_State) + sizeof(TValue) * th->stacksize + sizeof(CallInfo) * th->size_ci;
+    }
+    case LUA_TPROTO:
+    {
+        Proto* p = gco2p(o);
+        g->gray = p->gclist;
+        traverseproto(g, p);
+        return sizeof(Proto) + sizeof(Instruction) * p->sizecode + sizeof(Proto*) * p->sizep + sizeof(TValue) * p->sizek + p->sizelineinfo +
+               sizeof(LocVar) * p->sizelocvars + sizeof(TString*) * p->sizeupvalues;
+    }
+    default:
+        LUAU_ASSERT(0);
+        return 0;
+    }
+}
+
+static size_t propagateall(global_State* g)
+{
+    size_t work = 0;
+    while (g->gray)
+    {
+        work += propagatemark(g);
+    }
+    return work;
+}
+
+/*
+** The next function tells whether a key or value can be cleared from
+** a weak table. Non-collectable objects are never removed from weak
+** tables. Strings behave as `values', so are never removed too. for
+** other objects: if really collected, cannot keep them.
+*/
+static int isobjcleared(GCObject* o)
+{
+    if (o->gch.tt == LUA_TSTRING)
+    {
+        stringmark(&o->ts); // strings are `values', so are never weak
+        return 0;
+    }
+
+    return iswhite(o);
+}
+
+#define iscleared(o) (iscollectable(o) && isobjcleared(gcvalue(o)))
+
+/*
+** clear collected entries from weaktables
+*/
+static size_t cleartable(lua_State* L, GCObject* l)
+{
+    size_t work = 0;
+    while (l)
+    {
+        Table* h = gco2h(l);
+        work += sizeof(Table) + sizeof(TValue) * h->sizearray + sizeof(LuaNode) * sizenode(h);
+
+        int i = h->sizearray;
+        while (i--)
+        {
+            TValue* o = &h->array[i];
+            if (iscleared(o))   // value was collected?
+                setnilvalue(o); // remove value
+        }
+        i = sizenode(h);
+        int activevalues = 0;
+        while (i--)
+        {
+            LuaNode* n = gnode(h, i);
+
+            // non-empty entry?
+            if (!ttisnil(gval(n)))
+            {
+                // can we clear key or value?
+                if (iscleared(gkey(n)) || iscleared(gval(n)))
+                {
+                    setnilvalue(gval(n)); // remove value ...
+                    removeentry(n);       // remove entry from table
+                }
+                else
+                {
+                    activevalues++;
+                }
+            }
+        }
+
+        if (const char* modev = gettablemode(L->global, h))
+        {
+            // are we allowed to shrink this weak table?
+            if (strchr(modev, 's'))
+            {
+                // shrink at 37.5% occupancy
+                if (activevalues < sizenode(h) * 3 / 8)
+                    luaH_resizehash(L, h, activevalues);
+            }
+        }
+
+        l = h->gclist;
+    }
+    return work;
+}
+
+static void freeobj(lua_State* L, GCObject* o, lua_Page* page)
+{
+    switch (o->gch.tt)
+    {
+    case LUA_TPROTO:
+        luaF_freeproto(L, gco2p(o), page);
+        break;
+    case LUA_TFUNCTION:
+        luaF_freeclosure(L, gco2cl(o), page);
+        break;
+    case LUA_TUPVAL:
+        luaF_freeupval(L, gco2uv(o), page);
+        break;
+    case LUA_TTABLE:
+        luaH_free(L, gco2h(o), page);
+        break;
+    case LUA_TTHREAD:
+        LUAU_ASSERT(gco2th(o) != L && gco2th(o) != L->global->mainthread);
+        luaE_freethread(L, gco2th(o), page);
+        break;
+    case LUA_TSTRING:
+        luaS_free(L, gco2ts(o), page);
+        break;
+    case LUA_TUSERDATA:
+        luaU_freeudata(L, gco2u(o), page);
+        break;
+    case LUA_TBUFFER:
+        luaB_freebuffer(L, gco2buf(o), page);
+        break;
+    default:
+        LUAU_ASSERT(0);
+    }
+}
+
+static void shrinkbuffers(lua_State* L)
+{
+    global_State* g = L->global;
+    // check size of string hash
+    if (g->strt.nuse < cast_to(uint32_t, g->strt.size / 4) && g->strt.size > LUA_MINSTRTABSIZE * 2)
+        luaS_resize(L, g->strt.size / 2); // table is too big
+}
+
+static void shrinkbuffersfull(lua_State* L)
+{
+    global_State* g = L->global;
+    // check size of string hash
+    int hashsize = g->strt.size;
+    while (g->strt.nuse < cast_to(uint32_t, hashsize / 4) && hashsize > LUA_MINSTRTABSIZE * 2)
+        hashsize /= 2;
+    if (hashsize != g->strt.size)
+        luaS_resize(L, hashsize); // table is too big
+}
+
+static bool deletegco(void* context, lua_Page* page, GCObject* gco)
+{
+    lua_State* L = (lua_State*)context;
+    freeobj(L, gco, page);
+    return true;
+}
+
+void luaC_freeall(lua_State* L)
+{
+    global_State* g = L->global;
+
+    LUAU_ASSERT(L == g->mainthread);
+
+    luaM_visitgco(L, L, deletegco);
+
+    for (int i = 0; i < g->strt.size; i++) // free all string lists
+        LUAU_ASSERT(g->strt.hash[i] == NULL);
+
+    LUAU_ASSERT(L->global->strt.nuse == 0);
+}
+
+static void markmt(global_State* g)
+{
+    int i;
+    for (i = 0; i < LUA_T_COUNT; i++)
+        if (g->mt[i])
+            markobject(g, g->mt[i]);
+}
+
+// mark root set
+static void markroot(lua_State* L)
+{
+    global_State* g = L->global;
+    g->gray = NULL;
+    g->grayagain = NULL;
+    g->weak = NULL;
+    markobject(g, g->mainthread);
+    // make global table be traversed before main stack
+    markobject(g, g->mainthread->gt);
+    markvalue(g, registry(L));
+    markmt(g);
+    g->gcstate = GCSpropagate;
+}
+
+static size_t remarkupvals(global_State* g)
+{
+    size_t work = 0;
+
+    for (UpVal* uv = g->uvhead.u.open.next; uv != &g->uvhead; uv = uv->u.open.next)
+    {
+        work += sizeof(UpVal);
+
+        LUAU_ASSERT(upisopen(uv));
+        LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+        LUAU_ASSERT(!isblack(obj2gco(uv))); // open upvalues are never black
+
+        if (isgray(obj2gco(uv)))
+            markvalue(g, uv->v);
+    }
+
+    return work;
+}
+
+static size_t clearupvals(lua_State* L)
+{
+    global_State* g = L->global;
+
+    size_t work = 0;
+
+    for (UpVal* uv = g->uvhead.u.open.next; uv != &g->uvhead;)
+    {
+        work += sizeof(UpVal);
+
+        LUAU_ASSERT(upisopen(uv));
+        LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+        LUAU_ASSERT(!isblack(obj2gco(uv))); // open upvalues are never black
+        LUAU_ASSERT(iswhite(obj2gco(uv)) || !iscollectable(uv->v) || !iswhite(gcvalue(uv->v)));
+
+        if (uv->markedopen)
+        {
+            // upvalue is still open (belongs to alive thread)
+            LUAU_ASSERT(isgray(obj2gco(uv)));
+            uv->markedopen = 0; // for next cycle
+            uv = uv->u.open.next;
+        }
+        else
+        {
+            // upvalue is either dead, or alive but the thread is dead; unlink and close
+            UpVal* next = uv->u.open.next;
+            luaF_closeupval(L, uv, /* dead= */ iswhite(obj2gco(uv)));
+            uv = next;
+        }
+    }
+
+    return work;
+}
+
+static size_t atomic(lua_State* L)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT(g->gcstate == GCSatomic);
+
+    size_t work = 0;
+
+#ifdef LUAI_GCMETRICS
+    double currts = lua_clock();
+#endif
+
+    // remark occasional upvalues of (maybe) dead threads
+    work += remarkupvals(g);
+    // traverse objects caught by write barrier and by 'remarkupvals'
+    work += propagateall(g);
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics.currcycle.atomictimeupval += recordGcDeltaTime(currts);
+#endif
+
+    // remark weak tables
+    g->gray = g->weak;
+    g->weak = NULL;
+    LUAU_ASSERT(!iswhite(obj2gco(g->mainthread)));
+    markobject(g, L); // mark running thread
+    markmt(g);        // mark basic metatables (again)
+    work += propagateall(g);
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics.currcycle.atomictimeweak += recordGcDeltaTime(currts);
+#endif
+
+    // remark gray again
+    g->gray = g->grayagain;
+    g->grayagain = NULL;
+    work += propagateall(g);
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics.currcycle.atomictimegray += recordGcDeltaTime(currts);
+#endif
+
+    // remove collected objects from weak tables
+    work += cleartable(L, g->weak);
+    g->weak = NULL;
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics.currcycle.atomictimeclear += recordGcDeltaTime(currts);
+#endif
+
+    // close orphaned live upvalues of dead threads and clear dead upvalues
+    work += clearupvals(L);
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics.currcycle.atomictimeupval += recordGcDeltaTime(currts);
+#endif
+
+    // flip current white
+    g->currentwhite = cast_byte(otherwhite(g));
+    g->sweepgcopage = g->allgcopages;
+    g->gcstate = GCSsweep;
+
+    return work;
+}
+
+// a version of generic luaM_visitpage specialized for the main sweep stage
+static int sweepgcopage(lua_State* L, lua_Page* page)
+{
+    char* start;
+    char* end;
+    int busyBlocks;
+    int blockSize;
+    luaM_getpagewalkinfo(page, &start, &end, &busyBlocks, &blockSize);
+
+    LUAU_ASSERT(busyBlocks > 0);
+
+    global_State* g = L->global;
+
+    int deadmask = otherwhite(g);
+    LUAU_ASSERT(testbit(deadmask, FIXEDBIT)); // make sure we never sweep fixed objects
+
+    int newwhite = luaC_white(g);
+
+    for (char* pos = start; pos != end; pos += blockSize)
+    {
+        GCObject* gco = (GCObject*)pos;
+
+        // skip memory blocks that are already freed
+        if (gco->gch.tt == LUA_TNIL)
+            continue;
+
+        // is the object alive?
+        if ((gco->gch.marked ^ WHITEBITS) & deadmask)
+        {
+            LUAU_ASSERT(!isdead(g, gco));
+            // make it white (for next cycle)
+            gco->gch.marked = cast_byte((gco->gch.marked & maskmarks) | newwhite);
+        }
+        else
+        {
+            LUAU_ASSERT(isdead(g, gco));
+            freeobj(L, gco, page);
+
+            // if the last block was removed, page would be removed as well
+            if (--busyBlocks == 0)
+                return int(pos - start) / blockSize + 1;
+        }
+    }
+
+    return int(end - start) / blockSize;
+}
+
+static size_t gcstep(lua_State* L, size_t limit)
+{
+    size_t cost = 0;
+    global_State* g = L->global;
+    switch (g->gcstate)
+    {
+    case GCSpause:
+    {
+        markroot(L); // start a new collection
+        LUAU_ASSERT(g->gcstate == GCSpropagate);
+        break;
+    }
+    case GCSpropagate:
+    {
+        while (g->gray && cost < limit)
+        {
+            cost += propagatemark(g);
+        }
+
+        if (!g->gray)
+        {
+#ifdef LUAI_GCMETRICS
+            g->gcmetrics.currcycle.propagatework = g->gcmetrics.currcycle.explicitwork + g->gcmetrics.currcycle.assistwork;
+#endif
+
+            // perform one iteration over 'gray again' list
+            g->gray = g->grayagain;
+            g->grayagain = NULL;
+
+            g->gcstate = GCSpropagateagain;
+        }
+        break;
+    }
+    case GCSpropagateagain:
+    {
+        while (g->gray && cost < limit)
+        {
+            cost += propagatemark(g);
+        }
+
+        if (!g->gray) // no more `gray' objects
+        {
+#ifdef LUAI_GCMETRICS
+            g->gcmetrics.currcycle.propagateagainwork =
+                g->gcmetrics.currcycle.explicitwork + g->gcmetrics.currcycle.assistwork - g->gcmetrics.currcycle.propagatework;
+#endif
+
+            g->gcstate = GCSatomic;
+        }
+        break;
+    }
+    case GCSatomic:
+    {
+#ifdef LUAI_GCMETRICS
+        g->gcmetrics.currcycle.atomicstarttimestamp = lua_clock();
+        g->gcmetrics.currcycle.atomicstarttotalsizebytes = g->totalbytes;
+#endif
+
+        g->gcstats.atomicstarttimestamp = lua_clock();
+        g->gcstats.atomicstarttotalsizebytes = g->totalbytes;
+
+        cost = atomic(L); // finish mark phase
+
+        LUAU_ASSERT(g->gcstate == GCSsweep);
+        break;
+    }
+    case GCSsweep:
+    {
+        while (g->sweepgcopage && cost < limit)
+        {
+            lua_Page* next = luaM_getnextgcopage(g->sweepgcopage); // page sweep might destroy the page
+
+            int steps = sweepgcopage(L, g->sweepgcopage);
+
+            g->sweepgcopage = next;
+            cost += steps * GC_SWEEPPAGESTEPCOST;
+        }
+
+        // nothing more to sweep?
+        if (g->sweepgcopage == NULL)
+        {
+            // don't forget to visit main thread, it's the only object not allocated in GCO pages
+            LUAU_ASSERT(!isdead(g, obj2gco(g->mainthread)));
+            makewhite(g, obj2gco(g->mainthread)); // make it white (for next cycle)
+
+            shrinkbuffers(L);
+
+            g->gcstate = GCSpause; // end collection
+        }
+        break;
+    }
+    default:
+        LUAU_ASSERT(!"Unexpected GC state");
+    }
+    return cost;
+}
+
+static int64_t getheaptriggererroroffset(global_State* g)
+{
+    // adjust for error using Proportional-Integral controller
+    // https://en.wikipedia.org/wiki/PID_controller
+    int32_t errorKb = int32_t((g->gcstats.atomicstarttotalsizebytes - g->gcstats.heapgoalsizebytes) / 1024);
+
+    // we use sliding window for the error integral to avoid error sum 'windup' when the desired target cannot be reached
+    const size_t triggertermcount = sizeof(g->gcstats.triggerterms) / sizeof(g->gcstats.triggerterms[0]);
+
+    int32_t* slot = &g->gcstats.triggerterms[g->gcstats.triggertermpos % triggertermcount];
+    int32_t prev = *slot;
+    *slot = errorKb;
+    g->gcstats.triggerintegral += errorKb - prev;
+    g->gcstats.triggertermpos++;
+
+    // controller tuning
+    // https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method
+    const double Ku = 0.9; // ultimate gain (measured)
+    const double Tu = 2.5; // oscillation period (measured)
+
+    const double Kp = 0.45 * Ku; // proportional gain
+    const double Ti = 0.8 * Tu;
+    const double Ki = 0.54 * Ku / Ti; // integral gain
+
+    double proportionalTerm = Kp * errorKb;
+    double integralTerm = Ki * g->gcstats.triggerintegral;
+
+    double totalTerm = proportionalTerm + integralTerm;
+
+    return int64_t(totalTerm * 1024);
+}
+
+static size_t getheaptrigger(global_State* g, size_t heapgoal)
+{
+    // adjust threshold based on a guess of how many bytes will be allocated between the cycle start and sweep phase
+    // our goal is to begin the sweep when used memory has reached the heap goal
+    const double durationthreshold = 1e-3;
+    double allocationduration = g->gcstats.atomicstarttimestamp - g->gcstats.endtimestamp;
+
+    // avoid measuring intervals smaller than 1ms
+    if (allocationduration < durationthreshold)
+        return heapgoal;
+
+    double allocationrate = (g->gcstats.atomicstarttotalsizebytes - g->gcstats.endtotalsizebytes) / allocationduration;
+    double markduration = g->gcstats.atomicstarttimestamp - g->gcstats.starttimestamp;
+
+    int64_t expectedgrowth = int64_t(markduration * allocationrate);
+    int64_t offset = getheaptriggererroroffset(g);
+    int64_t heaptrigger = heapgoal - (expectedgrowth + offset);
+
+    // clamp the trigger between memory use at the end of the cycle and the heap goal
+    return heaptrigger < int64_t(g->totalbytes) ? g->totalbytes : (heaptrigger > int64_t(heapgoal) ? heapgoal : size_t(heaptrigger));
+}
+
+size_t luaC_step(lua_State* L, bool assist)
+{
+    global_State* g = L->global;
+
+    int lim = g->gcstepsize * g->gcstepmul / 100; // how much to work
+    LUAU_ASSERT(g->totalbytes >= g->GCthreshold);
+    size_t debt = g->totalbytes - g->GCthreshold;
+
+    GC_INTERRUPT(0);
+
+    // at the start of the new cycle
+    if (g->gcstate == GCSpause)
+        g->gcstats.starttimestamp = lua_clock();
+
+#ifdef LUAI_GCMETRICS
+    if (g->gcstate == GCSpause)
+        startGcCycleMetrics(g);
+
+    double lasttimestamp = lua_clock();
+#endif
+
+    int lastgcstate = g->gcstate;
+
+    size_t work = gcstep(L, lim);
+
+#ifdef LUAI_GCMETRICS
+    recordGcStateStep(g, lastgcstate, lua_clock() - lasttimestamp, assist, work);
+#endif
+
+    size_t actualstepsize = work * 100 / g->gcstepmul;
+
+    // at the end of the last cycle
+    if (g->gcstate == GCSpause)
+    {
+        // at the end of a collection cycle, set goal based on gcgoal setting
+        size_t heapgoal = (g->totalbytes / 100) * g->gcgoal;
+        size_t heaptrigger = getheaptrigger(g, heapgoal);
+
+        g->GCthreshold = heaptrigger;
+
+        g->gcstats.heapgoalsizebytes = heapgoal;
+        g->gcstats.endtimestamp = lua_clock();
+        g->gcstats.endtotalsizebytes = g->totalbytes;
+
+#ifdef LUAI_GCMETRICS
+        finishGcCycleMetrics(g);
+#endif
+    }
+    else
+    {
+        g->GCthreshold = g->totalbytes + actualstepsize;
+
+        // compensate if GC is "behind schedule" (has some debt to pay)
+        if (g->GCthreshold >= debt)
+            g->GCthreshold -= debt;
+    }
+
+    GC_INTERRUPT(lastgcstate);
+
+    return actualstepsize;
+}
+
+void luaC_fullgc(lua_State* L)
+{
+    global_State* g = L->global;
+
+#ifdef LUAI_GCMETRICS
+    if (g->gcstate == GCSpause)
+        startGcCycleMetrics(g);
+#endif
+
+    if (keepinvariant(g))
+    {
+        // reset sweep marks to sweep all elements (returning them to white)
+        g->sweepgcopage = g->allgcopages;
+        // reset other collector lists
+        g->gray = NULL;
+        g->grayagain = NULL;
+        g->weak = NULL;
+        g->gcstate = GCSsweep;
+    }
+    LUAU_ASSERT(g->gcstate == GCSpause || g->gcstate == GCSsweep);
+    // finish any pending sweep phase
+    while (g->gcstate != GCSpause)
+    {
+        LUAU_ASSERT(g->gcstate == GCSsweep);
+        gcstep(L, SIZE_MAX);
+    }
+
+    // clear markedopen bits for all open upvalues; these might be stuck from half-finished mark prior to full gc
+    for (UpVal* uv = g->uvhead.u.open.next; uv != &g->uvhead; uv = uv->u.open.next)
+    {
+        LUAU_ASSERT(upisopen(uv));
+        uv->markedopen = 0;
+    }
+
+#ifdef LUAI_GCMETRICS
+    finishGcCycleMetrics(g);
+    startGcCycleMetrics(g);
+#endif
+
+    // run a full collection cycle
+    markroot(L);
+    while (g->gcstate != GCSpause)
+    {
+        gcstep(L, SIZE_MAX);
+    }
+    // reclaim as much buffer memory as possible (shrinkbuffers() called during sweep is incremental)
+    shrinkbuffersfull(L);
+
+    size_t heapgoalsizebytes = (g->totalbytes / 100) * g->gcgoal;
+
+    // trigger cannot be correctly adjusted after a forced full GC.
+    // we will try to place it so that we can reach the goal based on
+    // the rate at which we run the GC relative to allocation rate
+    // and on amount of bytes we need to traverse in propagation stage.
+    // goal and stepmul are defined in percents
+    g->GCthreshold = g->totalbytes * (g->gcgoal * g->gcstepmul / 100 - 100) / g->gcstepmul;
+
+    // but it might be impossible to satisfy that directly
+    if (g->GCthreshold < g->totalbytes)
+        g->GCthreshold = g->totalbytes;
+
+    g->gcstats.heapgoalsizebytes = heapgoalsizebytes;
+
+#ifdef LUAI_GCMETRICS
+    finishGcCycleMetrics(g);
+#endif
+}
+
+void luaC_barrierf(lua_State* L, GCObject* o, GCObject* v)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT(isblack(o) && iswhite(v) && !isdead(g, v) && !isdead(g, o));
+    LUAU_ASSERT(g->gcstate != GCSpause);
+    // must keep invariant?
+    if (keepinvariant(g))
+        reallymarkobject(g, v); // restore invariant
+    else                        // don't mind
+        makewhite(g, o);        // mark as white just to avoid other barriers
+}
+
+void luaC_barriertable(lua_State* L, Table* t, GCObject* v)
+{
+    global_State* g = L->global;
+    GCObject* o = obj2gco(t);
+
+    // in the second propagation stage, table assignment barrier works as a forward barrier
+    if (g->gcstate == GCSpropagateagain)
+    {
+        LUAU_ASSERT(isblack(o) && iswhite(v) && !isdead(g, v) && !isdead(g, o));
+        reallymarkobject(g, v);
+        return;
+    }
+
+    LUAU_ASSERT(isblack(o) && !isdead(g, o));
+    LUAU_ASSERT(g->gcstate != GCSpause);
+    black2gray(o); // make table gray (again)
+    t->gclist = g->grayagain;
+    g->grayagain = o;
+}
+
+void luaC_barrierback(lua_State* L, GCObject* o, GCObject** gclist)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT(isblack(o) && !isdead(g, o));
+    LUAU_ASSERT(g->gcstate != GCSpause);
+
+    black2gray(o); // make object gray (again)
+    *gclist = g->grayagain;
+    g->grayagain = o;
+}
+
+void luaC_upvalclosed(lua_State* L, UpVal* uv)
+{
+    global_State* g = L->global;
+    GCObject* o = obj2gco(uv);
+
+    LUAU_ASSERT(!upisopen(uv)); // upvalue was closed but needs GC state fixup
+
+    if (isgray(o))
+    {
+        if (keepinvariant(g))
+        {
+            gray2black(o); // closed upvalues need barrier
+            luaC_barrier(L, uv, uv->v);
+        }
+        else
+        { // sweep phase: sweep it (turning it into white)
+            makewhite(g, o);
+            LUAU_ASSERT(g->gcstate != GCSpause);
+        }
+    }
+}
+
+// measure the allocation rate in bytes/sec
+// returns -1 if allocation rate cannot be measured
+int64_t luaC_allocationrate(lua_State* L)
+{
+    global_State* g = L->global;
+    const double durationthreshold = 1e-3; // avoid measuring intervals smaller than 1ms
+
+    if (g->gcstate <= GCSatomic)
+    {
+        double duration = lua_clock() - g->gcstats.endtimestamp;
+
+        if (duration < durationthreshold)
+            return -1;
+
+        return int64_t((g->totalbytes - g->gcstats.endtotalsizebytes) / duration);
+    }
+
+    // totalbytes is unstable during the sweep, use the rate measured at the end of mark phase
+    double duration = g->gcstats.atomicstarttimestamp - g->gcstats.endtimestamp;
+
+    if (duration < durationthreshold)
+        return -1;
+
+    return int64_t((g->gcstats.atomicstarttotalsizebytes - g->gcstats.endtotalsizebytes) / duration);
+}
+
+const char* luaC_statename(int state)
+{
+    switch (state)
+    {
+    case GCSpause:
+        return "pause";
+
+    case GCSpropagate:
+        return "mark";
+
+    case GCSpropagateagain:
+        return "remark";
+
+    case GCSatomic:
+        return "atomic";
+
+    case GCSsweep:
+        return "sweep";
+
+    default:
+        return NULL;
+    }
+}

--- a/lib/luau/VM/src/lgc.h
+++ b/lib/luau/VM/src/lgc.h
@@ -1,0 +1,143 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "ldo.h"
+#include "lobject.h"
+#include "lstate.h"
+
+/*
+** Default settings for GC tunables (settable via lua_gc)
+*/
+#define LUAI_GCGOAL 200    // 200% (allow heap to double compared to live heap size)
+#define LUAI_GCSTEPMUL 200 // GC runs 'twice the speed' of memory allocation
+#define LUAI_GCSTEPSIZE 1  // GC runs every KB of memory allocation
+
+/*
+** Possible states of the Garbage Collector
+*/
+#define GCSpause 0
+#define GCSpropagate 1
+#define GCSpropagateagain 2
+#define GCSatomic 3
+#define GCSsweep 4
+
+/*
+** macro to tell when main invariant (white objects cannot point to black
+** ones) must be kept. During a collection, the sweep
+** phase may break the invariant, as objects turned white may point to
+** still-black objects. The invariant is restored when sweep ends and
+** all objects are white again.
+*/
+#define keepinvariant(g) ((g)->gcstate == GCSpropagate || (g)->gcstate == GCSpropagateagain || (g)->gcstate == GCSatomic)
+
+/*
+** some useful bit tricks
+*/
+#define resetbits(x, m) ((x) &= cast_to(uint8_t, ~(m)))
+#define setbits(x, m) ((x) |= (m))
+#define testbits(x, m) ((x) & (m))
+#define bitmask(b) (1 << (b))
+#define bit2mask(b1, b2) (bitmask(b1) | bitmask(b2))
+#define l_setbit(x, b) setbits(x, bitmask(b))
+#define resetbit(x, b) resetbits(x, bitmask(b))
+#define testbit(x, b) testbits(x, bitmask(b))
+#define set2bits(x, b1, b2) setbits(x, (bit2mask(b1, b2)))
+#define reset2bits(x, b1, b2) resetbits(x, (bit2mask(b1, b2)))
+#define test2bits(x, b1, b2) testbits(x, (bit2mask(b1, b2)))
+
+/*
+** Layout for bit use in `marked' field:
+** bit 0 - object is white (type 0)
+** bit 1 - object is white (type 1)
+** bit 2 - object is black
+** bit 3 - object is fixed (should not be collected)
+*/
+
+#define WHITE0BIT 0
+#define WHITE1BIT 1
+#define BLACKBIT 2
+#define FIXEDBIT 3
+#define WHITEBITS bit2mask(WHITE0BIT, WHITE1BIT)
+
+#define iswhite(x) test2bits((x)->gch.marked, WHITE0BIT, WHITE1BIT)
+#define isblack(x) testbit((x)->gch.marked, BLACKBIT)
+#define isgray(x) (!testbits((x)->gch.marked, WHITEBITS | bitmask(BLACKBIT)))
+#define isfixed(x) testbit((x)->gch.marked, FIXEDBIT)
+
+#define otherwhite(g) (g->currentwhite ^ WHITEBITS)
+#define isdead(g, v) (((v)->gch.marked & (WHITEBITS | bitmask(FIXEDBIT))) == (otherwhite(g) & WHITEBITS))
+
+#define changewhite(x) ((x)->gch.marked ^= WHITEBITS)
+#define gray2black(x) l_setbit((x)->gch.marked, BLACKBIT)
+
+#define luaC_white(g) cast_to(uint8_t, ((g)->currentwhite) & WHITEBITS)
+
+#define luaC_needsGC(L) (L->global->totalbytes >= L->global->GCthreshold)
+
+#define luaC_checkGC(L) \
+    { \
+        condhardstacktests(luaD_reallocstack(L, L->stacksize - EXTRA_STACK)); \
+        if (luaC_needsGC(L)) \
+        { \
+            condhardmemtests(luaC_validate(L), 1); \
+            luaC_step(L, true); \
+        } \
+        else \
+        { \
+            condhardmemtests(luaC_validate(L), 2); \
+        } \
+    }
+
+#define luaC_barrier(L, p, v) \
+    { \
+        if (iscollectable(v) && isblack(obj2gco(p)) && iswhite(gcvalue(v))) \
+            luaC_barrierf(L, obj2gco(p), gcvalue(v)); \
+    }
+
+#define luaC_barriert(L, t, v) \
+    { \
+        if (iscollectable(v) && isblack(obj2gco(t)) && iswhite(gcvalue(v))) \
+            luaC_barriertable(L, t, gcvalue(v)); \
+    }
+
+#define luaC_barrierfast(L, t) \
+    { \
+        if (isblack(obj2gco(t))) \
+            luaC_barrierback(L, obj2gco(t), &t->gclist); \
+    }
+
+#define luaC_objbarrier(L, p, o) \
+    { \
+        if (isblack(obj2gco(p)) && iswhite(obj2gco(o))) \
+            luaC_barrierf(L, obj2gco(p), obj2gco(o)); \
+    }
+
+#define luaC_threadbarrier(L) \
+    { \
+        if (isblack(obj2gco(L))) \
+            luaC_barrierback(L, obj2gco(L), &L->gclist); \
+    }
+
+#define luaC_init(L, o, tt_) \
+    { \
+        o->marked = luaC_white(L->global); \
+        o->tt = tt_; \
+        o->memcat = L->activememcat; \
+    }
+
+LUAI_FUNC void luaC_freeall(lua_State* L);
+LUAI_FUNC size_t luaC_step(lua_State* L, bool assist);
+LUAI_FUNC void luaC_fullgc(lua_State* L);
+LUAI_FUNC void luaC_initobj(lua_State* L, GCObject* o, uint8_t tt);
+LUAI_FUNC void luaC_upvalclosed(lua_State* L, UpVal* uv);
+LUAI_FUNC void luaC_barrierf(lua_State* L, GCObject* o, GCObject* v);
+LUAI_FUNC void luaC_barriertable(lua_State* L, Table* t, GCObject* v);
+LUAI_FUNC void luaC_barrierback(lua_State* L, GCObject* o, GCObject** gclist);
+LUAI_FUNC void luaC_validate(lua_State* L);
+LUAI_FUNC void luaC_dump(lua_State* L, void* file, const char* (*categoryName)(lua_State* L, uint8_t memcat));
+LUAI_FUNC void luaC_enumheap(lua_State* L, void* context,
+    void (*node)(void* context, void* ptr, uint8_t tt, uint8_t memcat, size_t size, const char* name),
+    void (*edge)(void* context, void* from, void* to, const char* name));
+LUAI_FUNC int64_t luaC_allocationrate(lua_State* L);
+LUAI_FUNC const char* luaC_statename(int state);

--- a/lib/luau/VM/src/lgcdebug.cpp
+++ b/lib/luau/VM/src/lgcdebug.cpp
@@ -1,0 +1,897 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lgc.h"
+
+#include "lfunc.h"
+#include "lmem.h"
+#include "lobject.h"
+#include "lstate.h"
+#include "lstring.h"
+#include "ltable.h"
+#include "ludata.h"
+#include "lbuffer.h"
+
+#include <string.h>
+#include <stdio.h>
+
+static void validateobjref(global_State* g, GCObject* f, GCObject* t)
+{
+    LUAU_ASSERT(!isdead(g, t));
+
+    if (keepinvariant(g))
+    {
+        // basic incremental invariant: black can't point to white
+        LUAU_ASSERT(!(isblack(f) && iswhite(t)));
+    }
+}
+
+static void validateref(global_State* g, GCObject* f, TValue* v)
+{
+    if (iscollectable(v))
+    {
+        LUAU_ASSERT(ttype(v) == gcvalue(v)->gch.tt);
+        validateobjref(g, f, gcvalue(v));
+    }
+}
+
+static void validatetable(global_State* g, Table* h)
+{
+    int sizenode = 1 << h->lsizenode;
+
+    LUAU_ASSERT(h->lastfree <= sizenode);
+
+    if (h->metatable)
+        validateobjref(g, obj2gco(h), obj2gco(h->metatable));
+
+    for (int i = 0; i < h->sizearray; ++i)
+        validateref(g, obj2gco(h), &h->array[i]);
+
+    for (int i = 0; i < sizenode; ++i)
+    {
+        LuaNode* n = &h->node[i];
+
+        LUAU_ASSERT(ttype(gkey(n)) != LUA_TDEADKEY || ttisnil(gval(n)));
+        LUAU_ASSERT(i + gnext(n) >= 0 && i + gnext(n) < sizenode);
+
+        if (!ttisnil(gval(n)))
+        {
+            TValue k = {};
+            k.tt = gkey(n)->tt;
+            k.value = gkey(n)->value;
+
+            validateref(g, obj2gco(h), &k);
+            validateref(g, obj2gco(h), gval(n));
+        }
+    }
+}
+
+static void validateclosure(global_State* g, Closure* cl)
+{
+    validateobjref(g, obj2gco(cl), obj2gco(cl->env));
+
+    if (cl->isC)
+    {
+        for (int i = 0; i < cl->nupvalues; ++i)
+            validateref(g, obj2gco(cl), &cl->c.upvals[i]);
+    }
+    else
+    {
+        LUAU_ASSERT(cl->nupvalues == cl->l.p->nups);
+
+        validateobjref(g, obj2gco(cl), obj2gco(cl->l.p));
+
+        for (int i = 0; i < cl->nupvalues; ++i)
+            validateref(g, obj2gco(cl), &cl->l.uprefs[i]);
+    }
+}
+
+static void validatestack(global_State* g, lua_State* l)
+{
+    validateobjref(g, obj2gco(l), obj2gco(l->gt));
+
+    for (CallInfo* ci = l->base_ci; ci <= l->ci; ++ci)
+    {
+        LUAU_ASSERT(l->stack <= ci->base);
+        LUAU_ASSERT(ci->func <= ci->base && ci->base <= ci->top);
+        LUAU_ASSERT(ci->top <= l->stack_last);
+    }
+
+    // note: stack refs can violate gc invariant so we only check for liveness
+    for (StkId o = l->stack; o < l->top; ++o)
+        checkliveness(g, o);
+
+    if (l->namecall)
+        validateobjref(g, obj2gco(l), obj2gco(l->namecall));
+
+    for (UpVal* uv = l->openupval; uv; uv = uv->u.open.threadnext)
+    {
+        LUAU_ASSERT(uv->tt == LUA_TUPVAL);
+        LUAU_ASSERT(upisopen(uv));
+        LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+        LUAU_ASSERT(!isblack(obj2gco(uv))); // open upvalues are never black
+    }
+}
+
+static void validateproto(global_State* g, Proto* f)
+{
+    if (f->source)
+        validateobjref(g, obj2gco(f), obj2gco(f->source));
+
+    if (f->debugname)
+        validateobjref(g, obj2gco(f), obj2gco(f->debugname));
+
+    for (int i = 0; i < f->sizek; ++i)
+        validateref(g, obj2gco(f), &f->k[i]);
+
+    for (int i = 0; i < f->sizeupvalues; ++i)
+        if (f->upvalues[i])
+            validateobjref(g, obj2gco(f), obj2gco(f->upvalues[i]));
+
+    for (int i = 0; i < f->sizep; ++i)
+        if (f->p[i])
+            validateobjref(g, obj2gco(f), obj2gco(f->p[i]));
+
+    for (int i = 0; i < f->sizelocvars; i++)
+        if (f->locvars[i].varname)
+            validateobjref(g, obj2gco(f), obj2gco(f->locvars[i].varname));
+}
+
+static void validateobj(global_State* g, GCObject* o)
+{
+    // dead objects can only occur during sweep
+    if (isdead(g, o))
+    {
+        LUAU_ASSERT(g->gcstate == GCSsweep);
+        return;
+    }
+
+    switch (o->gch.tt)
+    {
+    case LUA_TSTRING:
+        break;
+
+    case LUA_TTABLE:
+        validatetable(g, gco2h(o));
+        break;
+
+    case LUA_TFUNCTION:
+        validateclosure(g, gco2cl(o));
+        break;
+
+    case LUA_TUSERDATA:
+        if (gco2u(o)->metatable)
+            validateobjref(g, o, obj2gco(gco2u(o)->metatable));
+        break;
+
+    case LUA_TTHREAD:
+        validatestack(g, gco2th(o));
+        break;
+
+    case LUA_TBUFFER:
+        break;
+
+    case LUA_TPROTO:
+        validateproto(g, gco2p(o));
+        break;
+
+    case LUA_TUPVAL:
+        validateref(g, o, gco2uv(o)->v);
+        break;
+
+    default:
+        LUAU_ASSERT(!"unexpected object type");
+    }
+}
+
+static void validategraylist(global_State* g, GCObject* o)
+{
+    if (!keepinvariant(g))
+        return;
+
+    while (o)
+    {
+        LUAU_ASSERT(isgray(o));
+
+        switch (o->gch.tt)
+        {
+        case LUA_TTABLE:
+            o = gco2h(o)->gclist;
+            break;
+        case LUA_TFUNCTION:
+            o = gco2cl(o)->gclist;
+            break;
+        case LUA_TTHREAD:
+            o = gco2th(o)->gclist;
+            break;
+        case LUA_TPROTO:
+            o = gco2p(o)->gclist;
+            break;
+        default:
+            LUAU_ASSERT(!"unknown object in gray list");
+            return;
+        }
+    }
+}
+
+static bool validategco(void* context, lua_Page* page, GCObject* gco)
+{
+    lua_State* L = (lua_State*)context;
+    global_State* g = L->global;
+
+    validateobj(g, gco);
+    return false;
+}
+
+void luaC_validate(lua_State* L)
+{
+    global_State* g = L->global;
+
+    LUAU_ASSERT(!isdead(g, obj2gco(g->mainthread)));
+    checkliveness(g, &g->registry);
+
+    for (int i = 0; i < LUA_T_COUNT; ++i)
+        if (g->mt[i])
+            LUAU_ASSERT(!isdead(g, obj2gco(g->mt[i])));
+
+    validategraylist(g, g->weak);
+    validategraylist(g, g->gray);
+    validategraylist(g, g->grayagain);
+
+    validategco(L, NULL, obj2gco(g->mainthread));
+
+    luaM_visitgco(L, L, validategco);
+
+    for (UpVal* uv = g->uvhead.u.open.next; uv != &g->uvhead; uv = uv->u.open.next)
+    {
+        LUAU_ASSERT(uv->tt == LUA_TUPVAL);
+        LUAU_ASSERT(upisopen(uv));
+        LUAU_ASSERT(uv->u.open.next->u.open.prev == uv && uv->u.open.prev->u.open.next == uv);
+        LUAU_ASSERT(!isblack(obj2gco(uv))); // open upvalues are never black
+    }
+}
+
+inline bool safejson(char ch)
+{
+    return unsigned(ch) < 128 && ch >= 32 && ch != '\\' && ch != '\"';
+}
+
+static void dumpref(FILE* f, GCObject* o)
+{
+    fprintf(f, "\"%p\"", o);
+}
+
+static void dumprefs(FILE* f, TValue* data, size_t size)
+{
+    bool first = true;
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (iscollectable(&data[i]))
+        {
+            if (!first)
+                fputc(',', f);
+            first = false;
+
+            dumpref(f, gcvalue(&data[i]));
+        }
+    }
+}
+
+static void dumpstringdata(FILE* f, const char* data, size_t len)
+{
+    for (size_t i = 0; i < len; ++i)
+        fputc(safejson(data[i]) ? data[i] : '?', f);
+}
+
+static void dumpstring(FILE* f, TString* ts)
+{
+    fprintf(f, "{\"type\":\"string\",\"cat\":%d,\"size\":%d,\"data\":\"", ts->memcat, int(sizestring(ts->len)));
+    dumpstringdata(f, ts->data, ts->len);
+    fprintf(f, "\"}");
+}
+
+static void dumptable(FILE* f, Table* h)
+{
+    size_t size = sizeof(Table) + (h->node == &luaH_dummynode ? 0 : sizenode(h) * sizeof(LuaNode)) + h->sizearray * sizeof(TValue);
+
+    fprintf(f, "{\"type\":\"table\",\"cat\":%d,\"size\":%d", h->memcat, int(size));
+
+    if (h->node != &luaH_dummynode)
+    {
+        fprintf(f, ",\"pairs\":[");
+
+        bool first = true;
+
+        for (int i = 0; i < sizenode(h); ++i)
+        {
+            const LuaNode& n = h->node[i];
+
+            if (!ttisnil(&n.val) && (iscollectable(&n.key) || iscollectable(&n.val)))
+            {
+                if (!first)
+                    fputc(',', f);
+                first = false;
+
+                if (iscollectable(&n.key))
+                    dumpref(f, gcvalue(&n.key));
+                else
+                    fprintf(f, "null");
+
+                fputc(',', f);
+
+                if (iscollectable(&n.val))
+                    dumpref(f, gcvalue(&n.val));
+                else
+                    fprintf(f, "null");
+            }
+        }
+
+        fprintf(f, "]");
+    }
+    if (h->sizearray)
+    {
+        fprintf(f, ",\"array\":[");
+        dumprefs(f, h->array, h->sizearray);
+        fprintf(f, "]");
+    }
+    if (h->metatable)
+    {
+        fprintf(f, ",\"metatable\":");
+        dumpref(f, obj2gco(h->metatable));
+    }
+    fprintf(f, "}");
+}
+
+static void dumpclosure(FILE* f, Closure* cl)
+{
+    fprintf(f, "{\"type\":\"function\",\"cat\":%d,\"size\":%d", cl->memcat,
+        cl->isC ? int(sizeCclosure(cl->nupvalues)) : int(sizeLclosure(cl->nupvalues)));
+
+    fprintf(f, ",\"env\":");
+    dumpref(f, obj2gco(cl->env));
+
+    if (cl->isC)
+    {
+        if (cl->c.debugname)
+            fprintf(f, ",\"name\":\"%s\"", cl->c.debugname + 0);
+
+        if (cl->nupvalues)
+        {
+            fprintf(f, ",\"upvalues\":[");
+            dumprefs(f, cl->c.upvals, cl->nupvalues);
+            fprintf(f, "]");
+        }
+    }
+    else
+    {
+        if (cl->l.p->debugname)
+            fprintf(f, ",\"name\":\"%s\"", getstr(cl->l.p->debugname));
+
+        fprintf(f, ",\"proto\":");
+        dumpref(f, obj2gco(cl->l.p));
+        if (cl->nupvalues)
+        {
+            fprintf(f, ",\"upvalues\":[");
+            dumprefs(f, cl->l.uprefs, cl->nupvalues);
+            fprintf(f, "]");
+        }
+    }
+    fprintf(f, "}");
+}
+
+static void dumpudata(FILE* f, Udata* u)
+{
+    fprintf(f, "{\"type\":\"userdata\",\"cat\":%d,\"size\":%d,\"tag\":%d", u->memcat, int(sizeudata(u->len)), u->tag);
+
+    if (u->metatable)
+    {
+        fprintf(f, ",\"metatable\":");
+        dumpref(f, obj2gco(u->metatable));
+    }
+    fprintf(f, "}");
+}
+
+static void dumpthread(FILE* f, lua_State* th)
+{
+    size_t size = sizeof(lua_State) + sizeof(TValue) * th->stacksize + sizeof(CallInfo) * th->size_ci;
+
+    fprintf(f, "{\"type\":\"thread\",\"cat\":%d,\"size\":%d", th->memcat, int(size));
+
+    fprintf(f, ",\"env\":");
+    dumpref(f, obj2gco(th->gt));
+
+    Closure* tcl = 0;
+    for (CallInfo* ci = th->base_ci; ci <= th->ci; ++ci)
+    {
+        if (ttisfunction(ci->func))
+        {
+            tcl = clvalue(ci->func);
+            break;
+        }
+    }
+
+    if (tcl && !tcl->isC && tcl->l.p->source)
+    {
+        Proto* p = tcl->l.p;
+
+        fprintf(f, ",\"source\":\"");
+        dumpstringdata(f, p->source->data, p->source->len);
+        fprintf(f, "\",\"line\":%d", p->linedefined);
+    }
+
+    if (th->top > th->stack)
+    {
+        fprintf(f, ",\"stack\":[");
+        dumprefs(f, th->stack, th->top - th->stack);
+        fprintf(f, "]");
+
+        CallInfo* ci = th->base_ci;
+        bool first = true;
+
+        fprintf(f, ",\"stacknames\":[");
+        for (StkId v = th->stack; v < th->top; ++v)
+        {
+            if (!iscollectable(v))
+                continue;
+
+            while (ci < th->ci && v >= (ci + 1)->func)
+                ci++;
+
+            if (!first)
+                fputc(',', f);
+            first = false;
+
+            if (v == ci->func)
+            {
+                Closure* cl = ci_func(ci);
+
+                if (cl->isC)
+                {
+                    fprintf(f, "\"frame:%s\"", cl->c.debugname ? cl->c.debugname : "[C]");
+                }
+                else
+                {
+                    Proto* p = cl->l.p;
+                    fprintf(f, "\"frame:");
+                    if (p->source)
+                        dumpstringdata(f, p->source->data, p->source->len);
+                    fprintf(f, ":%d:%s\"", p->linedefined, p->debugname ? getstr(p->debugname) : "");
+                }
+            }
+            else if (isLua(ci))
+            {
+                Proto* p = ci_func(ci)->l.p;
+                int pc = pcRel(ci->savedpc, p);
+                const LocVar* var = luaF_findlocal(p, int(v - ci->base), pc);
+
+                if (var && var->varname)
+                    fprintf(f, "\"%s\"", getstr(var->varname));
+                else
+                    fprintf(f, "null");
+            }
+            else
+                fprintf(f, "null");
+        }
+        fprintf(f, "]");
+    }
+    fprintf(f, "}");
+}
+
+static void dumpbuffer(FILE* f, Buffer* b)
+{
+    fprintf(f, "{\"type\":\"buffer\",\"cat\":%d,\"size\":%d}", b->memcat, int(sizebuffer(b->len)));
+}
+
+static void dumpproto(FILE* f, Proto* p)
+{
+    size_t size = sizeof(Proto) + sizeof(Instruction) * p->sizecode + sizeof(Proto*) * p->sizep + sizeof(TValue) * p->sizek + p->sizelineinfo +
+                  sizeof(LocVar) * p->sizelocvars + sizeof(TString*) * p->sizeupvalues;
+
+    fprintf(f, "{\"type\":\"proto\",\"cat\":%d,\"size\":%d", p->memcat, int(size));
+
+    if (p->source)
+    {
+        fprintf(f, ",\"source\":\"");
+        dumpstringdata(f, p->source->data, p->source->len);
+        fprintf(f, "\",\"line\":%d", p->abslineinfo ? p->abslineinfo[0] : 0);
+    }
+
+    if (p->sizek)
+    {
+        fprintf(f, ",\"constants\":[");
+        dumprefs(f, p->k, p->sizek);
+        fprintf(f, "]");
+    }
+
+    if (p->sizep)
+    {
+        fprintf(f, ",\"protos\":[");
+        for (int i = 0; i < p->sizep; ++i)
+        {
+            if (i != 0)
+                fputc(',', f);
+            dumpref(f, obj2gco(p->p[i]));
+        }
+        fprintf(f, "]");
+    }
+
+    fprintf(f, "}");
+}
+
+static void dumpupval(FILE* f, UpVal* uv)
+{
+    fprintf(f, "{\"type\":\"upvalue\",\"cat\":%d,\"size\":%d,\"open\":%s", uv->memcat, int(sizeof(UpVal)), upisopen(uv) ? "true" : "false");
+
+    if (iscollectable(uv->v))
+    {
+        fprintf(f, ",\"object\":");
+        dumpref(f, gcvalue(uv->v));
+    }
+
+    fprintf(f, "}");
+}
+
+static void dumpobj(FILE* f, GCObject* o)
+{
+    switch (o->gch.tt)
+    {
+    case LUA_TSTRING:
+        return dumpstring(f, gco2ts(o));
+
+    case LUA_TTABLE:
+        return dumptable(f, gco2h(o));
+
+    case LUA_TFUNCTION:
+        return dumpclosure(f, gco2cl(o));
+
+    case LUA_TUSERDATA:
+        return dumpudata(f, gco2u(o));
+
+    case LUA_TTHREAD:
+        return dumpthread(f, gco2th(o));
+
+    case LUA_TBUFFER:
+        return dumpbuffer(f, gco2buf(o));
+
+    case LUA_TPROTO:
+        return dumpproto(f, gco2p(o));
+
+    case LUA_TUPVAL:
+        return dumpupval(f, gco2uv(o));
+
+    default:
+        LUAU_ASSERT(0);
+    }
+}
+
+static bool dumpgco(void* context, lua_Page* page, GCObject* gco)
+{
+    FILE* f = (FILE*)context;
+
+    dumpref(f, gco);
+    fputc(':', f);
+    dumpobj(f, gco);
+    fputc(',', f);
+    fputc('\n', f);
+
+    return false;
+}
+
+void luaC_dump(lua_State* L, void* file, const char* (*categoryName)(lua_State* L, uint8_t memcat))
+{
+    global_State* g = L->global;
+    FILE* f = static_cast<FILE*>(file);
+
+    fprintf(f, "{\"objects\":{\n");
+
+    dumpgco(f, NULL, obj2gco(g->mainthread));
+
+    luaM_visitgco(L, f, dumpgco);
+
+    fprintf(f, "\"0\":{\"type\":\"userdata\",\"cat\":0,\"size\":0}\n"); // to avoid issues with trailing ,
+    fprintf(f, "},\"roots\":{\n");
+    fprintf(f, "\"mainthread\":");
+    dumpref(f, obj2gco(g->mainthread));
+    fprintf(f, ",\"registry\":");
+    dumpref(f, gcvalue(&g->registry));
+
+    fprintf(f, "},\"stats\":{\n");
+
+    fprintf(f, "\"size\":%d,\n", int(g->totalbytes));
+
+    fprintf(f, "\"categories\":{\n");
+    for (int i = 0; i < LUA_MEMORY_CATEGORIES; i++)
+    {
+        if (size_t bytes = g->memcatbytes[i])
+        {
+            if (categoryName)
+                fprintf(f, "\"%d\":{\"name\":\"%s\", \"size\":%d},\n", i, categoryName(L, i), int(bytes));
+            else
+                fprintf(f, "\"%d\":{\"size\":%d},\n", i, int(bytes));
+        }
+    }
+    fprintf(f, "\"none\":{}\n"); // to avoid issues with trailing ,
+    fprintf(f, "}\n");
+    fprintf(f, "}}\n");
+}
+
+struct EnumContext
+{
+    lua_State* L;
+    void* context;
+    void (*node)(void* context, void* ptr, uint8_t tt, uint8_t memcat, size_t size, const char* name);
+    void (*edge)(void* context, void* from, void* to, const char* name);
+};
+
+static void* enumtopointer(GCObject* gco)
+{
+    // To match lua_topointer, userdata pointer is represented as a pointer to internal data
+    return gco->gch.tt == LUA_TUSERDATA ? (void*)gco2u(gco)->data : (void*)gco;
+}
+
+static void enumnode(EnumContext* ctx, GCObject* gco, size_t size, const char* objname)
+{
+    ctx->node(ctx->context, enumtopointer(gco), gco->gch.tt, gco->gch.memcat, size, objname);
+}
+
+static void enumedge(EnumContext* ctx, GCObject* from, GCObject* to, const char* edgename)
+{
+    ctx->edge(ctx->context, enumtopointer(from), enumtopointer(to), edgename);
+}
+
+static void enumedges(EnumContext* ctx, GCObject* from, TValue* data, size_t size, const char* edgename)
+{
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (iscollectable(&data[i]))
+            enumedge(ctx, from, gcvalue(&data[i]), edgename);
+    }
+}
+
+static void enumstring(EnumContext* ctx, TString* ts)
+{
+    enumnode(ctx, obj2gco(ts), ts->len, NULL);
+}
+
+static void enumtable(EnumContext* ctx, Table* h)
+{
+    size_t size = sizeof(Table) + (h->node == &luaH_dummynode ? 0 : sizenode(h) * sizeof(LuaNode)) + h->sizearray * sizeof(TValue);
+
+    // Provide a name for a special registry table
+    enumnode(ctx, obj2gco(h), size, h == hvalue(registry(ctx->L)) ? "registry" : NULL);
+
+    if (h->node != &luaH_dummynode)
+    {
+        bool weakkey = false;
+        bool weakvalue = false;
+
+        if (const TValue* mode = gfasttm(ctx->L->global, h->metatable, TM_MODE))
+        {
+            if (ttisstring(mode))
+            {
+                weakkey = strchr(svalue(mode), 'k') != NULL;
+                weakvalue = strchr(svalue(mode), 'v') != NULL;
+            }
+        }
+
+        for (int i = 0; i < sizenode(h); ++i)
+        {
+            const LuaNode& n = h->node[i];
+
+            if (!ttisnil(&n.val) && (iscollectable(&n.key) || iscollectable(&n.val)))
+            {
+                if (!weakkey && iscollectable(&n.key))
+                    enumedge(ctx, obj2gco(h), gcvalue(&n.key), "[key]");
+
+                if (!weakvalue && iscollectable(&n.val))
+                {
+                    if (ttisstring(&n.key))
+                    {
+                        enumedge(ctx, obj2gco(h), gcvalue(&n.val), svalue(&n.key));
+                    }
+                    else if (ttisnumber(&n.key))
+                    {
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), "%.14g", nvalue(&n.key));
+                        enumedge(ctx, obj2gco(h), gcvalue(&n.val), buf);
+                    }
+                    else
+                    {
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), "[%s]", getstr(ctx->L->global->ttname[n.key.tt]));
+                        enumedge(ctx, obj2gco(h), gcvalue(&n.val), buf);
+                    }
+                }
+            }
+        }
+    }
+
+    if (h->sizearray)
+        enumedges(ctx, obj2gco(h), h->array, h->sizearray, "array");
+
+    if (h->metatable)
+        enumedge(ctx, obj2gco(h), obj2gco(h->metatable), "metatable");
+}
+
+static void enumclosure(EnumContext* ctx, Closure* cl)
+{
+    if (cl->isC)
+    {
+        enumnode(ctx, obj2gco(cl), sizeCclosure(cl->nupvalues), cl->c.debugname);
+    }
+    else
+    {
+        Proto* p = cl->l.p;
+
+        char buf[LUA_IDSIZE];
+
+        if (p->source)
+            snprintf(buf, sizeof(buf), "%s:%d %s", p->debugname ? getstr(p->debugname) : "", p->linedefined, getstr(p->source));
+        else
+            snprintf(buf, sizeof(buf), "%s:%d", p->debugname ? getstr(p->debugname) : "", p->linedefined);
+
+        enumnode(ctx, obj2gco(cl), sizeLclosure(cl->nupvalues), buf);
+    }
+
+    enumedge(ctx, obj2gco(cl), obj2gco(cl->env), "env");
+
+    if (cl->isC)
+    {
+        if (cl->nupvalues)
+            enumedges(ctx, obj2gco(cl), cl->c.upvals, cl->nupvalues, "upvalue");
+    }
+    else
+    {
+        enumedge(ctx, obj2gco(cl), obj2gco(cl->l.p), "proto");
+
+        if (cl->nupvalues)
+            enumedges(ctx, obj2gco(cl), cl->l.uprefs, cl->nupvalues, "upvalue");
+    }
+}
+
+static void enumudata(EnumContext* ctx, Udata* u)
+{
+    const char* name = NULL;
+
+    if (Table* h = u->metatable)
+    {
+        if (h->node != &luaH_dummynode)
+        {
+            for (int i = 0; i < sizenode(h); ++i)
+            {
+                const LuaNode& n = h->node[i];
+
+                if (ttisstring(&n.key) && ttisstring(&n.val) && strcmp(svalue(&n.key), "__type") == 0)
+                {
+                    name = svalue(&n.val);
+                    break;
+                }
+            }
+        }
+    }
+
+    enumnode(ctx, obj2gco(u), sizeudata(u->len), name);
+
+    if (u->metatable)
+        enumedge(ctx, obj2gco(u), obj2gco(u->metatable), "metatable");
+}
+
+static void enumthread(EnumContext* ctx, lua_State* th)
+{
+    size_t size = sizeof(lua_State) + sizeof(TValue) * th->stacksize + sizeof(CallInfo) * th->size_ci;
+
+    Closure* tcl = NULL;
+    for (CallInfo* ci = th->base_ci; ci <= th->ci; ++ci)
+    {
+        if (ttisfunction(ci->func))
+        {
+            tcl = clvalue(ci->func);
+            break;
+        }
+    }
+
+    if (tcl && !tcl->isC && tcl->l.p->source)
+    {
+        Proto* p = tcl->l.p;
+
+        char buf[LUA_IDSIZE];
+
+        if (p->source)
+            snprintf(buf, sizeof(buf), "%s:%d %s", p->debugname ? getstr(p->debugname) : "", p->linedefined, getstr(p->source));
+        else
+            snprintf(buf, sizeof(buf), "%s:%d", p->debugname ? getstr(p->debugname) : "", p->linedefined);
+
+        enumnode(ctx, obj2gco(th), size, buf);
+    }
+    else
+    {
+        enumnode(ctx, obj2gco(th), size, NULL);
+    }
+
+    enumedge(ctx, obj2gco(th), obj2gco(th->gt), "globals");
+
+    if (th->top > th->stack)
+        enumedges(ctx, obj2gco(th), th->stack, th->top - th->stack, "stack");
+}
+
+static void enumbuffer(EnumContext* ctx, Buffer* b)
+{
+    enumnode(ctx, obj2gco(b), sizebuffer(b->len), NULL);
+}
+
+static void enumproto(EnumContext* ctx, Proto* p)
+{
+    size_t size = sizeof(Proto) + sizeof(Instruction) * p->sizecode + sizeof(Proto*) * p->sizep + sizeof(TValue) * p->sizek + p->sizelineinfo +
+                  sizeof(LocVar) * p->sizelocvars + sizeof(TString*) * p->sizeupvalues;
+
+    enumnode(ctx, obj2gco(p), size, p->source ? getstr(p->source) : NULL);
+
+    if (p->sizek)
+        enumedges(ctx, obj2gco(p), p->k, p->sizek, "constants");
+
+    for (int i = 0; i < p->sizep; ++i)
+        enumedge(ctx, obj2gco(p), obj2gco(p->p[i]), "protos");
+}
+
+static void enumupval(EnumContext* ctx, UpVal* uv)
+{
+    enumnode(ctx, obj2gco(uv), sizeof(UpVal), NULL);
+
+    if (iscollectable(uv->v))
+        enumedge(ctx, obj2gco(uv), gcvalue(uv->v), "value");
+}
+
+static void enumobj(EnumContext* ctx, GCObject* o)
+{
+    switch (o->gch.tt)
+    {
+    case LUA_TSTRING:
+        return enumstring(ctx, gco2ts(o));
+
+    case LUA_TTABLE:
+        return enumtable(ctx, gco2h(o));
+
+    case LUA_TFUNCTION:
+        return enumclosure(ctx, gco2cl(o));
+
+    case LUA_TUSERDATA:
+        return enumudata(ctx, gco2u(o));
+
+    case LUA_TTHREAD:
+        return enumthread(ctx, gco2th(o));
+
+    case LUA_TBUFFER:
+        return enumbuffer(ctx, gco2buf(o));
+
+    case LUA_TPROTO:
+        return enumproto(ctx, gco2p(o));
+
+    case LUA_TUPVAL:
+        return enumupval(ctx, gco2uv(o));
+
+    default:
+        LUAU_ASSERT(!"Unknown object tag");
+    }
+}
+
+static bool enumgco(void* context, lua_Page* page, GCObject* gco)
+{
+    enumobj((EnumContext*)context, gco);
+    return false;
+}
+
+void luaC_enumheap(lua_State* L, void* context, void (*node)(void* context, void* ptr, uint8_t tt, uint8_t memcat, size_t size, const char* name),
+    void (*edge)(void* context, void* from, void* to, const char* name))
+{
+    global_State* g = L->global;
+
+    EnumContext ctx;
+    ctx.L = L;
+    ctx.context = context;
+    ctx.node = node;
+    ctx.edge = edge;
+
+    enumgco(&ctx, NULL, obj2gco(g->mainthread));
+
+    luaM_visitgco(L, &ctx, enumgco);
+}

--- a/lib/luau/VM/src/linit.cpp
+++ b/lib/luau/VM/src/linit.cpp
@@ -1,0 +1,88 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include <stdlib.h>
+
+static const luaL_Reg lualibs[] = {
+    {"", luaopen_base},
+    {LUA_COLIBNAME, luaopen_coroutine},
+    {LUA_TABLIBNAME, luaopen_table},
+    {LUA_OSLIBNAME, luaopen_os},
+    {LUA_STRLIBNAME, luaopen_string},
+    {LUA_MATHLIBNAME, luaopen_math},
+    {LUA_DBLIBNAME, luaopen_debug},
+    {LUA_UTF8LIBNAME, luaopen_utf8},
+    {LUA_BITLIBNAME, luaopen_bit32},
+    {LUA_BUFFERLIBNAME, luaopen_buffer},
+    {NULL, NULL},
+};
+
+void luaL_openlibs(lua_State* L)
+{
+    const luaL_Reg* lib = lualibs;
+    for (; lib->func; lib++)
+    {
+        lua_pushcfunction(L, lib->func, NULL);
+        lua_pushstring(L, lib->name);
+        lua_call(L, 1, 0);
+    }
+}
+
+void luaL_sandbox(lua_State* L)
+{
+    // set all libraries to read-only
+    lua_pushnil(L);
+    while (lua_next(L, LUA_GLOBALSINDEX) != 0)
+    {
+        if (lua_istable(L, -1))
+            lua_setreadonly(L, -1, true);
+
+        lua_pop(L, 1);
+    }
+
+    // set all builtin metatables to read-only
+    lua_pushliteral(L, "");
+    lua_getmetatable(L, -1);
+    lua_setreadonly(L, -1, true);
+    lua_pop(L, 2);
+
+    // set globals to readonly and activate safeenv since the env is immutable
+    lua_setreadonly(L, LUA_GLOBALSINDEX, true);
+    lua_setsafeenv(L, LUA_GLOBALSINDEX, true);
+}
+
+void luaL_sandboxthread(lua_State* L)
+{
+    // create new global table that proxies reads to original table
+    lua_newtable(L);
+
+    lua_newtable(L);
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    lua_setfield(L, -2, "__index");
+    lua_setreadonly(L, -1, true);
+
+    lua_setmetatable(L, -2);
+
+    // we can set safeenv now although it's important to set it to false if code is loaded twice into the thread
+    lua_replace(L, LUA_GLOBALSINDEX);
+    lua_setsafeenv(L, LUA_GLOBALSINDEX, true);
+}
+
+static void* l_alloc(void* ud, void* ptr, size_t osize, size_t nsize)
+{
+    (void)ud;
+    (void)osize;
+    if (nsize == 0)
+    {
+        free(ptr);
+        return NULL;
+    }
+    else
+        return realloc(ptr, nsize);
+}
+
+lua_State* luaL_newstate(void)
+{
+    return lua_newstate(l_alloc, NULL);
+}

--- a/lib/luau/VM/src/lmathlib.cpp
+++ b/lib/luau/VM/src/lmathlib.cpp
@@ -1,0 +1,441 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lstate.h"
+
+#include <math.h>
+#include <time.h>
+
+#undef PI
+#define PI (3.14159265358979323846)
+#define RADIANS_PER_DEGREE (PI / 180.0)
+
+#define PCG32_INC 105
+
+static uint32_t pcg32_random(uint64_t* state)
+{
+    uint64_t oldstate = *state;
+    *state = oldstate * 6364136223846793005ULL + (PCG32_INC | 1);
+    uint32_t xorshifted = uint32_t(((oldstate >> 18u) ^ oldstate) >> 27u);
+    uint32_t rot = uint32_t(oldstate >> 59u);
+    return (xorshifted >> rot) | (xorshifted << ((-int32_t(rot)) & 31));
+}
+
+static void pcg32_seed(uint64_t* state, uint64_t seed)
+{
+    *state = 0;
+    pcg32_random(state);
+    *state += seed;
+    pcg32_random(state);
+}
+
+static int math_abs(lua_State* L)
+{
+    lua_pushnumber(L, fabs(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_sin(lua_State* L)
+{
+    lua_pushnumber(L, sin(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_sinh(lua_State* L)
+{
+    lua_pushnumber(L, sinh(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_cos(lua_State* L)
+{
+    lua_pushnumber(L, cos(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_cosh(lua_State* L)
+{
+    lua_pushnumber(L, cosh(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_tan(lua_State* L)
+{
+    lua_pushnumber(L, tan(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_tanh(lua_State* L)
+{
+    lua_pushnumber(L, tanh(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_asin(lua_State* L)
+{
+    lua_pushnumber(L, asin(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_acos(lua_State* L)
+{
+    lua_pushnumber(L, acos(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_atan(lua_State* L)
+{
+    lua_pushnumber(L, atan(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_atan2(lua_State* L)
+{
+    lua_pushnumber(L, atan2(luaL_checknumber(L, 1), luaL_checknumber(L, 2)));
+    return 1;
+}
+
+static int math_ceil(lua_State* L)
+{
+    lua_pushnumber(L, ceil(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_floor(lua_State* L)
+{
+    lua_pushnumber(L, floor(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_fmod(lua_State* L)
+{
+    lua_pushnumber(L, fmod(luaL_checknumber(L, 1), luaL_checknumber(L, 2)));
+    return 1;
+}
+
+static int math_modf(lua_State* L)
+{
+    double ip;
+    double fp = modf(luaL_checknumber(L, 1), &ip);
+    lua_pushnumber(L, ip);
+    lua_pushnumber(L, fp);
+    return 2;
+}
+
+static int math_sqrt(lua_State* L)
+{
+    lua_pushnumber(L, sqrt(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_pow(lua_State* L)
+{
+    lua_pushnumber(L, pow(luaL_checknumber(L, 1), luaL_checknumber(L, 2)));
+    return 1;
+}
+
+static int math_log(lua_State* L)
+{
+    double x = luaL_checknumber(L, 1);
+    double res;
+    if (lua_isnoneornil(L, 2))
+        res = log(x);
+    else
+    {
+        double base = luaL_checknumber(L, 2);
+        if (base == 2.0)
+            res = log2(x);
+        else if (base == 10.0)
+            res = log10(x);
+        else
+            res = log(x) / log(base);
+    }
+    lua_pushnumber(L, res);
+    return 1;
+}
+
+static int math_log10(lua_State* L)
+{
+    lua_pushnumber(L, log10(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_exp(lua_State* L)
+{
+    lua_pushnumber(L, exp(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static int math_deg(lua_State* L)
+{
+    lua_pushnumber(L, luaL_checknumber(L, 1) / RADIANS_PER_DEGREE);
+    return 1;
+}
+
+static int math_rad(lua_State* L)
+{
+    lua_pushnumber(L, luaL_checknumber(L, 1) * RADIANS_PER_DEGREE);
+    return 1;
+}
+
+static int math_frexp(lua_State* L)
+{
+    int e;
+    lua_pushnumber(L, frexp(luaL_checknumber(L, 1), &e));
+    lua_pushinteger(L, e);
+    return 2;
+}
+
+static int math_ldexp(lua_State* L)
+{
+    lua_pushnumber(L, ldexp(luaL_checknumber(L, 1), luaL_checkinteger(L, 2)));
+    return 1;
+}
+
+static int math_min(lua_State* L)
+{
+    int n = lua_gettop(L); // number of arguments
+    double dmin = luaL_checknumber(L, 1);
+    int i;
+    for (i = 2; i <= n; i++)
+    {
+        double d = luaL_checknumber(L, i);
+        if (d < dmin)
+            dmin = d;
+    }
+    lua_pushnumber(L, dmin);
+    return 1;
+}
+
+static int math_max(lua_State* L)
+{
+    int n = lua_gettop(L); // number of arguments
+    double dmax = luaL_checknumber(L, 1);
+    int i;
+    for (i = 2; i <= n; i++)
+    {
+        double d = luaL_checknumber(L, i);
+        if (d > dmax)
+            dmax = d;
+    }
+    lua_pushnumber(L, dmax);
+    return 1;
+}
+
+static int math_random(lua_State* L)
+{
+    global_State* g = L->global;
+    switch (lua_gettop(L))
+    { // check number of arguments
+    case 0:
+    { // no arguments
+        // Using ldexp instead of division for speed & clarity.
+        // See http://mumble.net/~campbell/tmp/random_real.c for details on generating doubles from integer ranges.
+        uint32_t rl = pcg32_random(&g->rngstate);
+        uint32_t rh = pcg32_random(&g->rngstate);
+        double rd = ldexp(double(rl | (uint64_t(rh) << 32)), -64);
+        lua_pushnumber(L, rd); // number between 0 and 1
+        break;
+    }
+    case 1:
+    { // only upper limit
+        int u = luaL_checkinteger(L, 1);
+        luaL_argcheck(L, 1 <= u, 1, "interval is empty");
+
+        uint64_t x = uint64_t(u) * pcg32_random(&g->rngstate);
+        int r = int(1 + (x >> 32));
+        lua_pushinteger(L, r); // int between 1 and `u'
+        break;
+    }
+    case 2:
+    { // lower and upper limits
+        int l = luaL_checkinteger(L, 1);
+        int u = luaL_checkinteger(L, 2);
+        luaL_argcheck(L, l <= u, 2, "interval is empty");
+
+        uint32_t ul = uint32_t(u) - uint32_t(l);
+        luaL_argcheck(L, ul < UINT_MAX, 2, "interval is too large"); // -INT_MIN..INT_MAX interval can result in integer overflow
+        uint64_t x = uint64_t(ul + 1) * pcg32_random(&g->rngstate);
+        int r = int(l + (x >> 32));
+        lua_pushinteger(L, r); // int between `l' and `u'
+        break;
+    }
+    default:
+        luaL_error(L, "wrong number of arguments");
+    }
+    return 1;
+}
+
+static int math_randomseed(lua_State* L)
+{
+    int seed = luaL_checkinteger(L, 1);
+
+    pcg32_seed(&L->global->rngstate, seed);
+    return 0;
+}
+
+static const unsigned char kPerlinHash[257] = {151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142, 8,
+    99, 37, 240, 21, 10, 23, 190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33, 88, 237, 149, 56, 87,
+    174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71, 134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211, 133, 230, 220, 105, 92,
+    41, 55, 46, 245, 40, 244, 102, 143, 54, 65, 25, 63, 161, 1, 216, 80, 73, 209, 76, 132, 187, 208, 89, 18, 169, 200, 196, 135, 130, 116, 188, 159,
+    86, 164, 100, 109, 198, 173, 186, 3, 64, 52, 217, 226, 250, 124, 123, 5, 202, 38, 147, 118, 126, 255, 82, 85, 212, 207, 206, 59, 227, 47, 16, 58,
+    17, 182, 189, 28, 42, 223, 183, 170, 213, 119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101, 155, 167, 43, 172, 9, 129, 22, 39, 253, 19, 98, 108,
+    110, 79, 113, 224, 232, 178, 185, 112, 104, 218, 246, 97, 228, 251, 34, 242, 193, 238, 210, 144, 12, 191, 179, 162, 241, 81, 51, 145, 235, 249,
+    14, 239, 107, 49, 192, 214, 31, 181, 199, 106, 157, 184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254, 138, 236, 205, 93, 222, 114, 67, 29,
+    24, 72, 243, 141, 128, 195, 78, 66, 215, 61, 156, 180, 151};
+
+const float kPerlinGrad[16][3] = {{1, 1, 0}, {-1, 1, 0}, {1, -1, 0}, {-1, -1, 0}, {1, 0, 1}, {-1, 0, 1}, {1, 0, -1}, {-1, 0, -1}, {0, 1, 1},
+    {0, -1, 1}, {0, 1, -1}, {0, -1, -1}, {1, 1, 0}, {0, -1, 1}, {-1, 1, 0}, {0, -1, -1}};
+
+inline float perlin_fade(float t)
+{
+    return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+inline float perlin_lerp(float t, float a, float b)
+{
+    return a + t * (b - a);
+}
+
+inline float perlin_grad(int hash, float x, float y, float z)
+{
+    const float* g = kPerlinGrad[hash & 15];
+    return g[0] * x + g[1] * y + g[2] * z;
+}
+
+static float perlin(float x, float y, float z)
+{
+    float xflr = floorf(x);
+    float yflr = floorf(y);
+    float zflr = floorf(z);
+
+    int xi = int(xflr) & 255;
+    int yi = int(yflr) & 255;
+    int zi = int(zflr) & 255;
+
+    float xf = x - xflr;
+    float yf = y - yflr;
+    float zf = z - zflr;
+
+    float u = perlin_fade(xf);
+    float v = perlin_fade(yf);
+    float w = perlin_fade(zf);
+
+    const unsigned char* p = kPerlinHash;
+
+    int a = (p[xi] + yi) & 255;
+    int aa = (p[a] + zi) & 255;
+    int ab = (p[a + 1] + zi) & 255;
+
+    int b = (p[xi + 1] + yi) & 255;
+    int ba = (p[b] + zi) & 255;
+    int bb = (p[b + 1] + zi) & 255;
+
+    float la = perlin_lerp(u, perlin_grad(p[aa], xf, yf, zf), perlin_grad(p[ba], xf - 1, yf, zf));
+    float lb = perlin_lerp(u, perlin_grad(p[ab], xf, yf - 1, zf), perlin_grad(p[bb], xf - 1, yf - 1, zf));
+    float la1 = perlin_lerp(u, perlin_grad(p[aa + 1], xf, yf, zf - 1), perlin_grad(p[ba + 1], xf - 1, yf, zf - 1));
+    float lb1 = perlin_lerp(u, perlin_grad(p[ab + 1], xf, yf - 1, zf - 1), perlin_grad(p[bb + 1], xf - 1, yf - 1, zf - 1));
+
+    return perlin_lerp(w, perlin_lerp(v, la, lb), perlin_lerp(v, la1, lb1));
+}
+
+static int math_noise(lua_State* L)
+{
+    int nx, ny, nz;
+    double x = lua_tonumberx(L, 1, &nx);
+    double y = lua_tonumberx(L, 2, &ny);
+    double z = lua_tonumberx(L, 3, &nz);
+
+    luaL_argexpected(L, nx, 1, "number");
+    luaL_argexpected(L, ny || lua_isnoneornil(L, 2), 2, "number");
+    luaL_argexpected(L, nz || lua_isnoneornil(L, 3), 3, "number");
+
+    double r = perlin((float)x, (float)y, (float)z);
+
+    lua_pushnumber(L, r);
+    return 1;
+}
+
+static int math_clamp(lua_State* L)
+{
+    double v = luaL_checknumber(L, 1);
+    double min = luaL_checknumber(L, 2);
+    double max = luaL_checknumber(L, 3);
+
+    luaL_argcheck(L, min <= max, 3, "max must be greater than or equal to min");
+
+    double r = v < min ? min : v;
+    r = r > max ? max : r;
+
+    lua_pushnumber(L, r);
+    return 1;
+}
+
+static int math_sign(lua_State* L)
+{
+    double v = luaL_checknumber(L, 1);
+    lua_pushnumber(L, v > 0.0 ? 1.0 : v < 0.0 ? -1.0 : 0.0);
+    return 1;
+}
+
+static int math_round(lua_State* L)
+{
+    lua_pushnumber(L, round(luaL_checknumber(L, 1)));
+    return 1;
+}
+
+static const luaL_Reg mathlib[] = {
+    {"abs", math_abs},
+    {"acos", math_acos},
+    {"asin", math_asin},
+    {"atan2", math_atan2},
+    {"atan", math_atan},
+    {"ceil", math_ceil},
+    {"cosh", math_cosh},
+    {"cos", math_cos},
+    {"deg", math_deg},
+    {"exp", math_exp},
+    {"floor", math_floor},
+    {"fmod", math_fmod},
+    {"frexp", math_frexp},
+    {"ldexp", math_ldexp},
+    {"log10", math_log10},
+    {"log", math_log},
+    {"max", math_max},
+    {"min", math_min},
+    {"modf", math_modf},
+    {"pow", math_pow},
+    {"rad", math_rad},
+    {"random", math_random},
+    {"randomseed", math_randomseed},
+    {"sinh", math_sinh},
+    {"sin", math_sin},
+    {"sqrt", math_sqrt},
+    {"tanh", math_tanh},
+    {"tan", math_tan},
+    {"noise", math_noise},
+    {"clamp", math_clamp},
+    {"sign", math_sign},
+    {"round", math_round},
+    {NULL, NULL},
+};
+
+/*
+** Open math library
+*/
+int luaopen_math(lua_State* L)
+{
+    uint64_t seed = uintptr_t(L);
+    seed ^= time(NULL);
+    seed ^= clock();
+
+    pcg32_seed(&L->global->rngstate, seed);
+
+    luaL_register(L, LUA_MATHLIBNAME, mathlib);
+    lua_pushnumber(L, PI);
+    lua_setfield(L, -2, "pi");
+    lua_pushnumber(L, HUGE_VAL);
+    lua_setfield(L, -2, "huge");
+    return 1;
+}

--- a/lib/luau/VM/src/lmem.cpp
+++ b/lib/luau/VM/src/lmem.cpp
@@ -1,0 +1,649 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lmem.h"
+
+#include "lstate.h"
+#include "ldo.h"
+#include "ldebug.h"
+
+#include <string.h>
+
+/*
+ * Luau heap uses a size-segregated page structure, with individual pages and large allocations
+ * allocated using system heap (via frealloc callback).
+ *
+ * frealloc callback serves as a general, if slow, allocation callback that can allocate, free or
+ * resize allocations:
+ *
+ *    void* frealloc(void* ud, void* ptr, size_t oldsize, size_t newsize);
+ *
+ * frealloc(ud, NULL, 0, x) creates a new block of size x
+ * frealloc(ud, p, x, 0) frees the block p (must return NULL)
+ * frealloc(ud, NULL, 0, 0) does nothing, equivalent to free(NULL)
+ *
+ * frealloc returns NULL if it cannot create or reallocate the area
+ * (any reallocation to an equal or smaller size cannot fail!)
+ *
+ * On top of this, Luau implements heap storage which is split into two types of allocations:
+ *
+ * - GCO, short for "garbage collected objects"
+ * - other objects (for example, arrays stored inside table objects)
+ *
+ * The heap layout for these two allocation types is a bit different.
+ *
+ * All GCO are allocated in pages, which is a block of memory of ~16K in size that has a page header
+ * (lua_Page). Each page contains 1..N blocks of the same size, where N is selected to fill the page
+ * completely. This amortizes the allocation cost and increases locality. Each GCO block starts with
+ * the GC header (GCheader) which contains the object type, mark bits and other GC metadata. If the
+ * GCO block is free (not used), then it must have the type set to TNIL; in this case the block can
+ * be part of the per-page free list, the link for that list is stored after the header (freegcolink).
+ *
+ * Importantly, the GCO block doesn't have any back references to the page it's allocated in, so it's
+ * impossible to free it in isolation - GCO blocks are freed by sweeping the pages they belong to,
+ * using luaM_freegco which must specify the page; this is called by page sweeper that traverses the
+ * entire page's worth of objects. For this reason it's also important that freed GCO blocks keep the
+ * GC header intact and accessible (with type = NIL) so that the sweeper can access it.
+ *
+ * Some GCOs are too large to fit in a 16K page without excessive fragmentation (the size threshold is
+ * currently 512 bytes); in this case, we allocate a dedicated small page with just a single block's worth
+ * storage space, but that requires allocating an extra page header. In effect large GCOs are a little bit
+ * less memory efficient, but this allows us to uniformly sweep small and large GCOs using page lists.
+ *
+ * All GCO pages are linked in a large intrusive linked list (global_State::allgcopages). Additionally,
+ * for each block size there's a page free list that contains pages that have at least one free block
+ * (global_State::freegcopages). This free list is used to make sure object allocation is O(1).
+ *
+ * Compared to GCOs, regular allocations have two important differences: they can be freed in isolation,
+ * and they don't start with a GC header. Because of this, each allocation is prefixed with block metadata,
+ * which contains the pointer to the page for allocated blocks, and the pointer to the next free block
+ * inside the page for freed blocks.
+ * For regular allocations that are too large to fit in a page (using the same threshold of 512 bytes),
+ * we don't allocate a separate page, instead simply using frealloc to allocate a vanilla block of memory.
+ *
+ * Just like GCO pages, we store a page free list (global_State::freepages) that allows O(1) allocation;
+ * there is no global list for non-GCO pages since we never need to traverse them directly.
+ *
+ * In both cases, we pick the page by computing the size class from the block size which rounds the block
+ * size up to reduce the chance that we'll allocate pages that have very few allocated blocks. The size
+ * class strategy is determined by SizeClassConfig constructor.
+ *
+ * Note that when the last block in a page is freed, we immediately free the page with frealloc - the
+ * memory manager doesn't currently attempt to keep unused memory around. This can result in excessive
+ * allocation traffic and can be mitigated by adding a page cache in the future.
+ *
+ * For both GCO and non-GCO pages, the per-page block allocation combines bump pointer style allocation
+ * (lua_Page::freeNext) and per-page free list (lua_Page::freeList). We use the bump allocator to allocate
+ * the contents of the page, and the free list for further reuse; this allows shorter page setup times
+ * which results in less variance between allocation cost, as well as tighter sweep bounds for newly
+ * allocated pages.
+ */
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_feature(address_sanitizer) || defined(LUAU_ENABLE_ASAN)
+#include <sanitizer/asan_interface.h>
+#define ASAN_POISON_MEMORY_REGION(addr, size) __asan_poison_memory_region((addr), (size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) __asan_unpoison_memory_region((addr), (size))
+#else
+#define ASAN_POISON_MEMORY_REGION(addr, size) (void)0
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) (void)0
+#endif
+
+/*
+ * The sizes of Luau objects aren't crucial for code correctness, but they are crucial for memory efficiency
+ * To prevent some of them accidentally growing and us losing memory without realizing it, we're going to lock
+ * the sizes of all critical structures down.
+ */
+#if defined(__APPLE__)
+#define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : gcc32)
+#elif defined(__i386__) && defined(__MINGW32__) && !defined(__MINGW64__)
+#define ABISWITCH(x64, ms32, gcc32) (ms32)
+#elif defined(__i386__) && !defined(_MSC_VER)
+#define ABISWITCH(x64, ms32, gcc32) (gcc32)
+#else
+// Android somehow uses a similar ABI to MSVC, *not* to iOS...
+#define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : ms32)
+#endif
+
+#if LUA_VECTOR_SIZE == 4
+static_assert(sizeof(TValue) == ABISWITCH(24, 24, 24), "size mismatch for value");
+static_assert(sizeof(LuaNode) == ABISWITCH(48, 48, 48), "size mismatch for table entry");
+#else
+static_assert(sizeof(TValue) == ABISWITCH(16, 16, 16), "size mismatch for value");
+static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
+#endif
+
+static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
+static_assert(offsetof(Udata, data) == ABISWITCH(16, 16, 12), "size mismatch for userdata header");
+static_assert(sizeof(Table) == ABISWITCH(48, 32, 32), "size mismatch for table header");
+static_assert(offsetof(Buffer, data) == ABISWITCH(8, 8, 8), "size mismatch for buffer header");
+
+const size_t kSizeClasses = LUA_SIZECLASSES;
+const size_t kMaxSmallSize = 512;
+const size_t kPageSize = 16 * 1024 - 24; // slightly under 16KB since that results in less fragmentation due to heap metadata
+
+const size_t kBlockHeader = sizeof(double) > sizeof(void*) ? sizeof(double) : sizeof(void*); // suitable for aligning double & void* on all platforms
+const size_t kGCOLinkOffset = (sizeof(GCheader) + sizeof(void*) - 1) & ~(sizeof(void*) - 1); // GCO pages contain freelist links after the GC header
+
+struct SizeClassConfig
+{
+    int sizeOfClass[kSizeClasses];
+    int8_t classForSize[kMaxSmallSize + 1];
+    int classCount = 0;
+
+    SizeClassConfig()
+    {
+        memset(sizeOfClass, 0, sizeof(sizeOfClass));
+        memset(classForSize, -1, sizeof(classForSize));
+
+        // we use a progressive size class scheme:
+        // - all size classes are aligned by 8b to satisfy pointer alignment requirements
+        // - we first allocate sizes classes in multiples of 8
+        // - after the first cutoff we allocate size classes in multiples of 16
+        // - after the second cutoff we allocate size classes in multiples of 32
+        // this balances internal fragmentation vs external fragmentation
+        for (int size = 8; size < 64; size += 8)
+            sizeOfClass[classCount++] = size;
+
+        for (int size = 64; size < 256; size += 16)
+            sizeOfClass[classCount++] = size;
+
+        for (int size = 256; size <= 512; size += 32)
+            sizeOfClass[classCount++] = size;
+
+        LUAU_ASSERT(size_t(classCount) <= kSizeClasses);
+
+        // fill the lookup table for all classes
+        for (int klass = 0; klass < classCount; ++klass)
+            classForSize[sizeOfClass[klass]] = int8_t(klass);
+
+        // fill the gaps in lookup table
+        for (int size = kMaxSmallSize - 1; size >= 0; --size)
+            if (classForSize[size] < 0)
+                classForSize[size] = classForSize[size + 1];
+    }
+};
+
+const SizeClassConfig kSizeClassConfig;
+
+// size class for a block of size sz; returns -1 for size=0 because empty allocations take no space
+#define sizeclass(sz) (size_t((sz)-1) < kMaxSmallSize ? kSizeClassConfig.classForSize[sz] : -1)
+
+// metadata for a block is stored in the first pointer of the block
+#define metadata(block) (*(void**)(block))
+#define freegcolink(block) (*(void**)((char*)block + kGCOLinkOffset))
+
+struct lua_Page
+{
+    // list of pages with free blocks
+    lua_Page* prev;
+    lua_Page* next;
+
+    // list of all gco pages
+    lua_Page* gcolistprev;
+    lua_Page* gcolistnext;
+
+    int pageSize;  // page size in bytes, including page header
+    int blockSize; // block size in bytes, including block header (for non-GCO)
+
+    void* freeList; // next free block in this page; linked with metadata()/freegcolink()
+    int freeNext;   // next free block offset in this page, in bytes; when negative, freeList is used instead
+    int busyBlocks; // number of blocks allocated out of this page
+
+    union
+    {
+        char data[1];
+        double align1;
+        void* align2;
+    };
+};
+
+l_noret luaM_toobig(lua_State* L)
+{
+    luaG_runerror(L, "memory allocation error: block too big");
+}
+
+static lua_Page* newpage(lua_State* L, lua_Page** gcopageset, int pageSize, int blockSize, int blockCount)
+{
+    global_State* g = L->global;
+
+    LUAU_ASSERT(pageSize - int(offsetof(lua_Page, data)) >= blockSize * blockCount);
+
+    lua_Page* page = (lua_Page*)(*g->frealloc)(g->ud, NULL, 0, pageSize);
+    if (!page)
+        luaD_throw(L, LUA_ERRMEM);
+
+    ASAN_POISON_MEMORY_REGION(page->data, blockSize * blockCount);
+
+    // setup page header
+    page->prev = NULL;
+    page->next = NULL;
+
+    page->gcolistprev = NULL;
+    page->gcolistnext = NULL;
+
+    page->pageSize = pageSize;
+    page->blockSize = blockSize;
+
+    // note: we start with the last block in the page and move downward
+    // either order would work, but that way we don't need to store the block count in the page
+    // additionally, GC stores objects in singly linked lists, and this way the GC lists end up in increasing pointer order
+    page->freeList = NULL;
+    page->freeNext = (blockCount - 1) * blockSize;
+    page->busyBlocks = 0;
+
+    if (gcopageset)
+    {
+        page->gcolistnext = *gcopageset;
+        if (page->gcolistnext)
+            page->gcolistnext->gcolistprev = page;
+        *gcopageset = page;
+    }
+
+    return page;
+}
+
+static lua_Page* newclasspage(lua_State* L, lua_Page** freepageset, lua_Page** gcopageset, uint8_t sizeClass, bool storeMetadata)
+{
+    int blockSize = kSizeClassConfig.sizeOfClass[sizeClass] + (storeMetadata ? kBlockHeader : 0);
+    int blockCount = (kPageSize - offsetof(lua_Page, data)) / blockSize;
+
+    lua_Page* page = newpage(L, gcopageset, kPageSize, blockSize, blockCount);
+
+    // prepend a page to page freelist (which is empty because we only ever allocate a new page when it is!)
+    LUAU_ASSERT(!freepageset[sizeClass]);
+    freepageset[sizeClass] = page;
+
+    return page;
+}
+
+static void freepage(lua_State* L, lua_Page** gcopageset, lua_Page* page)
+{
+    global_State* g = L->global;
+
+    if (gcopageset)
+    {
+        // remove page from alllist
+        if (page->gcolistnext)
+            page->gcolistnext->gcolistprev = page->gcolistprev;
+
+        if (page->gcolistprev)
+            page->gcolistprev->gcolistnext = page->gcolistnext;
+        else if (*gcopageset == page)
+            *gcopageset = page->gcolistnext;
+    }
+
+    // so long
+    (*g->frealloc)(g->ud, page, page->pageSize, 0);
+}
+
+static void freeclasspage(lua_State* L, lua_Page** freepageset, lua_Page** gcopageset, lua_Page* page, uint8_t sizeClass)
+{
+    // remove page from freelist
+    if (page->next)
+        page->next->prev = page->prev;
+
+    if (page->prev)
+        page->prev->next = page->next;
+    else if (freepageset[sizeClass] == page)
+        freepageset[sizeClass] = page->next;
+
+    freepage(L, gcopageset, page);
+}
+
+static void* newblock(lua_State* L, int sizeClass)
+{
+    global_State* g = L->global;
+    lua_Page* page = g->freepages[sizeClass];
+
+    // slow path: no page in the freelist, allocate a new one
+    if (!page)
+        page = newclasspage(L, g->freepages, NULL, sizeClass, true);
+
+    LUAU_ASSERT(!page->prev);
+    LUAU_ASSERT(page->freeList || page->freeNext >= 0);
+    LUAU_ASSERT(size_t(page->blockSize) == kSizeClassConfig.sizeOfClass[sizeClass] + kBlockHeader);
+
+    void* block;
+
+    if (page->freeNext >= 0)
+    {
+        block = &page->data + page->freeNext;
+        ASAN_UNPOISON_MEMORY_REGION(block, page->blockSize);
+
+        page->freeNext -= page->blockSize;
+        page->busyBlocks++;
+    }
+    else
+    {
+        block = page->freeList;
+        ASAN_UNPOISON_MEMORY_REGION(block, page->blockSize);
+
+        page->freeList = metadata(block);
+        page->busyBlocks++;
+    }
+
+    // the first word in a block point back to the page
+    metadata(block) = page;
+
+    // if we allocate the last block out of a page, we need to remove it from free list
+    if (!page->freeList && page->freeNext < 0)
+    {
+        g->freepages[sizeClass] = page->next;
+        if (page->next)
+            page->next->prev = NULL;
+        page->next = NULL;
+    }
+
+    // the user data is right after the metadata
+    return (char*)block + kBlockHeader;
+}
+
+static void* newgcoblock(lua_State* L, int sizeClass)
+{
+    global_State* g = L->global;
+    lua_Page* page = g->freegcopages[sizeClass];
+
+    // slow path: no page in the freelist, allocate a new one
+    if (!page)
+        page = newclasspage(L, g->freegcopages, &g->allgcopages, sizeClass, false);
+
+    LUAU_ASSERT(!page->prev);
+    LUAU_ASSERT(page->freeList || page->freeNext >= 0);
+    LUAU_ASSERT(page->blockSize == kSizeClassConfig.sizeOfClass[sizeClass]);
+
+    void* block;
+
+    if (page->freeNext >= 0)
+    {
+        block = &page->data + page->freeNext;
+        ASAN_UNPOISON_MEMORY_REGION(block, page->blockSize);
+
+        page->freeNext -= page->blockSize;
+        page->busyBlocks++;
+    }
+    else
+    {
+        block = page->freeList;
+        ASAN_UNPOISON_MEMORY_REGION((char*)block + sizeof(GCheader), page->blockSize - sizeof(GCheader));
+
+        // when separate block metadata is not used, free list link is stored inside the block data itself
+        page->freeList = freegcolink(block);
+        page->busyBlocks++;
+    }
+
+    // if we allocate the last block out of a page, we need to remove it from free list
+    if (!page->freeList && page->freeNext < 0)
+    {
+        g->freegcopages[sizeClass] = page->next;
+        if (page->next)
+            page->next->prev = NULL;
+        page->next = NULL;
+    }
+
+    return block;
+}
+
+static void freeblock(lua_State* L, int sizeClass, void* block)
+{
+    global_State* g = L->global;
+
+    // the user data is right after the metadata
+    LUAU_ASSERT(block);
+    block = (char*)block - kBlockHeader;
+
+    lua_Page* page = (lua_Page*)metadata(block);
+    LUAU_ASSERT(page && page->busyBlocks > 0);
+    LUAU_ASSERT(size_t(page->blockSize) == kSizeClassConfig.sizeOfClass[sizeClass] + kBlockHeader);
+    LUAU_ASSERT(block >= page->data && block < (char*)page + page->pageSize);
+
+    // if the page wasn't in the page free list, it should be now since it got a block!
+    if (!page->freeList && page->freeNext < 0)
+    {
+        LUAU_ASSERT(!page->prev);
+        LUAU_ASSERT(!page->next);
+
+        page->next = g->freepages[sizeClass];
+        if (page->next)
+            page->next->prev = page;
+        g->freepages[sizeClass] = page;
+    }
+
+    // add the block to the free list inside the page
+    metadata(block) = page->freeList;
+    page->freeList = block;
+
+    ASAN_POISON_MEMORY_REGION(block, page->blockSize);
+
+    page->busyBlocks--;
+
+    // if it's the last block in the page, we don't need the page
+    if (page->busyBlocks == 0)
+        freeclasspage(L, g->freepages, NULL, page, sizeClass);
+}
+
+static void freegcoblock(lua_State* L, int sizeClass, void* block, lua_Page* page)
+{
+    LUAU_ASSERT(page && page->busyBlocks > 0);
+    LUAU_ASSERT(page->blockSize == kSizeClassConfig.sizeOfClass[sizeClass]);
+    LUAU_ASSERT(block >= page->data && block < (char*)page + page->pageSize);
+
+    global_State* g = L->global;
+
+    // if the page wasn't in the page free list, it should be now since it got a block!
+    if (!page->freeList && page->freeNext < 0)
+    {
+        LUAU_ASSERT(!page->prev);
+        LUAU_ASSERT(!page->next);
+
+        page->next = g->freegcopages[sizeClass];
+        if (page->next)
+            page->next->prev = page;
+        g->freegcopages[sizeClass] = page;
+    }
+
+    // when separate block metadata is not used, free list link is stored inside the block data itself
+    freegcolink(block) = page->freeList;
+    page->freeList = block;
+
+    ASAN_POISON_MEMORY_REGION((char*)block + sizeof(GCheader), page->blockSize - sizeof(GCheader));
+
+    page->busyBlocks--;
+
+    // if it's the last block in the page, we don't need the page
+    if (page->busyBlocks == 0)
+        freeclasspage(L, g->freegcopages, &g->allgcopages, page, sizeClass);
+}
+
+void* luaM_new_(lua_State* L, size_t nsize, uint8_t memcat)
+{
+    global_State* g = L->global;
+
+    int nclass = sizeclass(nsize);
+
+    void* block = nclass >= 0 ? newblock(L, nclass) : (*g->frealloc)(g->ud, NULL, 0, nsize);
+    if (block == NULL && nsize > 0)
+        luaD_throw(L, LUA_ERRMEM);
+
+    g->totalbytes += nsize;
+    g->memcatbytes[memcat] += nsize;
+
+    return block;
+}
+
+GCObject* luaM_newgco_(lua_State* L, size_t nsize, uint8_t memcat)
+{
+    // we need to accommodate space for link for free blocks (freegcolink)
+    LUAU_ASSERT(nsize >= kGCOLinkOffset + sizeof(void*));
+
+    global_State* g = L->global;
+
+    int nclass = sizeclass(nsize);
+
+    void* block = NULL;
+
+    if (nclass >= 0)
+    {
+        block = newgcoblock(L, nclass);
+    }
+    else
+    {
+        lua_Page* page = newpage(L, &g->allgcopages, offsetof(lua_Page, data) + int(nsize), int(nsize), 1);
+
+        block = &page->data;
+        ASAN_UNPOISON_MEMORY_REGION(block, page->blockSize);
+
+        page->freeNext -= page->blockSize;
+        page->busyBlocks++;
+    }
+
+    if (block == NULL && nsize > 0)
+        luaD_throw(L, LUA_ERRMEM);
+
+    g->totalbytes += nsize;
+    g->memcatbytes[memcat] += nsize;
+
+    return (GCObject*)block;
+}
+
+void luaM_free_(lua_State* L, void* block, size_t osize, uint8_t memcat)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT((osize == 0) == (block == NULL));
+
+    int oclass = sizeclass(osize);
+
+    if (oclass >= 0)
+        freeblock(L, oclass, block);
+    else
+        (*g->frealloc)(g->ud, block, osize, 0);
+
+    g->totalbytes -= osize;
+    g->memcatbytes[memcat] -= osize;
+}
+
+void luaM_freegco_(lua_State* L, GCObject* block, size_t osize, uint8_t memcat, lua_Page* page)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT((osize == 0) == (block == NULL));
+
+    int oclass = sizeclass(osize);
+
+    if (oclass >= 0)
+    {
+        block->gch.tt = LUA_TNIL;
+
+        freegcoblock(L, oclass, block, page);
+    }
+    else
+    {
+        LUAU_ASSERT(page->busyBlocks == 1);
+        LUAU_ASSERT(size_t(page->blockSize) == osize);
+        LUAU_ASSERT((void*)block == page->data);
+
+        freepage(L, &g->allgcopages, page);
+    }
+
+    g->totalbytes -= osize;
+    g->memcatbytes[memcat] -= osize;
+}
+
+void* luaM_realloc_(lua_State* L, void* block, size_t osize, size_t nsize, uint8_t memcat)
+{
+    global_State* g = L->global;
+    LUAU_ASSERT((osize == 0) == (block == NULL));
+
+    int nclass = sizeclass(nsize);
+    int oclass = sizeclass(osize);
+    void* result;
+
+    // if either block needs to be allocated using a block allocator, we can't use realloc directly
+    if (nclass >= 0 || oclass >= 0)
+    {
+        result = nclass >= 0 ? newblock(L, nclass) : (*g->frealloc)(g->ud, NULL, 0, nsize);
+        if (result == NULL && nsize > 0)
+            luaD_throw(L, LUA_ERRMEM);
+
+        if (osize > 0 && nsize > 0)
+            memcpy(result, block, osize < nsize ? osize : nsize);
+
+        if (oclass >= 0)
+            freeblock(L, oclass, block);
+        else
+            (*g->frealloc)(g->ud, block, osize, 0);
+    }
+    else
+    {
+        result = (*g->frealloc)(g->ud, block, osize, nsize);
+        if (result == NULL && nsize > 0)
+            luaD_throw(L, LUA_ERRMEM);
+    }
+
+    LUAU_ASSERT((nsize == 0) == (result == NULL));
+    g->totalbytes = (g->totalbytes - osize) + nsize;
+    g->memcatbytes[memcat] += nsize - osize;
+    return result;
+}
+
+void luaM_getpagewalkinfo(lua_Page* page, char** start, char** end, int* busyBlocks, int* blockSize)
+{
+    int blockCount = (page->pageSize - offsetof(lua_Page, data)) / page->blockSize;
+
+    LUAU_ASSERT(page->freeNext >= -page->blockSize && page->freeNext <= (blockCount - 1) * page->blockSize);
+
+    char* data = page->data; // silences ubsan when indexing page->data
+
+    *start = data + page->freeNext + page->blockSize;
+    *end = data + blockCount * page->blockSize;
+    *busyBlocks = page->busyBlocks;
+    *blockSize = page->blockSize;
+}
+
+lua_Page* luaM_getnextgcopage(lua_Page* page)
+{
+    return page->gcolistnext;
+}
+
+void luaM_visitpage(lua_Page* page, void* context, bool (*visitor)(void* context, lua_Page* page, GCObject* gco))
+{
+    char* start;
+    char* end;
+    int busyBlocks;
+    int blockSize;
+    luaM_getpagewalkinfo(page, &start, &end, &busyBlocks, &blockSize);
+
+    for (char* pos = start; pos != end; pos += blockSize)
+    {
+        GCObject* gco = (GCObject*)pos;
+
+        // skip memory blocks that are already freed
+        if (gco->gch.tt == LUA_TNIL)
+            continue;
+
+        // when true is returned it means that the element was deleted
+        if (visitor(context, page, gco))
+        {
+            LUAU_ASSERT(busyBlocks > 0);
+
+            // if the last block was removed, page would be removed as well
+            if (--busyBlocks == 0)
+                break;
+        }
+    }
+}
+
+void luaM_visitgco(lua_State* L, void* context, bool (*visitor)(void* context, lua_Page* page, GCObject* gco))
+{
+    global_State* g = L->global;
+
+    for (lua_Page* curr = g->allgcopages; curr;)
+    {
+        lua_Page* next = curr->gcolistnext; // block visit might destroy the page
+
+        luaM_visitpage(curr, context, visitor);
+
+        curr = next;
+    }
+}

--- a/lib/luau/VM/src/lmem.h
+++ b/lib/luau/VM/src/lmem.h
@@ -1,0 +1,32 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lua.h"
+
+struct lua_Page;
+union GCObject;
+
+#define luaM_newgco(L, t, size, memcat) cast_to(t*, luaM_newgco_(L, size, memcat))
+#define luaM_freegco(L, p, size, memcat, page) luaM_freegco_(L, obj2gco(p), size, memcat, page)
+
+#define luaM_arraysize_(L, n, e) ((cast_to(size_t, (n)) <= SIZE_MAX / (e)) ? (n) * (e) : (luaM_toobig(L), SIZE_MAX))
+
+#define luaM_newarray(L, n, t, memcat) cast_to(t*, luaM_new_(L, luaM_arraysize_(L, n, sizeof(t)), memcat))
+#define luaM_freearray(L, b, n, t, memcat) luaM_free_(L, (b), (n) * sizeof(t), memcat)
+#define luaM_reallocarray(L, v, oldn, n, t, memcat) \
+    ((v) = cast_to(t*, luaM_realloc_(L, v, (oldn) * sizeof(t), luaM_arraysize_(L, n, sizeof(t)), memcat)))
+
+LUAI_FUNC void* luaM_new_(lua_State* L, size_t nsize, uint8_t memcat);
+LUAI_FUNC GCObject* luaM_newgco_(lua_State* L, size_t nsize, uint8_t memcat);
+LUAI_FUNC void luaM_free_(lua_State* L, void* block, size_t osize, uint8_t memcat);
+LUAI_FUNC void luaM_freegco_(lua_State* L, GCObject* block, size_t osize, uint8_t memcat, lua_Page* page);
+LUAI_FUNC void* luaM_realloc_(lua_State* L, void* block, size_t osize, size_t nsize, uint8_t memcat);
+
+LUAI_FUNC l_noret luaM_toobig(lua_State* L);
+
+LUAI_FUNC void luaM_getpagewalkinfo(lua_Page* page, char** start, char** end, int* busyBlocks, int* blockSize);
+LUAI_FUNC lua_Page* luaM_getnextgcopage(lua_Page* page);
+
+LUAI_FUNC void luaM_visitpage(lua_Page* page, void* context, bool (*visitor)(void* context, lua_Page* page, GCObject* gco));
+LUAI_FUNC void luaM_visitgco(lua_State* L, void* context, bool (*visitor)(void* context, lua_Page* page, GCObject* gco));

--- a/lib/luau/VM/src/lnumprint.cpp
+++ b/lib/luau/VM/src/lnumprint.cpp
@@ -1,0 +1,366 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "luaconf.h"
+#include "lnumutils.h"
+
+#include "lcommon.h"
+
+#include <string.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+// This work is based on:
+// Raffaello Giulietti. The Schubfach way to render doubles. 2021
+// https://drive.google.com/file/d/1IEeATSVnEE6TkrHlCYNY2GjaraBjOT4f/edit
+
+// The code uses the notation from the paper for local variables where appropriate, and refers to paper sections/figures/results.
+
+// 9.8.2. Precomputed table for 128-bit overestimates of powers of 10 (see figure 3 for table bounds)
+// To avoid storing 616 128-bit numbers directly we use a technique inspired by Dragonbox implementation and store 16 consecutive
+// powers using a 128-bit baseline and a bitvector with 1-bit scale and 3-bit offset for the delta between each entry and base*5^k
+static const int kPow10TableMin = -292;
+static const int kPow10TableMax = 324;
+
+// clang-format off
+static const uint64_t kPow5Table[16] = {
+    0x8000000000000000, 0xa000000000000000, 0xc800000000000000, 0xfa00000000000000, 0x9c40000000000000, 0xc350000000000000,
+    0xf424000000000000, 0x9896800000000000, 0xbebc200000000000, 0xee6b280000000000, 0x9502f90000000000, 0xba43b74000000000,
+    0xe8d4a51000000000, 0x9184e72a00000000, 0xb5e620f480000000, 0xe35fa931a0000000,
+};
+static const uint64_t kPow10Table[(kPow10TableMax - kPow10TableMin + 1 + 15) / 16][3] = {
+    {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b, 0x333443443333443b}, {0x8dd01fad907ffc3b, 0xae3da7d97f6792e4, 0xbbb3ab3cb3ba3cbc},
+    {0x9d71ac8fada6c9b5, 0x6f773fc3603db4aa, 0x4ba4bc4bb4bb4bcc}, {0xaecc49914078536d, 0x58fae9f773886e19, 0x3ba3bc33b43b43bb},
+    {0xc21094364dfb5636, 0x985915fc12f542e5, 0x33b43b43a33b33cb}, {0xd77485cb25823ac7, 0x7d633293366b828c, 0x34b44c444343443c},
+    {0xef340a98172aace4, 0x86fb897116c87c35, 0x333343333343334b}, {0x84c8d4dfd2c63f3b, 0x29ecd9f40041e074, 0xccaccbbcbcbb4bbc},
+    {0x936b9fcebb25c995, 0xcab10dd900beec35, 0x3ab3ab3ab3bb3bbb}, {0xa3ab66580d5fdaf5, 0xc13e60d0d2e0ebbb, 0x4cc3dc4db4db4dbb},
+    {0xb5b5ada8aaff80b8, 0x0d819992132456bb, 0x33b33a34c33b34ab}, {0xc9bcff6034c13052, 0xfc89b393dd02f0b6, 0x33c33b44b43c34bc},
+    {0xdff9772470297ebd, 0x59787e2b93bc56f8, 0x43b444444443434c}, {0xf8a95fcf88747d94, 0x75a44c6397ce912b, 0x443334343443343b},
+    {0x8a08f0f8bf0f156b, 0x1b8e9ecb641b5900, 0xbbabab3aa3ab4ccc}, {0x993fe2c6d07b7fab, 0xe546a8038efe402a, 0x4cb4bc4db4db4bcc},
+    {0xaa242499697392d2, 0xdde50bd1d5d0b9ea, 0x3ba3ba3bb33b33bc}, {0xbce5086492111aea, 0x88f4bb1ca6bcf585, 0x44b44c44c44c43cb},
+    {0xd1b71758e219652b, 0xd3c36113404ea4a9, 0x44c44c44c444443b}, {0xe8d4a51000000000, 0x0000000000000000, 0x444444444444444c},
+    {0x813f3978f8940984, 0x4000000000000000, 0xcccccccccccccccc}, {0x8f7e32ce7bea5c6f, 0xe4820023a2000000, 0xbba3bc4cc4cc4ccc},
+    {0x9f4f2726179a2245, 0x01d762422c946591, 0x4aa3bb3aa3ba3bab}, {0xb0de65388cc8ada8, 0x3b25a55f43294bcc, 0x3ca33b33b44b43bc},
+    {0xc45d1df942711d9a, 0x3ba5d0bd324f8395, 0x44c44c34c44b44cb}, {0xda01ee641a708de9, 0xe80e6f4820cc9496, 0x33b33b343333333c},
+    {0xf209787bb47d6b84, 0xc0678c5dbd23a49b, 0x443444444443443b}, {0x865b86925b9bc5c2, 0x0b8a2392ba45a9b3, 0xdbccbcccb4cb3bbb},
+    {0x952ab45cfa97a0b2, 0xdd945a747bf26184, 0x3bc4bb4ab3ca3cbc}, {0xa59bc234db398c25, 0x43fab9837e699096, 0x3bb3ac3ab3bb33ac},
+    {0xb7dcbf5354e9bece, 0x0c11ed6d538aeb30, 0x33b43b43b34c34dc}, {0xcc20ce9bd35c78a5, 0x31ec038df7b441f5, 0x34c44c43c44b44cb},
+    {0xe2a0b5dc971f303a, 0x2e44ae64840fd61e, 0x333333333333333c}, {0xfb9b7cd9a4a7443c, 0x169840ef017da3b2, 0x433344443333344c},
+    {0x8bab8eefb6409c1a, 0x1ad089b6c2f7548f, 0xdcbdcc3cc4cc4bcb}, {0x9b10a4e5e9913128, 0xca7cf2b4191c8327, 0x3ab3cb3bc3bb4bbb},
+    {0xac2820d9623bf429, 0x546345fa9fbdcd45, 0x3bb3cc43c43c43cb}, {0xbf21e44003acdd2c, 0xe0470a63e6bd56c4, 0x44b34a43b44c44bc},
+    {0xd433179d9c8cb841, 0x5fa60692a46151ec, 0x43a33a33a333333c},
+};
+// clang-format on
+
+static const char kDigitTable[] = "0001020304050607080910111213141516171819202122232425262728293031323334353637383940414243444546474849"
+                                  "5051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899";
+
+// x*y => 128-bit product (lo+hi)
+inline uint64_t mul128(uint64_t x, uint64_t y, uint64_t* hi)
+{
+#if defined(_MSC_VER) && defined(_M_X64)
+    return _umul128(x, y, hi);
+#elif defined(__SIZEOF_INT128__)
+    unsigned __int128 r = x;
+    r *= y;
+    *hi = uint64_t(r >> 64);
+    return uint64_t(r);
+#else
+    uint32_t x0 = uint32_t(x), x1 = uint32_t(x >> 32);
+    uint32_t y0 = uint32_t(y), y1 = uint32_t(y >> 32);
+    uint64_t p11 = uint64_t(x1) * y1, p01 = uint64_t(x0) * y1;
+    uint64_t p10 = uint64_t(x1) * y0, p00 = uint64_t(x0) * y0;
+    uint64_t mid = p10 + (p00 >> 32) + uint32_t(p01);
+    uint64_t r0 = (mid << 32) | uint32_t(p00);
+    uint64_t r1 = p11 + (mid >> 32) + (p01 >> 32);
+    *hi = r1;
+    return r0;
+#endif
+}
+
+// (x*y)>>64 => 128-bit product (lo+hi)
+inline uint64_t mul192hi(uint64_t xhi, uint64_t xlo, uint64_t y, uint64_t* hi)
+{
+    uint64_t z2;
+    uint64_t z1 = mul128(xhi, y, &z2);
+
+    uint64_t z1c;
+    uint64_t z0 = mul128(xlo, y, &z1c);
+    (void)z0;
+
+    z1 += z1c;
+    z2 += (z1 < z1c);
+
+    *hi = z2;
+    return z1;
+}
+
+// 9.3. Rounding to odd (+ figure 8 + result 23)
+inline uint64_t roundodd(uint64_t ghi, uint64_t glo, uint64_t cp)
+{
+    uint64_t xhi;
+    uint64_t xlo = mul128(glo, cp, &xhi);
+    (void)xlo;
+
+    uint64_t yhi;
+    uint64_t ylo = mul128(ghi, cp, &yhi);
+
+    uint64_t z = ylo + xhi;
+    return (yhi + (z < xhi)) | (z > 1);
+}
+
+struct Decimal
+{
+    uint64_t s;
+    int k;
+};
+
+static Decimal schubfach(int exponent, uint64_t fraction)
+{
+    // Extract c & q such that c*2^q == |v|
+    uint64_t c = fraction;
+    int q = exponent - 1023 - 51;
+
+    if (exponent != 0) // normal numbers have implicit leading 1
+    {
+        c |= (1ull << 52);
+        q--;
+    }
+
+    // 8.3. Fast path for integers
+    if (unsigned(-q) < 53 && (c & ((1ull << (-q)) - 1)) == 0)
+        return {c >> (-q), 0};
+
+    // 5. Rounding interval
+    int irr = (c == (1ull << 52) && q != -1074); // Qmin
+    int out = int(c & 1);
+
+    // 9.8.1. Boundaries for c
+    uint64_t cbl = 4 * c - 2 + irr;
+    uint64_t cb = 4 * c;
+    uint64_t cbr = 4 * c + 2;
+
+    // 9.1. Computing k and h
+    const int Q = 20;
+    const int C = 315652;   // floor(2^Q * log10(2))
+    const int A = -131008;  // floor(2^Q * log10(3/4))
+    const int C2 = 3483294; // floor(2^Q * log2(10))
+    int k = (q * C + (irr ? A : 0)) >> Q;
+    int h = q + ((-k * C2) >> Q) + 1; // see (9) in 9.9
+
+    // 9.8.2. Overestimates of powers of 10
+    // Recover 10^-k fraction using compact tables generated by tools/numutils.py
+    // The 128-bit fraction is encoded as 128-bit baseline * power-of-5 * scale + offset
+    LUAU_ASSERT(-k >= kPow10TableMin && -k <= kPow10TableMax);
+    int gtoff = -k - kPow10TableMin;
+    const uint64_t* gt = kPow10Table[gtoff >> 4];
+
+    uint64_t ghi;
+    uint64_t glo = mul192hi(gt[0], gt[1], kPow5Table[gtoff & 15], &ghi);
+
+    // Apply 1-bit scale + 3-bit offset; note, offset is intentionally applied without carry, numutils.py validates that this is sufficient
+    int gterr = (gt[2] >> ((gtoff & 15) * 4)) & 15;
+    int gtscale = gterr >> 3;
+
+    ghi <<= gtscale;
+    ghi += (glo >> 63) & gtscale;
+    glo <<= gtscale;
+    glo -= (gterr & 7) - 4;
+
+    // 9.9. Boundaries for v
+    uint64_t vbl = roundodd(ghi, glo, cbl << h);
+    uint64_t vb = roundodd(ghi, glo, cb << h);
+    uint64_t vbr = roundodd(ghi, glo, cbr << h);
+
+    // Main algorithm; see figure 7 + figure 9
+    uint64_t s = vb / 4;
+
+    if (s >= 10)
+    {
+        uint64_t sp = s / 10;
+
+        bool upin = vbl + out <= 40 * sp;
+        bool wpin = vbr >= 40 * sp + 40 + out;
+
+        if (upin != wpin)
+            return {sp + wpin, k + 1};
+    }
+
+    // Figure 7 contains the algorithm to select between u (s) and w (s+1)
+    // rup computes the last 4 conditions in that algorithm
+    // rup is only used when uin == win, but since these branches predict poorly we use branchless selects
+    bool uin = vbl + out <= 4 * s;
+    bool win = 4 * s + 4 + out <= vbr;
+    bool rup = vb >= 4 * s + 2 + 1 - (s & 1);
+
+    return {s + (uin != win ? win : rup), k};
+}
+
+static char* printspecial(char* buf, int sign, uint64_t fraction)
+{
+    if (fraction == 0)
+    {
+        memcpy(buf, ("-inf") + (1 - sign), 4);
+        return buf + 3 + sign;
+    }
+    else
+    {
+        memcpy(buf, "nan", 4);
+        return buf + 3;
+    }
+}
+
+static char* printunsignedrev(char* end, uint64_t num)
+{
+    while (num >= 10000)
+    {
+        unsigned int tail = unsigned(num % 10000);
+
+        memcpy(end - 4, &kDigitTable[int(tail / 100) * 2], 2);
+        memcpy(end - 2, &kDigitTable[int(tail % 100) * 2], 2);
+        num /= 10000;
+        end -= 4;
+    }
+
+    unsigned int rest = unsigned(num);
+
+    while (rest >= 10)
+    {
+        memcpy(end - 2, &kDigitTable[int(rest % 100) * 2], 2);
+        rest /= 100;
+        end -= 2;
+    }
+
+    if (rest)
+    {
+        end[-1] = '0' + int(rest);
+        end -= 1;
+    }
+
+    return end;
+}
+
+static char* printexp(char* buf, int num)
+{
+    *buf++ = 'e';
+    *buf++ = num < 0 ? '-' : '+';
+
+    int v = num < 0 ? -num : num;
+
+    if (v >= 100)
+    {
+        *buf++ = '0' + (v / 100);
+        v %= 100;
+    }
+
+    memcpy(buf, &kDigitTable[v * 2], 2);
+    return buf + 2;
+}
+
+inline char* trimzero(char* end)
+{
+    while (end[-1] == '0')
+        end--;
+
+    return end;
+}
+
+// We use fixed-length memcpy/memset since they lower to fast SIMD+scalar writes; the target buffers should have padding space
+#define fastmemcpy(dst, src, size, sizefast) check_exp((size) <= sizefast, memcpy(dst, src, sizefast))
+#define fastmemset(dst, val, size, sizefast) check_exp((size) <= sizefast, memset(dst, val, sizefast))
+
+char* luai_num2str(char* buf, double n)
+{
+    // IEEE-754
+    union
+    {
+        double v;
+        uint64_t bits;
+    } v = {n};
+    int sign = int(v.bits >> 63);
+    int exponent = int(v.bits >> 52) & 2047;
+    uint64_t fraction = v.bits & ((1ull << 52) - 1);
+
+    // specials
+    if (LUAU_UNLIKELY(exponent == 0x7ff))
+        return printspecial(buf, sign, fraction);
+
+    // sign bit
+    *buf = '-';
+    buf += sign;
+
+    // zero
+    if (exponent == 0 && fraction == 0)
+    {
+        buf[0] = '0';
+        return buf + 1;
+    }
+
+    // convert binary to decimal using Schubfach
+    Decimal d = schubfach(exponent, fraction);
+    LUAU_ASSERT(d.s < uint64_t(1e17));
+
+    // print the decimal to a temporary buffer; we'll need to insert the decimal point and figure out the format
+    char decbuf[40];
+    char* decend = decbuf + 20; // significand needs at most 17 digits; the rest of the buffer may be copied using fixed length memcpy
+    char* dec = printunsignedrev(decend, d.s);
+
+    int declen = int(decend - dec);
+    LUAU_ASSERT(declen <= 17);
+
+    int dot = declen + d.k;
+
+    // the limits are somewhat arbitrary but changing them may require changing fastmemset/fastmemcpy sizes below
+    if (dot >= -5 && dot <= 21)
+    {
+        // fixed point format
+        if (dot <= 0)
+        {
+            buf[0] = '0';
+            buf[1] = '.';
+
+            fastmemset(buf + 2, '0', -dot, 5);
+            fastmemcpy(buf + 2 + (-dot), dec, declen, 17);
+
+            return trimzero(buf + 2 + (-dot) + declen);
+        }
+        else if (dot == declen)
+        {
+            // no dot
+            fastmemcpy(buf, dec, dot, 17);
+
+            return buf + dot;
+        }
+        else if (dot < declen)
+        {
+            // dot in the middle
+            fastmemcpy(buf, dec, dot, 16);
+
+            buf[dot] = '.';
+
+            fastmemcpy(buf + dot + 1, dec + dot, declen - dot, 16);
+
+            return trimzero(buf + declen + 1);
+        }
+        else
+        {
+            // no dot, zero padding
+            fastmemcpy(buf, dec, declen, 17);
+            fastmemset(buf + declen, '0', dot - declen, 8);
+
+            return buf + dot;
+        }
+    }
+    else
+    {
+        // scientific format
+        buf[0] = dec[0];
+        buf[1] = '.';
+        fastmemcpy(buf + 2, dec + 1, declen - 1, 16);
+
+        char* exp = trimzero(buf + declen + 1);
+
+        return printexp(exp, dot - 1);
+    }
+}

--- a/lib/luau/VM/src/lnumutils.h
+++ b/lib/luau/VM/src/lnumutils.h
@@ -1,0 +1,69 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include <math.h>
+
+#define luai_numadd(a, b) ((a) + (b))
+#define luai_numsub(a, b) ((a) - (b))
+#define luai_nummul(a, b) ((a) * (b))
+#define luai_numdiv(a, b) ((a) / (b))
+#define luai_numpow(a, b) (pow(a, b))
+#define luai_numunm(a) (-(a))
+#define luai_numisnan(a) ((a) != (a))
+#define luai_numeq(a, b) ((a) == (b))
+#define luai_numlt(a, b) ((a) < (b))
+#define luai_numle(a, b) ((a) <= (b))
+
+inline bool luai_veceq(const float* a, const float* b)
+{
+#if LUA_VECTOR_SIZE == 4
+    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
+#else
+    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2];
+#endif
+}
+
+inline bool luai_vecisnan(const float* a)
+{
+#if LUA_VECTOR_SIZE == 4
+    return a[0] != a[0] || a[1] != a[1] || a[2] != a[2] || a[3] != a[3];
+#else
+    return a[0] != a[0] || a[1] != a[1] || a[2] != a[2];
+#endif
+}
+
+LUAU_FASTMATH_BEGIN
+inline double luai_nummod(double a, double b)
+{
+    return a - floor(a / b) * b;
+}
+LUAU_FASTMATH_END
+
+LUAU_FASTMATH_BEGIN
+inline double luai_numidiv(double a, double b)
+{
+    return floor(a / b);
+}
+LUAU_FASTMATH_END
+
+#define luai_num2int(i, d) ((i) = (int)(d))
+
+// On MSVC in 32-bit, double to unsigned cast compiles into a call to __dtoui3, so we invoke x87->int64 conversion path manually
+#if defined(_MSC_VER) && defined(_M_IX86)
+#define luai_num2unsigned(i, n) \
+    { \
+        __int64 l; \
+        __asm { __asm fld n __asm fistp l} \
+        ; \
+        i = (unsigned int)l; \
+    }
+#else
+#define luai_num2unsigned(i, n) ((i) = (unsigned)(long long)(n))
+#endif
+
+#define LUAI_MAXNUM2STR 48
+
+LUAI_FUNC char* luai_num2str(char* buf, double n);
+
+#define luai_str2num(s, p) strtod((s), (p))

--- a/lib/luau/VM/src/lobject.cpp
+++ b/lib/luau/VM/src/lobject.cpp
@@ -1,0 +1,154 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lobject.h"
+
+#include "lstate.h"
+#include "lstring.h"
+#include "lgc.h"
+#include "ldo.h"
+#include "lnumutils.h"
+
+#include <ctype.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+const TValue luaO_nilobject_ = {{NULL}, {0}, LUA_TNIL};
+
+int luaO_log2(unsigned int x)
+{
+    static const uint8_t log_2[256] = {0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8,
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
+    int l = -1;
+    while (x >= 256)
+    {
+        l += 8;
+        x >>= 8;
+    }
+    return l + log_2[x];
+}
+
+int luaO_rawequalObj(const TValue* t1, const TValue* t2)
+{
+    if (ttype(t1) != ttype(t2))
+        return 0;
+    else
+        switch (ttype(t1))
+        {
+        case LUA_TNIL:
+            return 1;
+        case LUA_TNUMBER:
+            return luai_numeq(nvalue(t1), nvalue(t2));
+        case LUA_TVECTOR:
+            return luai_veceq(vvalue(t1), vvalue(t2));
+        case LUA_TBOOLEAN:
+            return bvalue(t1) == bvalue(t2); // boolean true must be 1 !!
+        case LUA_TLIGHTUSERDATA:
+            return pvalue(t1) == pvalue(t2) && (!FFlag::TaggedLuData || lightuserdatatag(t1) == lightuserdatatag(t2));
+        default:
+            LUAU_ASSERT(iscollectable(t1));
+            return gcvalue(t1) == gcvalue(t2);
+        }
+}
+
+int luaO_rawequalKey(const TKey* t1, const TValue* t2)
+{
+    if (ttype(t1) != ttype(t2))
+        return 0;
+    else
+        switch (ttype(t1))
+        {
+        case LUA_TNIL:
+            return 1;
+        case LUA_TNUMBER:
+            return luai_numeq(nvalue(t1), nvalue(t2));
+        case LUA_TVECTOR:
+            return luai_veceq(vvalue(t1), vvalue(t2));
+        case LUA_TBOOLEAN:
+            return bvalue(t1) == bvalue(t2); // boolean true must be 1 !!
+        case LUA_TLIGHTUSERDATA:
+            return pvalue(t1) == pvalue(t2) && (!FFlag::TaggedLuData || lightuserdatatag(t1) == lightuserdatatag(t2));
+        default:
+            LUAU_ASSERT(iscollectable(t1));
+            return gcvalue(t1) == gcvalue(t2);
+        }
+}
+
+int luaO_str2d(const char* s, double* result)
+{
+    char* endptr;
+    *result = luai_str2num(s, &endptr);
+    if (endptr == s)
+        return 0;                         // conversion failed
+    if (*endptr == 'x' || *endptr == 'X') // maybe an hexadecimal constant?
+        *result = cast_num(strtoul(s, &endptr, 16));
+    if (*endptr == '\0')
+        return 1; // most common case
+    while (isspace(cast_to(unsigned char, *endptr)))
+        endptr++;
+    if (*endptr != '\0')
+        return 0; // invalid trailing characters?
+    return 1;
+}
+
+const char* luaO_pushvfstring(lua_State* L, const char* fmt, va_list argp)
+{
+    char result[LUA_BUFFERSIZE];
+    vsnprintf(result, sizeof(result), fmt, argp);
+
+    setsvalue(L, L->top, luaS_new(L, result));
+    incr_top(L);
+    return svalue(L->top - 1);
+}
+
+const char* luaO_pushfstring(lua_State* L, const char* fmt, ...)
+{
+    const char* msg;
+    va_list argp;
+    va_start(argp, fmt);
+    msg = luaO_pushvfstring(L, fmt, argp);
+    va_end(argp);
+    return msg;
+}
+
+const char* luaO_chunkid(char* buf, size_t buflen, const char* source, size_t srclen)
+{
+    if (*source == '=')
+    {
+        if (srclen <= buflen)
+            return source + 1;
+        // truncate the part after =
+        memcpy(buf, source + 1, buflen - 1);
+        buf[buflen - 1] = '\0';
+    }
+    else if (*source == '@')
+    {
+        if (srclen <= buflen)
+            return source + 1;
+        // truncate the part after @
+        memcpy(buf, "...", 3);
+        memcpy(buf + 3, source + srclen - (buflen - 4), buflen - 4);
+        buf[buflen - 1] = '\0';
+    }
+    else
+    {                                         // buf = [string "string"]
+        size_t len = strcspn(source, "\n\r"); // stop at first newline
+        buflen -= sizeof("[string \"...\"]");
+        if (len > buflen)
+            len = buflen;
+        strcpy(buf, "[string \"");
+        if (source[len] != '\0')
+        { // must truncate?
+            strncat(buf, source, len);
+            strcat(buf, "...");
+        }
+        else
+            strcat(buf, source);
+        strcat(buf, "\"]");
+    }
+    return buf;
+}

--- a/lib/luau/VM/src/lobject.h
+++ b/lib/luau/VM/src/lobject.h
@@ -1,0 +1,502 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lua.h"
+#include "lcommon.h"
+
+/*
+** Union of all collectible objects
+*/
+typedef union GCObject GCObject;
+
+/*
+** Common Header for all collectible objects (in macro form, to be included in other objects)
+*/
+// clang-format off
+#define CommonHeader \
+     uint8_t tt; uint8_t marked; uint8_t memcat
+// clang-format on
+
+/*
+** Common header in struct form
+*/
+typedef struct GCheader
+{
+    CommonHeader;
+} GCheader;
+
+/*
+** Union of all Lua values
+*/
+typedef union
+{
+    GCObject* gc;
+    void* p;
+    double n;
+    int b;
+    float v[2]; // v[0], v[1] live here; v[2] lives in TValue::extra
+} Value;
+
+/*
+** Tagged Values
+*/
+
+typedef struct lua_TValue
+{
+    Value value;
+    int extra[LUA_EXTRA_SIZE];
+    int tt;
+} TValue;
+
+// Macros to test type
+#define ttisnil(o) (ttype(o) == LUA_TNIL)
+#define ttisnumber(o) (ttype(o) == LUA_TNUMBER)
+#define ttisstring(o) (ttype(o) == LUA_TSTRING)
+#define ttistable(o) (ttype(o) == LUA_TTABLE)
+#define ttisfunction(o) (ttype(o) == LUA_TFUNCTION)
+#define ttisboolean(o) (ttype(o) == LUA_TBOOLEAN)
+#define ttisuserdata(o) (ttype(o) == LUA_TUSERDATA)
+#define ttisthread(o) (ttype(o) == LUA_TTHREAD)
+#define ttisbuffer(o) (ttype(o) == LUA_TBUFFER)
+#define ttislightuserdata(o) (ttype(o) == LUA_TLIGHTUSERDATA)
+#define ttisvector(o) (ttype(o) == LUA_TVECTOR)
+#define ttisupval(o) (ttype(o) == LUA_TUPVAL)
+
+// Macros to access values
+#define ttype(o) ((o)->tt)
+#define gcvalue(o) check_exp(iscollectable(o), (o)->value.gc)
+#define pvalue(o) check_exp(ttislightuserdata(o), (o)->value.p)
+#define nvalue(o) check_exp(ttisnumber(o), (o)->value.n)
+#define vvalue(o) check_exp(ttisvector(o), (o)->value.v)
+#define tsvalue(o) check_exp(ttisstring(o), &(o)->value.gc->ts)
+#define uvalue(o) check_exp(ttisuserdata(o), &(o)->value.gc->u)
+#define clvalue(o) check_exp(ttisfunction(o), &(o)->value.gc->cl)
+#define hvalue(o) check_exp(ttistable(o), &(o)->value.gc->h)
+#define bvalue(o) check_exp(ttisboolean(o), (o)->value.b)
+#define thvalue(o) check_exp(ttisthread(o), &(o)->value.gc->th)
+#define bufvalue(o) check_exp(ttisbuffer(o), &(o)->value.gc->buf)
+#define upvalue(o) check_exp(ttisupval(o), &(o)->value.gc->uv)
+
+#define l_isfalse(o) (ttisnil(o) || (ttisboolean(o) && bvalue(o) == 0))
+
+#define lightuserdatatag(o) check_exp(ttislightuserdata(o), (o)->extra[0])
+
+// Internal tags used by the VM
+#define LU_TAG_ITERATOR LUA_UTAG_LIMIT
+
+/*
+** for internal debug only
+*/
+#define checkconsistency(obj) LUAU_ASSERT(!iscollectable(obj) || (ttype(obj) == (obj)->value.gc->gch.tt))
+
+#define checkliveness(g, obj) LUAU_ASSERT(!iscollectable(obj) || ((ttype(obj) == (obj)->value.gc->gch.tt) && !isdead(g, (obj)->value.gc)))
+
+// Macros to set values
+#define setnilvalue(obj) ((obj)->tt = LUA_TNIL)
+
+#define setnvalue(obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.n = (x); \
+        i_o->tt = LUA_TNUMBER; \
+    }
+
+#if LUA_VECTOR_SIZE == 4
+#define setvvalue(obj, x, y, z, w) \
+    { \
+        TValue* i_o = (obj); \
+        float* i_v = i_o->value.v; \
+        i_v[0] = (x); \
+        i_v[1] = (y); \
+        i_v[2] = (z); \
+        i_v[3] = (w); \
+        i_o->tt = LUA_TVECTOR; \
+    }
+#else
+#define setvvalue(obj, x, y, z, w) \
+    { \
+        TValue* i_o = (obj); \
+        float* i_v = i_o->value.v; \
+        i_v[0] = (x); \
+        i_v[1] = (y); \
+        i_v[2] = (z); \
+        i_o->tt = LUA_TVECTOR; \
+    }
+#endif
+
+#define setpvalue(obj, x, tag) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.p = (x); \
+        i_o->extra[0] = (tag); \
+        i_o->tt = LUA_TLIGHTUSERDATA; \
+    }
+
+#define setbvalue(obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.b = (x); \
+        i_o->tt = LUA_TBOOLEAN; \
+    }
+
+#define setsvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TSTRING; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setuvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TUSERDATA; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setthvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TTHREAD; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setbufvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TBUFFER; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setclvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TFUNCTION; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define sethvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TTABLE; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setptvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TPROTO; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setupvalue(L, obj, x) \
+    { \
+        TValue* i_o = (obj); \
+        i_o->value.gc = cast_to(GCObject*, (x)); \
+        i_o->tt = LUA_TUPVAL; \
+        checkliveness(L->global, i_o); \
+    }
+
+#define setobj(L, obj1, obj2) \
+    { \
+        const TValue* o2 = (obj2); \
+        TValue* o1 = (obj1); \
+        *o1 = *o2; \
+        checkliveness(L->global, o1); \
+    }
+
+/*
+** different types of sets, according to destination
+*/
+
+// to stack
+#define setobj2s setobj
+// from table to same table (no barrier)
+#define setobjt2t setobj
+// to table (needs barrier)
+#define setobj2t setobj
+// to new object (no barrier)
+#define setobj2n setobj
+
+#define setttype(obj, tt) (ttype(obj) = (tt))
+
+#define iscollectable(o) (ttype(o) >= LUA_TSTRING)
+
+typedef TValue* StkId; // index to stack elements
+
+/*
+** String headers for string table
+*/
+typedef struct TString
+{
+    CommonHeader;
+    // 1 byte padding
+
+    int16_t atom;
+    // 2 byte padding
+
+    TString* next; // next string in the hash table bucket
+
+    unsigned int hash;
+    unsigned int len;
+
+    char data[1]; // string data is allocated right after the header
+} TString;
+
+#define getstr(ts) (ts)->data
+#define svalue(o) getstr(tsvalue(o))
+
+typedef struct Udata
+{
+    CommonHeader;
+
+    uint8_t tag;
+
+    int len;
+
+    struct Table* metatable;
+
+    union
+    {
+        char data[1];      // userdata is allocated right after the header
+        L_Umaxalign dummy; // ensures maximum alignment for data
+    };
+} Udata;
+
+typedef struct Buffer
+{
+    CommonHeader;
+
+    unsigned int len;
+
+    union
+    {
+        char data[1];      // buffer is allocated right after the header
+        L_Umaxalign dummy; // ensures maximum alignment for data
+    };
+} Buffer;
+
+/*
+** Function Prototypes
+*/
+// clang-format off
+typedef struct Proto
+{
+    CommonHeader;
+
+
+    uint8_t nups; // number of upvalues
+    uint8_t numparams;
+    uint8_t is_vararg;
+    uint8_t maxstacksize;
+    uint8_t flags;
+
+
+    TValue* k;              // constants used by the function
+    Instruction* code;      // function bytecode
+    struct Proto** p;       // functions defined inside the function
+    const Instruction* codeentry;
+
+    void* execdata;
+    uintptr_t exectarget;
+
+
+    uint8_t* lineinfo;      // for each instruction, line number as a delta from baseline
+    int* abslineinfo;       // baseline line info, one entry for each 1<<linegaplog2 instructions; allocated after lineinfo
+    struct LocVar* locvars; // information about local variables
+    TString** upvalues;     // upvalue names
+    TString* source;
+
+    TString* debugname;
+    uint8_t* debuginsn; // a copy of code[] array with just opcodes
+
+    uint8_t* typeinfo;
+
+    void* userdata;
+
+    GCObject* gclist;
+
+
+    int sizecode;
+    int sizep;
+    int sizelocvars;
+    int sizeupvalues;
+    int sizek;
+    int sizelineinfo;
+    int linegaplog2;
+    int linedefined;
+    int bytecodeid;
+} Proto;
+// clang-format on
+
+typedef struct LocVar
+{
+    TString* varname;
+    int startpc; // first point where variable is active
+    int endpc;   // first point where variable is dead
+    uint8_t reg; // register slot, relative to base, where variable is stored
+} LocVar;
+
+/*
+** Upvalues
+*/
+
+typedef struct UpVal
+{
+    CommonHeader;
+    uint8_t markedopen; // set if reachable from an alive thread (only valid during atomic)
+
+    // 4 byte padding (x64)
+
+    TValue* v; // points to stack or to its own value
+    union
+    {
+        TValue value; // the value (when closed)
+        struct
+        {
+            // global double linked list (when open)
+            struct UpVal* prev;
+            struct UpVal* next;
+
+            // thread linked list (when open)
+            struct UpVal* threadnext;
+        } open;
+    } u;
+} UpVal;
+
+#define upisopen(up) ((up)->v != &(up)->u.value)
+
+/*
+** Closures
+*/
+
+typedef struct Closure
+{
+    CommonHeader;
+
+    uint8_t isC;
+    uint8_t nupvalues;
+    uint8_t stacksize;
+    uint8_t preload;
+
+    GCObject* gclist;
+    struct Table* env;
+
+    union
+    {
+        struct
+        {
+            lua_CFunction f;
+            lua_Continuation cont;
+            const char* debugname;
+            TValue upvals[1];
+        } c;
+
+        struct
+        {
+            struct Proto* p;
+            TValue uprefs[1];
+        } l;
+    };
+} Closure;
+
+#define iscfunction(o) (ttype(o) == LUA_TFUNCTION && clvalue(o)->isC)
+#define isLfunction(o) (ttype(o) == LUA_TFUNCTION && !clvalue(o)->isC)
+
+/*
+** Tables
+*/
+
+typedef struct TKey
+{
+    ::Value value;
+    int extra[LUA_EXTRA_SIZE];
+    unsigned tt : 4;
+    int next : 28; // for chaining
+} TKey;
+
+typedef struct LuaNode
+{
+    TValue val;
+    TKey key;
+} LuaNode;
+
+// copy a value into a key
+#define setnodekey(L, node, obj) \
+    { \
+        LuaNode* n_ = (node); \
+        const TValue* i_o = (obj); \
+        n_->key.value = i_o->value; \
+        memcpy(n_->key.extra, i_o->extra, sizeof(n_->key.extra)); \
+        n_->key.tt = i_o->tt; \
+        checkliveness(L->global, i_o); \
+    }
+
+// copy a value from a key
+#define getnodekey(L, obj, node) \
+    { \
+        TValue* i_o = (obj); \
+        const LuaNode* n_ = (node); \
+        i_o->value = n_->key.value; \
+        memcpy(i_o->extra, n_->key.extra, sizeof(i_o->extra)); \
+        i_o->tt = n_->key.tt; \
+        checkliveness(L->global, i_o); \
+    }
+
+// clang-format off
+typedef struct Table
+{
+    CommonHeader;
+
+
+    uint8_t tmcache;    // 1<<p means tagmethod(p) is not present
+    uint8_t readonly;   // sandboxing feature to prohibit writes to table
+    uint8_t safeenv;    // environment doesn't share globals with other scripts
+    uint8_t lsizenode;  // log2 of size of `node' array
+    uint8_t nodemask8; // (1<<lsizenode)-1, truncated to 8 bits
+
+    int sizearray; // size of `array' array
+    union
+    {
+        int lastfree;  // any free position is before this position
+        int aboundary; // negated 'boundary' of `array' array; iff aboundary < 0
+    };
+
+
+    struct Table* metatable;
+    TValue* array;  // array part
+    LuaNode* node;
+    GCObject* gclist;
+} Table;
+// clang-format on
+
+/*
+** `module' operation for hashing (size is always a power of 2)
+*/
+#define lmod(s, size) (check_exp((size & (size - 1)) == 0, (cast_to(int, (s) & ((size)-1)))))
+
+#define twoto(x) ((int)(1 << (x)))
+#define sizenode(t) (twoto((t)->lsizenode))
+
+#define luaO_nilobject (&luaO_nilobject_)
+
+LUAI_DATA const TValue luaO_nilobject_;
+
+#define ceillog2(x) (luaO_log2((x)-1) + 1)
+
+LUAI_FUNC int luaO_log2(unsigned int x);
+LUAI_FUNC int luaO_rawequalObj(const TValue* t1, const TValue* t2);
+LUAI_FUNC int luaO_rawequalKey(const TKey* t1, const TValue* t2);
+LUAI_FUNC int luaO_str2d(const char* s, double* result);
+LUAI_FUNC const char* luaO_pushvfstring(lua_State* L, const char* fmt, va_list argp);
+LUAI_FUNC const char* luaO_pushfstring(lua_State* L, const char* fmt, ...);
+LUAI_FUNC const char* luaO_chunkid(char* buf, size_t buflen, const char* source, size_t srclen);
+
+LUAU_FASTFLAG(TaggedLuData)

--- a/lib/luau/VM/src/loslib.cpp
+++ b/lib/luau/VM/src/loslib.cpp
@@ -1,0 +1,225 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lcommon.h"
+
+#include <string.h>
+#include <time.h>
+
+#define LUA_STRFTIMEOPTIONS "aAbBcdHIjmMpSUwWxXyYzZ%"
+
+#if defined(_WIN32)
+static tm* gmtime_r(const time_t* timep, tm* result)
+{
+    return gmtime_s(result, timep) == 0 ? result : NULL;
+}
+
+static tm* localtime_r(const time_t* timep, tm* result)
+{
+    return localtime_s(result, timep) == 0 ? result : NULL;
+}
+#endif
+
+static time_t os_timegm(struct tm* timep)
+{
+    // Julian day number calculation
+    int day = timep->tm_mday;
+    int month = timep->tm_mon + 1;
+    int year = timep->tm_year + 1900;
+
+    // year adjustment, pretend that it starts in March
+    int a = timep->tm_mon % 12 < 2 ? 1 : 0;
+
+    // also adjust for out-of-range month numbers in input
+    a -= timep->tm_mon / 12;
+
+    int y = year + 4800 - a;
+    int m = month + (12 * a) - 3;
+
+    int julianday = day + ((153 * m + 2) / 5) + (365 * y) + (y / 4) - (y / 100) + (y / 400) - 32045;
+
+    const int utcstartasjulianday = 2440588;                              // Jan 1st 1970 offset in Julian calendar
+    const int64_t utcstartasjuliansecond = utcstartasjulianday * 86400ll; // same in seconds
+
+    // fail the dates before UTC start
+    if (julianday < utcstartasjulianday)
+        return time_t(-1);
+
+    int64_t daysecond = timep->tm_hour * 3600ll + timep->tm_min * 60ll + timep->tm_sec;
+    int64_t julianseconds = int64_t(julianday) * 86400ull + daysecond;
+
+    if (julianseconds < utcstartasjuliansecond)
+        return time_t(-1);
+
+    int64_t utc = julianseconds - utcstartasjuliansecond;
+    return time_t(utc);
+}
+
+static int os_clock(lua_State* L)
+{
+    lua_pushnumber(L, lua_clock());
+    return 1;
+}
+
+/*
+** {======================================================
+** Time/Date operations
+** { year=%Y, month=%m, day=%d, hour=%H, min=%M, sec=%S,
+**   wday=%w+1, yday=%j, isdst=? }
+** =======================================================
+*/
+
+static void setfield(lua_State* L, const char* key, int value)
+{
+    lua_pushinteger(L, value);
+    lua_setfield(L, -2, key);
+}
+
+static void setboolfield(lua_State* L, const char* key, int value)
+{
+    if (value < 0) // undefined?
+        return;    // does not set field
+    lua_pushboolean(L, value);
+    lua_setfield(L, -2, key);
+}
+
+static int getboolfield(lua_State* L, const char* key)
+{
+    int res;
+    lua_rawgetfield(L, -1, key);
+    res = lua_isnil(L, -1) ? -1 : lua_toboolean(L, -1);
+    lua_pop(L, 1);
+    return res;
+}
+
+static int getfield(lua_State* L, const char* key, int d)
+{
+    int res;
+    lua_rawgetfield(L, -1, key);
+    if (lua_isnumber(L, -1))
+        res = (int)lua_tointeger(L, -1);
+    else
+    {
+        if (d < 0)
+            luaL_error(L, "field '%s' missing in date table", key);
+        res = d;
+    }
+    lua_pop(L, 1);
+    return res;
+}
+
+static int os_date(lua_State* L)
+{
+    const char* s = luaL_optstring(L, 1, "%c");
+    time_t t = luaL_opt(L, (time_t)luaL_checknumber, 2, time(NULL));
+
+    struct tm tm;
+    struct tm* stm;
+    if (*s == '!')
+    { // UTC?
+        stm = gmtime_r(&t, &tm);
+        s++; // skip `!'
+    }
+    else
+    {
+        // on Windows, localtime() fails with dates before epoch start so we disallow that
+        stm = t < 0 ? NULL : localtime_r(&t, &tm);
+    }
+
+    if (stm == NULL) // invalid date?
+    {
+        lua_pushnil(L);
+    }
+    else if (strcmp(s, "*t") == 0)
+    {
+        lua_createtable(L, 0, 9); // 9 = number of fields
+        setfield(L, "sec", stm->tm_sec);
+        setfield(L, "min", stm->tm_min);
+        setfield(L, "hour", stm->tm_hour);
+        setfield(L, "day", stm->tm_mday);
+        setfield(L, "month", stm->tm_mon + 1);
+        setfield(L, "year", stm->tm_year + 1900);
+        setfield(L, "wday", stm->tm_wday + 1);
+        setfield(L, "yday", stm->tm_yday + 1);
+        setboolfield(L, "isdst", stm->tm_isdst);
+    }
+    else
+    {
+        char cc[3];
+        cc[0] = '%';
+        cc[2] = '\0';
+
+        luaL_Strbuf b;
+        luaL_buffinit(L, &b);
+        for (; *s; s++)
+        {
+            if (*s != '%' || *(s + 1) == '\0') // no conversion specifier?
+            {
+                luaL_addchar(&b, *s);
+            }
+            else if (strchr(LUA_STRFTIMEOPTIONS, *(s + 1)) == 0)
+            {
+                luaL_argerror(L, 1, "invalid conversion specifier");
+            }
+            else
+            {
+                size_t reslen;
+                char buff[200]; // should be big enough for any conversion result
+                cc[1] = *(++s);
+                reslen = strftime(buff, sizeof(buff), cc, stm);
+                luaL_addlstring(&b, buff, reslen);
+            }
+        }
+        luaL_pushresult(&b);
+    }
+    return 1;
+}
+
+static int os_time(lua_State* L)
+{
+    time_t t;
+    if (lua_isnoneornil(L, 1)) // called without args?
+        t = time(NULL);        // get current time
+    else
+    {
+        struct tm ts;
+        luaL_checktype(L, 1, LUA_TTABLE);
+        lua_settop(L, 1); // make sure table is at the top
+        ts.tm_sec = getfield(L, "sec", 0);
+        ts.tm_min = getfield(L, "min", 0);
+        ts.tm_hour = getfield(L, "hour", 12);
+        ts.tm_mday = getfield(L, "day", -1);
+        ts.tm_mon = getfield(L, "month", -1) - 1;
+        ts.tm_year = getfield(L, "year", -1) - 1900;
+        ts.tm_isdst = getboolfield(L, "isdst");
+
+        // Note: upstream Lua uses mktime() here which assumes input is local time, but we prefer UTC for consistency
+        t = os_timegm(&ts);
+    }
+    if (t == (time_t)(-1))
+        lua_pushnil(L);
+    else
+        lua_pushnumber(L, (double)t);
+    return 1;
+}
+
+static int os_difftime(lua_State* L)
+{
+    lua_pushnumber(L, difftime((time_t)(luaL_checknumber(L, 1)), (time_t)(luaL_optnumber(L, 2, 0))));
+    return 1;
+}
+
+static const luaL_Reg syslib[] = {
+    {"clock", os_clock},
+    {"date", os_date},
+    {"difftime", os_difftime},
+    {"time", os_time},
+    {NULL, NULL},
+};
+
+int luaopen_os(lua_State* L)
+{
+    luaL_register(L, LUA_OSLIBNAME, syslib);
+    return 1;
+}

--- a/lib/luau/VM/src/lperf.cpp
+++ b/lib/luau/VM/src/lperf.cpp
@@ -1,0 +1,63 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lua.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+
+
+#include <time.h>
+
+static double clock_period()
+{
+#if defined(_WIN32)
+    LARGE_INTEGER result = {};
+    QueryPerformanceFrequency(&result);
+    return 1.0 / double(result.QuadPart);
+#elif defined(__APPLE__)
+    mach_timebase_info_data_t result = {};
+    mach_timebase_info(&result);
+    return double(result.numer) / double(result.denom) * 1e-9;
+#elif defined(__linux__)
+    return 1e-9;
+#else
+    return 1.0 / double(CLOCKS_PER_SEC);
+#endif
+}
+
+static double clock_timestamp()
+{
+#if defined(_WIN32)
+    LARGE_INTEGER result = {};
+    QueryPerformanceCounter(&result);
+    return double(result.QuadPart);
+#elif defined(__APPLE__)
+    return double(mach_absolute_time());
+#elif defined(__linux__)
+    timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return now.tv_sec * 1e9 + now.tv_nsec;
+#else
+    return double(clock());
+#endif
+}
+
+double lua_clock()
+{
+    static double period = clock_period();
+
+    return clock_timestamp() * period;
+}

--- a/lib/luau/VM/src/lstate.cpp
+++ b/lib/luau/VM/src/lstate.cpp
@@ -1,0 +1,244 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lstate.h"
+
+#include "ltable.h"
+#include "lstring.h"
+#include "lfunc.h"
+#include "lmem.h"
+#include "lgc.h"
+#include "ldo.h"
+#include "ldebug.h"
+
+/*
+** Main thread combines a thread state and the global state
+*/
+typedef struct LG
+{
+    lua_State l;
+    global_State g;
+} LG;
+
+static void stack_init(lua_State* L1, lua_State* L)
+{
+    // initialize CallInfo array
+    L1->base_ci = luaM_newarray(L, BASIC_CI_SIZE, CallInfo, L1->memcat);
+    L1->ci = L1->base_ci;
+    L1->size_ci = BASIC_CI_SIZE;
+    L1->end_ci = L1->base_ci + L1->size_ci - 1;
+    // initialize stack array
+    L1->stack = luaM_newarray(L, BASIC_STACK_SIZE + EXTRA_STACK, TValue, L1->memcat);
+    L1->stacksize = BASIC_STACK_SIZE + EXTRA_STACK;
+    TValue* stack = L1->stack;
+    for (int i = 0; i < BASIC_STACK_SIZE + EXTRA_STACK; i++)
+        setnilvalue(stack + i); // erase new stack
+    L1->top = stack;
+    L1->stack_last = stack + (L1->stacksize - EXTRA_STACK);
+    // initialize first ci
+    L1->ci->func = L1->top;
+    setnilvalue(L1->top++); // `function' entry for this `ci'
+    L1->base = L1->ci->base = L1->top;
+    L1->ci->top = L1->top + LUA_MINSTACK;
+}
+
+static void freestack(lua_State* L, lua_State* L1)
+{
+    luaM_freearray(L, L1->base_ci, L1->size_ci, CallInfo, L1->memcat);
+    luaM_freearray(L, L1->stack, L1->stacksize, TValue, L1->memcat);
+}
+
+/*
+** open parts that may cause memory-allocation errors
+*/
+static void f_luaopen(lua_State* L, void* ud)
+{
+    global_State* g = L->global;
+    stack_init(L, L);                             // init stack
+    L->gt = luaH_new(L, 0, 2);                    // table of globals
+    sethvalue(L, registry(L), luaH_new(L, 0, 2)); // registry
+    luaS_resize(L, LUA_MINSTRTABSIZE);            // initial size of string table
+    luaT_init(L);
+    luaS_fix(luaS_newliteral(L, LUA_MEMERRMSG)); // pin to make sure we can always throw this error
+    luaS_fix(luaS_newliteral(L, LUA_ERRERRMSG)); // pin to make sure we can always throw this error
+    g->GCthreshold = 4 * g->totalbytes;
+}
+
+static void preinit_state(lua_State* L, global_State* g)
+{
+    L->global = g;
+    L->stack = NULL;
+    L->stacksize = 0;
+    L->gt = NULL;
+    L->openupval = NULL;
+    L->size_ci = 0;
+    L->nCcalls = L->baseCcalls = 0;
+    L->status = 0;
+    L->base_ci = L->ci = NULL;
+    L->namecall = NULL;
+    L->cachedslot = 0;
+    L->singlestep = false;
+    L->isactive = false;
+    L->activememcat = 0;
+    L->userdata = NULL;
+}
+
+static void close_state(lua_State* L)
+{
+    global_State* g = L->global;
+    luaF_close(L, L->stack); // close all upvalues for this thread
+    luaC_freeall(L);         // collect all objects
+    LUAU_ASSERT(g->strt.nuse == 0);
+    luaM_freearray(L, L->global->strt.hash, L->global->strt.size, TString*, 0);
+    freestack(L, L);
+    for (int i = 0; i < LUA_SIZECLASSES; i++)
+    {
+        LUAU_ASSERT(g->freepages[i] == NULL);
+        LUAU_ASSERT(g->freegcopages[i] == NULL);
+    }
+    LUAU_ASSERT(g->allgcopages == NULL);
+    LUAU_ASSERT(g->totalbytes == sizeof(LG));
+    LUAU_ASSERT(g->memcatbytes[0] == sizeof(LG));
+    for (int i = 1; i < LUA_MEMORY_CATEGORIES; i++)
+        LUAU_ASSERT(g->memcatbytes[i] == 0);
+
+    if (L->global->ecb.close)
+        L->global->ecb.close(L);
+
+    (*g->frealloc)(g->ud, L, sizeof(LG), 0);
+}
+
+lua_State* luaE_newthread(lua_State* L)
+{
+    lua_State* L1 = luaM_newgco(L, lua_State, sizeof(lua_State), L->activememcat);
+    luaC_init(L, L1, LUA_TTHREAD);
+    preinit_state(L1, L->global);
+    L1->activememcat = L->activememcat; // inherit the active memory category
+    stack_init(L1, L);                  // init stack
+    L1->gt = L->gt;                     // share table of globals
+    L1->singlestep = L->singlestep;
+    LUAU_ASSERT(iswhite(obj2gco(L1)));
+    return L1;
+}
+
+void luaE_freethread(lua_State* L, lua_State* L1, lua_Page* page)
+{
+    global_State* g = L->global;
+    if (g->cb.userthread)
+        g->cb.userthread(NULL, L1);
+    freestack(L, L1);
+    luaM_freegco(L, L1, sizeof(lua_State), L1->memcat, page);
+}
+
+void lua_resetthread(lua_State* L)
+{
+    // close upvalues before clearing anything
+    luaF_close(L, L->stack);
+    // clear call frames
+    CallInfo* ci = L->base_ci;
+    ci->func = L->stack;
+    ci->base = ci->func + 1;
+    ci->top = ci->base + LUA_MINSTACK;
+    setnilvalue(ci->func);
+    L->ci = ci;
+    if (L->size_ci != BASIC_CI_SIZE)
+        luaD_reallocCI(L, BASIC_CI_SIZE);
+    // clear thread state
+    L->status = LUA_OK;
+    L->base = L->ci->base;
+    L->top = L->ci->base;
+    L->nCcalls = L->baseCcalls = 0;
+    // clear thread stack
+    if (L->stacksize != BASIC_STACK_SIZE + EXTRA_STACK)
+        luaD_reallocstack(L, BASIC_STACK_SIZE);
+    for (int i = 0; i < L->stacksize; i++)
+        setnilvalue(L->stack + i);
+}
+
+int lua_isthreadreset(lua_State* L)
+{
+    return L->ci == L->base_ci && L->base == L->top && L->status == LUA_OK;
+}
+
+lua_State* lua_newstate(lua_Alloc f, void* ud)
+{
+    int i;
+    lua_State* L;
+    global_State* g;
+    void* l = (*f)(ud, NULL, 0, sizeof(LG));
+    if (l == NULL)
+        return NULL;
+    L = (lua_State*)l;
+    g = &((LG*)L)->g;
+    L->tt = LUA_TTHREAD;
+    L->marked = g->currentwhite = bit2mask(WHITE0BIT, FIXEDBIT);
+    L->memcat = 0;
+    preinit_state(L, g);
+    g->frealloc = f;
+    g->ud = ud;
+    g->mainthread = L;
+    g->uvhead.u.open.prev = &g->uvhead;
+    g->uvhead.u.open.next = &g->uvhead;
+    g->GCthreshold = 0; // mark it as unfinished state
+    g->registryfree = 0;
+    g->errorjmp = NULL;
+    g->rngstate = 0;
+    g->ptrenckey[0] = 1;
+    g->ptrenckey[1] = 0;
+    g->ptrenckey[2] = 0;
+    g->ptrenckey[3] = 0;
+    g->strt.size = 0;
+    g->strt.nuse = 0;
+    g->strt.hash = NULL;
+    setnilvalue(&g->pseudotemp);
+    setnilvalue(registry(L));
+    g->gcstate = GCSpause;
+    g->gray = NULL;
+    g->grayagain = NULL;
+    g->weak = NULL;
+    g->totalbytes = sizeof(LG);
+    g->gcgoal = LUAI_GCGOAL;
+    g->gcstepmul = LUAI_GCSTEPMUL;
+    g->gcstepsize = LUAI_GCSTEPSIZE << 10;
+    for (i = 0; i < LUA_SIZECLASSES; i++)
+    {
+        g->freepages[i] = NULL;
+        g->freegcopages[i] = NULL;
+    }
+    g->allgcopages = NULL;
+    g->sweepgcopage = NULL;
+    for (i = 0; i < LUA_T_COUNT; i++)
+        g->mt[i] = NULL;
+    for (i = 0; i < LUA_UTAG_LIMIT; i++)
+        g->udatagc[i] = NULL;
+    for (i = 0; i < LUA_LUTAG_LIMIT; i++)
+        g->lightuserdataname[i] = NULL;
+    for (i = 0; i < LUA_MEMORY_CATEGORIES; i++)
+        g->memcatbytes[i] = 0;
+
+    g->memcatbytes[0] = sizeof(LG);
+
+    g->cb = lua_Callbacks();
+
+    g->ecb = lua_ExecutionCallbacks();
+
+    g->gcstats = GCStats();
+
+#ifdef LUAI_GCMETRICS
+    g->gcmetrics = GCMetrics();
+#endif
+
+    if (luaD_rawrunprotected(L, f_luaopen, NULL) != 0)
+    {
+        // memory allocation error: free partial state
+        close_state(L);
+        L = NULL;
+    }
+    return L;
+}
+
+void lua_close(lua_State* L)
+{
+    L = L->global->mainthread; // only the main thread can be closed
+    luaF_close(L, L->stack);   // close all upvalues for this thread
+    close_state(L);
+}

--- a/lib/luau/VM/src/lstate.h
+++ b/lib/luau/VM/src/lstate.h
@@ -1,0 +1,304 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+#include "ltm.h"
+
+// registry
+#define registry(L) (&L->global->registry)
+
+// extra stack space to handle TM calls and some other extras
+#define EXTRA_STACK 5
+
+#define BASIC_CI_SIZE 8
+
+#define BASIC_STACK_SIZE (2 * LUA_MINSTACK)
+
+// clang-format off
+typedef struct stringtable
+{
+
+    TString** hash;
+    uint32_t nuse; // number of elements
+    int size;
+} stringtable;
+// clang-format on
+
+/*
+** informations about a call
+**
+** the general Lua stack frame structure is as follows:
+** - each function gets a stack frame, with function "registers" being stack slots on the frame
+** - function arguments are associated with registers 0+
+** - function locals and temporaries follow after; usually locals are a consecutive block per scope, and temporaries are allocated after this, but
+*this is up to the compiler
+**
+** when function doesn't have varargs, the stack layout is as follows:
+** ^ (func) ^^ [fixed args] [locals + temporaries]
+** where ^ is the 'func' pointer in CallInfo struct, and ^^ is the 'base' pointer (which is what registers are relative to)
+**
+** when function *does* have varargs, the stack layout is more complex - the runtime has to copy the fixed arguments so that the 0+ addressing still
+*works as follows:
+** ^ (func) [fixed args] [varargs] ^^ [fixed args] [locals + temporaries]
+**
+** computing the sizes of these individual blocks works as follows:
+** - the number of fixed args is always matching the `numparams` in a function's Proto object; runtime adds `nil` during the call execution as
+*necessary
+** - the number of variadic args can be computed by evaluating (ci->base - ci->func - 1 - numparams)
+**
+** the CallInfo structures are allocated as an array, with each subsequent call being *appended* to this array (so if f calls g, CallInfo for g
+*immediately follows CallInfo for f)
+** the `nresults` field in CallInfo is set by the caller to tell the function how many arguments the caller is expecting on the stack after the
+*function returns
+** the `flags` field in CallInfo contains internal execution flags that are important for pcall/etc, see LUA_CALLINFO_*
+*/
+// clang-format off
+typedef struct CallInfo
+{
+
+    StkId base;    // base for this function
+    StkId func;    // function index in the stack
+    StkId top;     // top for this function
+    const Instruction* savedpc;
+
+    int nresults;       // expected number of results from this function
+    unsigned int flags; // call frame flags, see LUA_CALLINFO_*
+} CallInfo;
+// clang-format on
+
+#define LUA_CALLINFO_RETURN (1 << 0) // should the interpreter return after returning from this callinfo? first frame must have this set
+#define LUA_CALLINFO_HANDLE (1 << 1) // should the error thrown during execution get handled by continuation from this callinfo? func must be C
+#define LUA_CALLINFO_NATIVE (1 << 2) // should this function be executed using execution callback for native code
+
+#define curr_func(L) (clvalue(L->ci->func))
+#define ci_func(ci) (clvalue((ci)->func))
+#define f_isLua(ci) (!ci_func(ci)->isC)
+#define isLua(ci) (ttisfunction((ci)->func) && f_isLua(ci))
+
+struct GCStats
+{
+    // data for proportional-integral controller of heap trigger value
+    int32_t triggerterms[32] = {0};
+    uint32_t triggertermpos = 0;
+    int32_t triggerintegral = 0;
+
+    size_t atomicstarttotalsizebytes = 0;
+    size_t endtotalsizebytes = 0;
+    size_t heapgoalsizebytes = 0;
+
+    double starttimestamp = 0;
+    double atomicstarttimestamp = 0;
+    double endtimestamp = 0;
+};
+
+#ifdef LUAI_GCMETRICS
+struct GCCycleMetrics
+{
+    size_t starttotalsizebytes = 0;
+    size_t heaptriggersizebytes = 0;
+
+    double pausetime = 0.0; // time from end of the last cycle to the start of a new one
+
+    double starttimestamp = 0.0;
+    double endtimestamp = 0.0;
+
+    double marktime = 0.0;
+    double markassisttime = 0.0;
+    double markmaxexplicittime = 0.0;
+    size_t markexplicitsteps = 0;
+    size_t markwork = 0;
+
+    double atomicstarttimestamp = 0.0;
+    size_t atomicstarttotalsizebytes = 0;
+    double atomictime = 0.0;
+
+    // specific atomic stage parts
+    double atomictimeupval = 0.0;
+    double atomictimeweak = 0.0;
+    double atomictimegray = 0.0;
+    double atomictimeclear = 0.0;
+
+    double sweeptime = 0.0;
+    double sweepassisttime = 0.0;
+    double sweepmaxexplicittime = 0.0;
+    size_t sweepexplicitsteps = 0;
+    size_t sweepwork = 0;
+
+    size_t assistwork = 0;
+    size_t explicitwork = 0;
+
+    size_t propagatework = 0;
+    size_t propagateagainwork = 0;
+
+    size_t endtotalsizebytes = 0;
+};
+
+struct GCMetrics
+{
+    double stepexplicittimeacc = 0.0;
+    double stepassisttimeacc = 0.0;
+
+    // when cycle is completed, last cycle values are updated
+    uint64_t completedcycles = 0;
+
+    GCCycleMetrics lastcycle;
+    GCCycleMetrics currcycle;
+};
+#endif
+
+// Callbacks that can be used to to redirect code execution from Luau bytecode VM to a custom implementation (AoT/JiT/sandboxing/...)
+struct lua_ExecutionCallbacks
+{
+    void* context;
+    void (*close)(lua_State* L);                 // called when global VM state is closed
+    void (*destroy)(lua_State* L, Proto* proto); // called when function is destroyed
+    int (*enter)(lua_State* L, Proto* proto);    // called when function is about to start/resume (when execdata is present), return 0 to exit VM
+};
+
+/*
+** `global state', shared by all threads of this state
+*/
+// clang-format off
+typedef struct global_State
+{
+    stringtable strt; // hash table for strings
+
+
+    lua_Alloc frealloc;   // function to reallocate memory
+    void* ud;            // auxiliary data to `frealloc'
+
+
+    uint8_t currentwhite;
+    uint8_t gcstate; // state of garbage collector
+
+
+    GCObject* gray;      // list of gray objects
+    GCObject* grayagain; // list of objects to be traversed atomically
+    GCObject* weak;     // list of weak tables (to be cleared)
+
+
+    size_t GCthreshold;                       // when totalbytes > GCthreshold, run GC step
+    size_t totalbytes;                        // number of bytes currently allocated
+    int gcgoal;                               // see LUAI_GCGOAL
+    int gcstepmul;                            // see LUAI_GCSTEPMUL
+    int gcstepsize;                          // see LUAI_GCSTEPSIZE
+
+    struct lua_Page* freepages[LUA_SIZECLASSES]; // free page linked list for each size class for non-collectable objects
+    struct lua_Page* freegcopages[LUA_SIZECLASSES]; // free page linked list for each size class for collectable objects
+    struct lua_Page* allgcopages; // page linked list with all pages for all classes
+    struct lua_Page* sweepgcopage; // position of the sweep in `allgcopages'
+
+    size_t memcatbytes[LUA_MEMORY_CATEGORIES]; // total amount of memory used by each memory category
+
+
+    struct lua_State* mainthread;
+    UpVal uvhead;                                    // head of double-linked list of all open upvalues
+    struct Table* mt[LUA_T_COUNT];                   // metatables for basic types
+    TString* ttname[LUA_T_COUNT];       // names for basic types
+    TString* tmname[TM_N];             // array with tag-method names
+
+    TValue pseudotemp; // storage for temporary values used in pseudo2addr
+
+    TValue registry; // registry table, used by lua_ref and LUA_REGISTRYINDEX
+    int registryfree; // next free slot in registry
+
+    struct lua_jmpbuf* errorjmp; // jump buffer data for longjmp-style error handling
+
+    uint64_t rngstate; // PCG random number generator state
+    uint64_t ptrenckey[4]; // pointer encoding key for display
+
+    lua_Callbacks cb;
+
+    lua_ExecutionCallbacks ecb;
+
+    void (*udatagc[LUA_UTAG_LIMIT])(lua_State*, void*); // for each userdata tag, a gc callback to be called immediately before freeing memory
+
+    TString* lightuserdataname[LUA_LUTAG_LIMIT]; // names for tagged lightuserdata
+
+    GCStats gcstats;
+
+#ifdef LUAI_GCMETRICS
+    GCMetrics gcmetrics;
+#endif
+} global_State;
+// clang-format on
+
+/*
+** `per thread' state
+*/
+// clang-format off
+struct lua_State
+{
+    CommonHeader;
+    uint8_t status;
+
+    uint8_t activememcat; // memory category that is used for new GC object allocations
+
+    bool isactive;   // thread is currently executing, stack may be mutated without barriers
+    bool singlestep; // call debugstep hook after each instruction
+
+
+    StkId top;                                        // first free slot in the stack
+    StkId base;                                       // base of current function
+    global_State* global;
+    CallInfo* ci;                                     // call info for current function
+    StkId stack_last;                                 // last free slot in the stack
+    StkId stack;                                     // stack base
+
+
+    CallInfo* end_ci;                          // points after end of ci array
+    CallInfo* base_ci;                        // array of CallInfo's
+
+
+    int stacksize;
+    int size_ci;                              // size of array `base_ci'
+
+
+    unsigned short nCcalls;     // number of nested C calls
+    unsigned short baseCcalls; // nested C calls when resuming coroutine
+
+    int cachedslot;    // when table operations or INDEX/NEWINDEX is invoked from Luau, what is the expected slot for lookup?
+
+
+    Table* gt;           // table of globals
+    UpVal* openupval;    // list of open upvalues in this stack
+    GCObject* gclist;
+
+    TString* namecall; // when invoked from Luau using NAMECALL, what method do we need to invoke?
+
+    void* userdata;
+};
+// clang-format on
+
+/*
+** Union of all collectible objects
+*/
+union GCObject
+{
+    GCheader gch;
+    struct TString ts;
+    struct Udata u;
+    struct Closure cl;
+    struct Table h;
+    struct Proto p;
+    struct UpVal uv;
+    struct lua_State th; // thread
+    struct Buffer buf;
+};
+
+// macros to convert a GCObject into a specific value
+#define gco2ts(o) check_exp((o)->gch.tt == LUA_TSTRING, &((o)->ts))
+#define gco2u(o) check_exp((o)->gch.tt == LUA_TUSERDATA, &((o)->u))
+#define gco2cl(o) check_exp((o)->gch.tt == LUA_TFUNCTION, &((o)->cl))
+#define gco2h(o) check_exp((o)->gch.tt == LUA_TTABLE, &((o)->h))
+#define gco2p(o) check_exp((o)->gch.tt == LUA_TPROTO, &((o)->p))
+#define gco2uv(o) check_exp((o)->gch.tt == LUA_TUPVAL, &((o)->uv))
+#define gco2th(o) check_exp((o)->gch.tt == LUA_TTHREAD, &((o)->th))
+#define gco2buf(o) check_exp((o)->gch.tt == LUA_TBUFFER, &((o)->buf))
+
+// macro to convert any Lua object into a GCObject
+#define obj2gco(v) check_exp(iscollectable(v), cast_to(GCObject*, (v) + 0))
+
+LUAI_FUNC lua_State* luaE_newthread(lua_State* L);
+LUAI_FUNC void luaE_freethread(lua_State* L, lua_State* L1, struct lua_Page* page);

--- a/lib/luau/VM/src/lstring.cpp
+++ b/lib/luau/VM/src/lstring.cpp
@@ -1,0 +1,193 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lstring.h"
+
+#include "lgc.h"
+#include "lmem.h"
+
+#include <string.h>
+
+unsigned int luaS_hash(const char* str, size_t len)
+{
+    // Note that this hashing algorithm is replicated in BytecodeBuilder.cpp, BytecodeBuilder::getStringHash
+    unsigned int a = 0, b = 0;
+    unsigned int h = unsigned(len);
+
+    // hash prefix in 12b chunks (using aligned reads) with ARX based hash (LuaJIT v2.1, lookup3)
+    // note that we stop at length<32 to maintain compatibility with Lua 5.1
+    while (len >= 32)
+    {
+#define rol(x, s) ((x >> s) | (x << (32 - s)))
+#define mix(u, v, w) a ^= h, a -= rol(h, u), b ^= a, b -= rol(a, v), h ^= b, h -= rol(b, w)
+
+        // should compile into fast unaligned reads
+        uint32_t block[3];
+        memcpy(block, str, 12);
+
+        a += block[0];
+        b += block[1];
+        h += block[2];
+        mix(14, 11, 25);
+        str += 12;
+        len -= 12;
+
+#undef mix
+#undef rol
+    }
+
+    // original Lua 5.1 hash for compatibility (exact match when len<32)
+    for (size_t i = len; i > 0; --i)
+        h ^= (h << 5) + (h >> 2) + (uint8_t)str[i - 1];
+
+    return h;
+}
+
+void luaS_resize(lua_State* L, int newsize)
+{
+    TString** newhash = luaM_newarray(L, newsize, TString*, 0);
+    stringtable* tb = &L->global->strt;
+    for (int i = 0; i < newsize; i++)
+        newhash[i] = NULL;
+    // rehash
+    for (int i = 0; i < tb->size; i++)
+    {
+        TString* p = tb->hash[i];
+        while (p)
+        {                            // for each node in the list
+            TString* next = p->next; // save next
+            unsigned int h = p->hash;
+            int h1 = lmod(h, newsize); // new position
+            LUAU_ASSERT(cast_int(h % newsize) == lmod(h, newsize));
+            p->next = newhash[h1]; // chain it
+            newhash[h1] = p;
+            p = next;
+        }
+    }
+    luaM_freearray(L, tb->hash, tb->size, TString*, 0);
+    tb->size = newsize;
+    tb->hash = newhash;
+}
+
+static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
+{
+    if (l > MAXSSIZE)
+        luaM_toobig(L);
+
+    TString* ts = luaM_newgco(L, TString, sizestring(l), L->activememcat);
+    luaC_init(L, ts, LUA_TSTRING);
+    ts->atom = ATOM_UNDEF;
+    ts->hash = h;
+    ts->len = unsigned(l);
+
+    memcpy(ts->data, str, l);
+    ts->data[l] = '\0'; // ending 0
+
+    stringtable* tb = &L->global->strt;
+    h = lmod(h, tb->size);
+    ts->next = tb->hash[h]; // chain new entry
+    tb->hash[h] = ts;
+
+    tb->nuse++;
+    if (tb->nuse > cast_to(uint32_t, tb->size) && tb->size <= INT_MAX / 2)
+        luaS_resize(L, tb->size * 2); // too crowded
+
+    return ts;
+}
+
+TString* luaS_bufstart(lua_State* L, size_t size)
+{
+    if (size > MAXSSIZE)
+        luaM_toobig(L);
+
+    TString* ts = luaM_newgco(L, TString, sizestring(size), L->activememcat);
+    luaC_init(L, ts, LUA_TSTRING);
+    ts->atom = ATOM_UNDEF;
+    ts->hash = 0; // computed in luaS_buffinish
+    ts->len = unsigned(size);
+
+    ts->next = NULL;
+
+    return ts;
+}
+
+TString* luaS_buffinish(lua_State* L, TString* ts)
+{
+    unsigned int h = luaS_hash(ts->data, ts->len);
+    stringtable* tb = &L->global->strt;
+    int bucket = lmod(h, tb->size);
+
+    // search if we already have this string in the hash table
+    for (TString* el = tb->hash[bucket]; el != NULL; el = el->next)
+    {
+        if (el->len == ts->len && memcmp(el->data, ts->data, ts->len) == 0)
+        {
+            // string may be dead
+            if (isdead(L->global, obj2gco(el)))
+                changewhite(obj2gco(el));
+
+            return el;
+        }
+    }
+
+    LUAU_ASSERT(ts->next == NULL);
+
+    ts->hash = h;
+    ts->data[ts->len] = '\0'; // ending 0
+    ts->atom = ATOM_UNDEF;
+    ts->next = tb->hash[bucket]; // chain new entry
+    tb->hash[bucket] = ts;
+
+    tb->nuse++;
+    if (tb->nuse > cast_to(uint32_t, tb->size) && tb->size <= INT_MAX / 2)
+        luaS_resize(L, tb->size * 2); // too crowded
+
+    return ts;
+}
+
+TString* luaS_newlstr(lua_State* L, const char* str, size_t l)
+{
+    unsigned int h = luaS_hash(str, l);
+    for (TString* el = L->global->strt.hash[lmod(h, L->global->strt.size)]; el != NULL; el = el->next)
+    {
+        if (el->len == l && (memcmp(str, getstr(el), l) == 0))
+        {
+            // string may be dead
+            if (isdead(L->global, obj2gco(el)))
+                changewhite(obj2gco(el));
+            return el;
+        }
+    }
+    return newlstr(L, str, l, h); // not found
+}
+
+static bool unlinkstr(lua_State* L, TString* ts)
+{
+    global_State* g = L->global;
+
+    TString** p = &g->strt.hash[lmod(ts->hash, g->strt.size)];
+
+    while (TString* curr = *p)
+    {
+        if (curr == ts)
+        {
+            *p = curr->next;
+            return true;
+        }
+        else
+        {
+            p = &curr->next;
+        }
+    }
+
+    return false;
+}
+
+void luaS_free(lua_State* L, TString* ts, lua_Page* page)
+{
+    if (unlinkstr(L, ts))
+        L->global->strt.nuse--;
+    else
+        LUAU_ASSERT(ts->next == NULL); // orphaned string buffer
+
+    luaM_freegco(L, ts, sizestring(ts->len), ts->memcat, page);
+}

--- a/lib/luau/VM/src/lstring.h
+++ b/lib/luau/VM/src/lstring.h
@@ -1,0 +1,29 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+#include "lstate.h"
+
+// string size limit
+#define MAXSSIZE (1 << 30)
+
+// string atoms are not defined by default; the storage is 16-bit integer
+#define ATOM_UNDEF -32768
+
+#define sizestring(len) (offsetof(TString, data) + len + 1)
+
+#define luaS_new(L, s) (luaS_newlstr(L, s, strlen(s)))
+#define luaS_newliteral(L, s) (luaS_newlstr(L, "" s, (sizeof(s) / sizeof(char)) - 1))
+
+#define luaS_fix(s) l_setbit((s)->marked, FIXEDBIT)
+
+LUAI_FUNC unsigned int luaS_hash(const char* str, size_t len);
+
+LUAI_FUNC void luaS_resize(lua_State* L, int newsize);
+
+LUAI_FUNC TString* luaS_newlstr(lua_State* L, const char* str, size_t l);
+LUAI_FUNC void luaS_free(lua_State* L, TString* ts, struct lua_Page* page);
+
+LUAI_FUNC TString* luaS_bufstart(lua_State* L, size_t size);
+LUAI_FUNC TString* luaS_buffinish(lua_State* L, TString* ts);

--- a/lib/luau/VM/src/lstrlib.cpp
+++ b/lib/luau/VM/src/lstrlib.cpp
@@ -1,0 +1,1665 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lstring.h"
+
+#include <ctype.h>
+#include <string.h>
+#include <stdio.h>
+
+// macro to `unsign' a character
+#define uchar(c) ((unsigned char)(c))
+
+static int str_len(lua_State* L)
+{
+    size_t l;
+    luaL_checklstring(L, 1, &l);
+    lua_pushinteger(L, (int)l);
+    return 1;
+}
+
+static int posrelat(int pos, size_t len)
+{
+    // relative string position: negative means back from end
+    if (pos < 0)
+        pos += (int)len + 1;
+    return (pos >= 0) ? pos : 0;
+}
+
+static int str_sub(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    int start = posrelat(luaL_checkinteger(L, 2), l);
+    int end = posrelat(luaL_optinteger(L, 3, -1), l);
+    if (start < 1)
+        start = 1;
+    if (end > (int)l)
+        end = (int)l;
+    if (start <= end)
+        lua_pushlstring(L, s + start - 1, end - start + 1);
+    else
+        lua_pushliteral(L, "");
+    return 1;
+}
+
+static int str_reverse(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    luaL_Strbuf b;
+    char* ptr = luaL_buffinitsize(L, &b, l);
+    while (l--)
+        *ptr++ = s[l];
+    luaL_pushresultsize(&b, ptr - b.p);
+    return 1;
+}
+
+static int str_lower(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    luaL_Strbuf b;
+    char* ptr = luaL_buffinitsize(L, &b, l);
+    for (size_t i = 0; i < l; i++)
+        *ptr++ = tolower(uchar(s[i]));
+    luaL_pushresultsize(&b, l);
+    return 1;
+}
+
+static int str_upper(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    luaL_Strbuf b;
+    char* ptr = luaL_buffinitsize(L, &b, l);
+    for (size_t i = 0; i < l; i++)
+        *ptr++ = toupper(uchar(s[i]));
+    luaL_pushresultsize(&b, l);
+    return 1;
+}
+
+static int str_rep(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    int n = luaL_checkinteger(L, 2);
+
+    if (n <= 0)
+    {
+        lua_pushliteral(L, "");
+        return 1;
+    }
+
+    if (l > MAXSSIZE / (size_t)n) // may overflow?
+        luaL_error(L, "resulting string too large");
+
+    luaL_Strbuf b;
+    char* ptr = luaL_buffinitsize(L, &b, l * n);
+
+    const char* start = ptr;
+
+    size_t left = l * n;
+    size_t step = l;
+
+    memcpy(ptr, s, l);
+    ptr += l;
+    left -= l;
+
+    // use the increasing 'pattern' inside our target buffer to fill the next part
+    while (step < left)
+    {
+        memcpy(ptr, start, step);
+        ptr += step;
+        left -= step;
+        step <<= 1;
+    }
+
+    // fill tail
+    memcpy(ptr, start, left);
+    ptr += left;
+
+    luaL_pushresultsize(&b, l * n);
+
+    return 1;
+}
+
+static int str_byte(lua_State* L)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, 1, &l);
+    int posi = posrelat(luaL_optinteger(L, 2, 1), l);
+    int pose = posrelat(luaL_optinteger(L, 3, posi), l);
+    int n, i;
+    if (posi <= 0)
+        posi = 1;
+    if ((size_t)pose > l)
+        pose = (int)l;
+    if (posi > pose)
+        return 0; // empty interval; return no values
+    n = (int)(pose - posi + 1);
+    if (posi + n <= pose) // overflow?
+        luaL_error(L, "string slice too long");
+    luaL_checkstack(L, n, "string slice too long");
+    for (i = 0; i < n; i++)
+        lua_pushinteger(L, uchar(s[posi + i - 1]));
+    return n;
+}
+
+static int str_char(lua_State* L)
+{
+    int n = lua_gettop(L); // number of arguments
+
+    luaL_Strbuf b;
+    char* ptr = luaL_buffinitsize(L, &b, n);
+
+    for (int i = 1; i <= n; i++)
+    {
+        int c = luaL_checkinteger(L, i);
+        luaL_argcheck(L, uchar(c) == c, i, "invalid value");
+
+        *ptr++ = uchar(c);
+    }
+    luaL_pushresultsize(&b, n);
+    return 1;
+}
+
+/*
+** {======================================================
+** PATTERN MATCHING
+** =======================================================
+*/
+
+#define CAP_UNFINISHED (-1)
+#define CAP_POSITION (-2)
+
+typedef struct MatchState
+{
+    int matchdepth;       // control for recursive depth (to avoid C stack overflow)
+    const char* src_init; // init of source string
+    const char* src_end;  // end ('\0') of source string
+    const char* p_end;    // end ('\0') of pattern
+    lua_State* L;
+    int level; // total number of captures (finished or unfinished)
+    struct
+    {
+        const char* init;
+        ptrdiff_t len;
+    } capture[LUA_MAXCAPTURES];
+} MatchState;
+
+// recursive function
+static const char* match(MatchState* ms, const char* s, const char* p);
+
+#define L_ESC '%'
+#define SPECIALS "^$*+?.([%-"
+
+static int check_capture(MatchState* ms, int l)
+{
+    l -= '1';
+    if (l < 0 || l >= ms->level || ms->capture[l].len == CAP_UNFINISHED)
+        luaL_error(ms->L, "invalid capture index %%%d", l + 1);
+    return l;
+}
+
+static int capture_to_close(MatchState* ms)
+{
+    int level = ms->level;
+    for (level--; level >= 0; level--)
+        if (ms->capture[level].len == CAP_UNFINISHED)
+            return level;
+    luaL_error(ms->L, "invalid pattern capture");
+}
+
+static const char* classend(MatchState* ms, const char* p)
+{
+    switch (*p++)
+    {
+    case L_ESC:
+    {
+        if (p == ms->p_end)
+            luaL_error(ms->L, "malformed pattern (ends with '%%')");
+        return p + 1;
+    }
+    case '[':
+    {
+        if (*p == '^')
+            p++;
+        do
+        { // look for a `]'
+            if (p == ms->p_end)
+                luaL_error(ms->L, "malformed pattern (missing ']')");
+            if (*(p++) == L_ESC && p < ms->p_end)
+                p++; // skip escapes (e.g. `%]')
+        } while (*p != ']');
+        return p + 1;
+    }
+    default:
+    {
+        return p;
+    }
+    }
+}
+
+static int match_class(int c, int cl)
+{
+    int res;
+    switch (tolower(cl))
+    {
+    case 'a':
+        res = isalpha(c);
+        break;
+    case 'c':
+        res = iscntrl(c);
+        break;
+    case 'd':
+        res = isdigit(c);
+        break;
+    case 'g':
+        res = isgraph(c);
+        break;
+    case 'l':
+        res = islower(c);
+        break;
+    case 'p':
+        res = ispunct(c);
+        break;
+    case 's':
+        res = isspace(c);
+        break;
+    case 'u':
+        res = isupper(c);
+        break;
+    case 'w':
+        res = isalnum(c);
+        break;
+    case 'x':
+        res = isxdigit(c);
+        break;
+    case 'z':
+        res = (c == 0);
+        break; // deprecated option
+    default:
+        return (cl == c);
+    }
+    return (islower(cl) ? res : !res);
+}
+
+static int matchbracketclass(int c, const char* p, const char* ec)
+{
+    int sig = 1;
+    if (*(p + 1) == '^')
+    {
+        sig = 0;
+        p++; // skip the `^'
+    }
+    while (++p < ec)
+    {
+        if (*p == L_ESC)
+        {
+            p++;
+            if (match_class(c, uchar(*p)))
+                return sig;
+        }
+        else if ((*(p + 1) == '-') && (p + 2 < ec))
+        {
+            p += 2;
+            if (uchar(*(p - 2)) <= c && c <= uchar(*p))
+                return sig;
+        }
+        else if (uchar(*p) == c)
+            return sig;
+    }
+    return !sig;
+}
+
+static int singlematch(MatchState* ms, const char* s, const char* p, const char* ep)
+{
+    if (s >= ms->src_end)
+        return 0;
+    else
+    {
+        int c = uchar(*s);
+        switch (*p)
+        {
+        case '.':
+            return 1; // matches any char
+        case L_ESC:
+            return match_class(c, uchar(*(p + 1)));
+        case '[':
+            return matchbracketclass(c, p, ep - 1);
+        default:
+            return (uchar(*p) == c);
+        }
+    }
+}
+
+static const char* matchbalance(MatchState* ms, const char* s, const char* p)
+{
+    if (p >= ms->p_end - 1)
+        luaL_error(ms->L, "malformed pattern (missing arguments to '%%b')");
+    if (*s != *p)
+        return NULL;
+    else
+    {
+        int b = *p;
+        int e = *(p + 1);
+        int cont = 1;
+        while (++s < ms->src_end)
+        {
+            if (*s == e)
+            {
+                if (--cont == 0)
+                    return s + 1;
+            }
+            else if (*s == b)
+                cont++;
+        }
+    }
+    return NULL; // string ends out of balance
+}
+
+static const char* max_expand(MatchState* ms, const char* s, const char* p, const char* ep)
+{
+    ptrdiff_t i = 0; // counts maximum expand for item
+    while (singlematch(ms, s + i, p, ep))
+        i++;
+    // keeps trying to match with the maximum repetitions
+    while (i >= 0)
+    {
+        const char* res = match(ms, (s + i), ep + 1);
+        if (res)
+            return res;
+        i--; // else didn't match; reduce 1 repetition to try again
+    }
+    return NULL;
+}
+
+static const char* min_expand(MatchState* ms, const char* s, const char* p, const char* ep)
+{
+    for (;;)
+    {
+        const char* res = match(ms, s, ep + 1);
+        if (res != NULL)
+            return res;
+        else if (singlematch(ms, s, p, ep))
+            s++; // try with one more repetition
+        else
+            return NULL;
+    }
+}
+
+static const char* start_capture(MatchState* ms, const char* s, const char* p, int what)
+{
+    const char* res;
+    int level = ms->level;
+    if (level >= LUA_MAXCAPTURES)
+        luaL_error(ms->L, "too many captures");
+    ms->capture[level].init = s;
+    ms->capture[level].len = what;
+    ms->level = level + 1;
+    if ((res = match(ms, s, p)) == NULL) // match failed?
+        ms->level--;                     // undo capture
+    return res;
+}
+
+static const char* end_capture(MatchState* ms, const char* s, const char* p)
+{
+    int l = capture_to_close(ms);
+    const char* res;
+    ms->capture[l].len = s - ms->capture[l].init; // close capture
+    if ((res = match(ms, s, p)) == NULL)          // match failed?
+        ms->capture[l].len = CAP_UNFINISHED;      // undo capture
+    return res;
+}
+
+static const char* match_capture(MatchState* ms, const char* s, int l)
+{
+    size_t len;
+    l = check_capture(ms, l);
+    len = ms->capture[l].len;
+    if ((size_t)(ms->src_end - s) >= len && memcmp(ms->capture[l].init, s, len) == 0)
+        return s + len;
+    else
+        return NULL;
+}
+
+static const char* match(MatchState* ms, const char* s, const char* p)
+{
+    if (ms->matchdepth-- == 0)
+        luaL_error(ms->L, "pattern too complex");
+init: // using goto's to optimize tail recursion
+    if (p != ms->p_end)
+    { // end of pattern?
+        switch (*p)
+        {
+        case '(':
+        {                        // start capture
+            if (*(p + 1) == ')') // position capture?
+                s = start_capture(ms, s, p + 2, CAP_POSITION);
+            else
+                s = start_capture(ms, s, p + 1, CAP_UNFINISHED);
+            break;
+        }
+        case ')':
+        { // end capture
+            s = end_capture(ms, s, p + 1);
+            break;
+        }
+        case '$':
+        {
+            if ((p + 1) != ms->p_end)          // is the `$' the last char in pattern?
+                goto dflt;                     // no; go to default
+            s = (s == ms->src_end) ? s : NULL; // check end of string
+            break;
+        }
+        case L_ESC:
+        { // escaped sequences not in the format class[*+?-]?
+            switch (*(p + 1))
+            {
+            case 'b':
+            { // balanced string?
+                s = matchbalance(ms, s, p + 2);
+                if (s != NULL)
+                {
+                    p += 4;
+                    goto init; // return match(ms, s, p + 4);
+                }              // else fail (s == NULL)
+                break;
+            }
+            case 'f':
+            { // frontier?
+                const char* ep;
+                char previous;
+                p += 2;
+                if (*p != '[')
+                    luaL_error(ms->L, "missing '[' after '%%f' in pattern");
+                ep = classend(ms, p); // points to what is next
+                previous = (s == ms->src_init) ? '\0' : *(s - 1);
+                if (!matchbracketclass(uchar(previous), p, ep - 1) && matchbracketclass(uchar(*s), p, ep - 1))
+                {
+                    p = ep;
+                    goto init; // return match(ms, s, ep);
+                }
+                s = NULL; // match failed
+                break;
+            }
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            { // capture results (%0-%9)?
+                s = match_capture(ms, s, uchar(*(p + 1)));
+                if (s != NULL)
+                {
+                    p += 2;
+                    goto init; // return match(ms, s, p + 2)
+                }
+                break;
+            }
+            default:
+                goto dflt;
+            }
+            break;
+        }
+        default:
+        dflt:
+        {                                     // pattern class plus optional suffix
+            const char* ep = classend(ms, p); // points to optional suffix
+            // does not match at least once?
+            if (!singlematch(ms, s, p, ep))
+            {
+                if (*ep == '*' || *ep == '?' || *ep == '-')
+                { // accept empty?
+                    p = ep + 1;
+                    goto init; // return match(ms, s, ep + 1);
+                }
+                else          // '+' or no suffix
+                    s = NULL; // fail
+            }
+            else
+            { // matched once
+                switch (*ep)
+                { // handle optional suffix
+                case '?':
+                { // optional
+                    const char* res;
+                    if ((res = match(ms, s + 1, ep + 1)) != NULL)
+                        s = res;
+                    else
+                    {
+                        p = ep + 1;
+                        goto init; // else return match(ms, s, ep + 1);
+                    }
+                    break;
+                }
+                case '+': // 1 or more repetitions
+                    s++;  // 1 match already done
+                          // go through
+                case '*': // 0 or more repetitions
+                    s = max_expand(ms, s, p, ep);
+                    break;
+                case '-': // 0 or more repetitions (minimum)
+                    s = min_expand(ms, s, p, ep);
+                    break;
+                default: // no suffix
+                    s++;
+                    p = ep;
+                    goto init; // return match(ms, s + 1, ep);
+                }
+            }
+            break;
+        }
+        }
+    }
+    ms->matchdepth++;
+    return s;
+}
+
+static const char* lmemfind(const char* s1, size_t l1, const char* s2, size_t l2)
+{
+    if (l2 == 0)
+        return s1; // empty strings are everywhere
+    else if (l2 > l1)
+        return NULL; // avoids a negative `l1'
+    else
+    {
+        const char* init; // to search for a `*s2' inside `s1'
+        l2--;             // 1st char will be checked by `memchr'
+        l1 = l1 - l2;     // `s2' cannot be found after that
+        while (l1 > 0 && (init = (const char*)memchr(s1, *s2, l1)) != NULL)
+        {
+            init++; // 1st char is already checked
+            if (memcmp(init, s2 + 1, l2) == 0)
+                return init - 1;
+            else
+            { // correct `l1' and `s1' to try again
+                l1 -= init - s1;
+                s1 = init;
+            }
+        }
+        return NULL; // not found
+    }
+}
+
+static void push_onecapture(MatchState* ms, int i, const char* s, const char* e)
+{
+    if (i >= ms->level)
+    {
+        if (i == 0)                           // ms->level == 0, too
+            lua_pushlstring(ms->L, s, e - s); // add whole match
+        else
+            luaL_error(ms->L, "invalid capture index");
+    }
+    else
+    {
+        ptrdiff_t l = ms->capture[i].len;
+        if (l == CAP_UNFINISHED)
+            luaL_error(ms->L, "unfinished capture");
+        if (l == CAP_POSITION)
+            lua_pushinteger(ms->L, (int)(ms->capture[i].init - ms->src_init) + 1);
+        else
+            lua_pushlstring(ms->L, ms->capture[i].init, l);
+    }
+}
+
+static int push_captures(MatchState* ms, const char* s, const char* e)
+{
+    int i;
+    int nlevels = (ms->level == 0 && s) ? 1 : ms->level;
+    luaL_checkstack(ms->L, nlevels, "too many captures");
+    for (i = 0; i < nlevels; i++)
+        push_onecapture(ms, i, s, e);
+    return nlevels; // number of strings pushed
+}
+
+// check whether pattern has no special characters
+static int nospecials(const char* p, size_t l)
+{
+    size_t upto = 0;
+    do
+    {
+        if (strpbrk(p + upto, SPECIALS))
+            return 0;                 // pattern has a special character
+        upto += strlen(p + upto) + 1; // may have more after \0
+    } while (upto <= l);
+    return 1; // no special chars found
+}
+
+static void prepstate(MatchState* ms, lua_State* L, const char* s, size_t ls, const char* p, size_t lp)
+{
+    ms->L = L;
+    ms->matchdepth = LUAI_MAXCCALLS;
+    ms->src_init = s;
+    ms->src_end = s + ls;
+    ms->p_end = p + lp;
+}
+
+static void reprepstate(MatchState* ms)
+{
+    ms->level = 0;
+    LUAU_ASSERT(ms->matchdepth == LUAI_MAXCCALLS);
+}
+
+static int str_find_aux(lua_State* L, int find)
+{
+    size_t ls, lp;
+    const char* s = luaL_checklstring(L, 1, &ls);
+    const char* p = luaL_checklstring(L, 2, &lp);
+    int init = posrelat(luaL_optinteger(L, 3, 1), ls);
+    if (init < 1)
+        init = 1;
+    else if (init > (int)ls + 1)
+    {                   // start after string's end?
+        lua_pushnil(L); // cannot find anything
+        return 1;
+    }
+    // explicit request or no special characters?
+    if (find && (lua_toboolean(L, 4) || nospecials(p, lp)))
+    {
+        // do a plain search
+        const char* s2 = lmemfind(s + init - 1, ls - init + 1, p, lp);
+        if (s2)
+        {
+            lua_pushinteger(L, (int)(s2 - s + 1));
+            lua_pushinteger(L, (int)(s2 - s + lp));
+            return 2;
+        }
+    }
+    else
+    {
+        MatchState ms;
+        const char* s1 = s + init - 1;
+        int anchor = (*p == '^');
+        if (anchor)
+        {
+            p++;
+            lp--; // skip anchor character
+        }
+        prepstate(&ms, L, s, ls, p, lp);
+        do
+        {
+            const char* res;
+            reprepstate(&ms);
+            if ((res = match(&ms, s1, p)) != NULL)
+            {
+                if (find)
+                {
+                    lua_pushinteger(L, (int)(s1 - s + 1)); // start
+                    lua_pushinteger(L, (int)(res - s));    // end
+                    return push_captures(&ms, NULL, 0) + 2;
+                }
+                else
+                    return push_captures(&ms, s1, res);
+            }
+        } while (s1++ < ms.src_end && !anchor);
+    }
+    lua_pushnil(L); // not found
+    return 1;
+}
+
+static int str_find(lua_State* L)
+{
+    return str_find_aux(L, 1);
+}
+
+static int str_match(lua_State* L)
+{
+    return str_find_aux(L, 0);
+}
+
+static int gmatch_aux(lua_State* L)
+{
+    MatchState ms;
+    size_t ls, lp;
+    const char* s = lua_tolstring(L, lua_upvalueindex(1), &ls);
+    const char* p = lua_tolstring(L, lua_upvalueindex(2), &lp);
+    const char* src;
+    prepstate(&ms, L, s, ls, p, lp);
+    for (src = s + (size_t)lua_tointeger(L, lua_upvalueindex(3)); src <= ms.src_end; src++)
+    {
+        const char* e;
+        reprepstate(&ms);
+        if ((e = match(&ms, src, p)) != NULL)
+        {
+            int newstart = (int)(e - s);
+            if (e == src)
+                newstart++; // empty match? go at least one position
+            lua_pushinteger(L, newstart);
+            lua_replace(L, lua_upvalueindex(3));
+            return push_captures(&ms, src, e);
+        }
+    }
+    return 0; // not found
+}
+
+static int gmatch(lua_State* L)
+{
+    luaL_checkstring(L, 1);
+    luaL_checkstring(L, 2);
+    lua_settop(L, 2);
+    lua_pushinteger(L, 0);
+    lua_pushcclosure(L, gmatch_aux, NULL, 3);
+    return 1;
+}
+
+static void add_s(MatchState* ms, luaL_Strbuf* b, const char* s, const char* e)
+{
+    size_t l, i;
+    const char* news = lua_tolstring(ms->L, 3, &l);
+
+    luaL_prepbuffsize(b, l);
+
+    for (i = 0; i < l; i++)
+    {
+        if (news[i] != L_ESC)
+            luaL_addchar(b, news[i]);
+        else
+        {
+            i++; // skip ESC
+            if (!isdigit(uchar(news[i])))
+            {
+                if (news[i] != L_ESC)
+                    luaL_error(ms->L, "invalid use of '%c' in replacement string", L_ESC);
+                luaL_addchar(b, news[i]);
+            }
+            else if (news[i] == '0')
+                luaL_addlstring(b, s, e - s);
+            else
+            {
+                push_onecapture(ms, news[i] - '1', s, e);
+                luaL_addvalue(b); // add capture to accumulated result
+            }
+        }
+    }
+}
+
+static void add_value(MatchState* ms, luaL_Strbuf* b, const char* s, const char* e, int tr)
+{
+    lua_State* L = ms->L;
+    switch (tr)
+    {
+    case LUA_TFUNCTION:
+    {
+        int n;
+        lua_pushvalue(L, 3);
+        n = push_captures(ms, s, e);
+        lua_call(L, n, 1);
+        break;
+    }
+    case LUA_TTABLE:
+    {
+        push_onecapture(ms, 0, s, e);
+        lua_gettable(L, 3);
+        break;
+    }
+    default:
+    { // LUA_TNUMBER or LUA_TSTRING
+        add_s(ms, b, s, e);
+        return;
+    }
+    }
+    if (!lua_toboolean(L, -1))
+    { // nil or false?
+        lua_pop(L, 1);
+        lua_pushlstring(L, s, e - s); // keep original text
+    }
+    else if (!lua_isstring(L, -1))
+        luaL_error(L, "invalid replacement value (a %s)", luaL_typename(L, -1));
+    luaL_addvalue(b); // add result to accumulator
+}
+
+static int str_gsub(lua_State* L)
+{
+    size_t srcl, lp;
+    const char* src = luaL_checklstring(L, 1, &srcl);
+    const char* p = luaL_checklstring(L, 2, &lp);
+    int tr = lua_type(L, 3);
+    int max_s = luaL_optinteger(L, 4, (int)srcl + 1);
+    int anchor = (*p == '^');
+    int n = 0;
+    MatchState ms;
+    luaL_Strbuf b;
+    luaL_argexpected(L, tr == LUA_TNUMBER || tr == LUA_TSTRING || tr == LUA_TFUNCTION || tr == LUA_TTABLE, 3, "string/function/table");
+    luaL_buffinit(L, &b);
+    if (anchor)
+    {
+        p++;
+        lp--; // skip anchor character
+    }
+    prepstate(&ms, L, src, srcl, p, lp);
+    while (n < max_s)
+    {
+        const char* e;
+        reprepstate(&ms);
+        e = match(&ms, src, p);
+        if (e)
+        {
+            n++;
+            add_value(&ms, &b, src, e, tr);
+        }
+        if (e && e > src) // non empty match?
+            src = e;      // skip it
+        else if (src < ms.src_end)
+            luaL_addchar(&b, *src++);
+        else
+            break;
+        if (anchor)
+            break;
+    }
+    luaL_addlstring(&b, src, ms.src_end - src);
+    luaL_pushresult(&b);
+    lua_pushinteger(L, n); // number of substitutions
+    return 2;
+}
+
+// }======================================================
+
+// valid flags in a format specification
+#define FLAGS "-+ #0"
+// maximum size of each formatted item (> len(format('%99.99f', -1e308)))
+#define MAX_ITEM 512
+// maximum size of each format specification (such as '%-099.99d')
+#define MAX_FORMAT 32
+
+static void addquoted(lua_State* L, luaL_Strbuf* b, int arg)
+{
+    size_t l;
+    const char* s = luaL_checklstring(L, arg, &l);
+
+    luaL_prepbuffsize(b, l + 2);
+
+    luaL_addchar(b, '"');
+    while (l--)
+    {
+        switch (*s)
+        {
+        case '"':
+        case '\\':
+        case '\n':
+        {
+            luaL_addchar(b, '\\');
+            luaL_addchar(b, *s);
+            break;
+        }
+        case '\r':
+        {
+            luaL_addlstring(b, "\\r", 2);
+            break;
+        }
+        case '\0':
+        {
+            luaL_addlstring(b, "\\000", 4);
+            break;
+        }
+        default:
+        {
+            luaL_addchar(b, *s);
+            break;
+        }
+        }
+        s++;
+    }
+    luaL_addchar(b, '"');
+}
+
+static const char* scanformat(lua_State* L, const char* strfrmt, char* form, size_t* size)
+{
+    const char* p = strfrmt;
+    while (*p != '\0' && strchr(FLAGS, *p) != NULL)
+        p++; // skip flags
+    if ((size_t)(p - strfrmt) >= sizeof(FLAGS))
+        luaL_error(L, "invalid format (repeated flags)");
+    if (isdigit(uchar(*p)))
+        p++; // skip width
+    if (isdigit(uchar(*p)))
+        p++; // (2 digits at most)
+    if (*p == '.')
+    {
+        p++;
+        if (isdigit(uchar(*p)))
+            p++; // skip precision
+        if (isdigit(uchar(*p)))
+            p++; // (2 digits at most)
+    }
+    if (isdigit(uchar(*p)))
+        luaL_error(L, "invalid format (width or precision too long)");
+    *(form++) = '%';
+    *size = p - strfrmt + 1;
+    strncpy(form, strfrmt, *size);
+    form += *size;
+    *form = '\0';
+    return p;
+}
+
+static void addInt64Format(char form[MAX_FORMAT], char formatIndicator, size_t formatItemSize)
+{
+    LUAU_ASSERT((formatItemSize + 3) <= MAX_FORMAT);
+    LUAU_ASSERT(form[0] == '%');
+    LUAU_ASSERT(form[formatItemSize] != 0);
+    LUAU_ASSERT(form[formatItemSize + 1] == 0);
+    form[formatItemSize + 0] = 'l';
+    form[formatItemSize + 1] = 'l';
+    form[formatItemSize + 2] = formatIndicator;
+    form[formatItemSize + 3] = 0;
+}
+
+static int str_format(lua_State* L)
+{
+    int top = lua_gettop(L);
+    int arg = 1;
+    size_t sfl;
+    const char* strfrmt = luaL_checklstring(L, arg, &sfl);
+    const char* strfrmt_end = strfrmt + sfl;
+    luaL_Strbuf b;
+    luaL_buffinit(L, &b);
+    while (strfrmt < strfrmt_end)
+    {
+        if (*strfrmt != L_ESC)
+            luaL_addchar(&b, *strfrmt++);
+        else if (*++strfrmt == L_ESC)
+            luaL_addchar(&b, *strfrmt++); // %%
+        else if (*strfrmt == '*')
+        {
+            strfrmt++;
+            if (++arg > top)
+                luaL_error(L, "missing argument #%d", arg);
+
+            luaL_addvalueany(&b, arg);
+        }
+        else
+        {                          // format item
+            char form[MAX_FORMAT]; // to store the format (`%...')
+            char buff[MAX_ITEM];   // to store the formatted item
+            if (++arg > top)
+                luaL_error(L, "missing argument #%d", arg);
+            size_t formatItemSize = 0;
+            strfrmt = scanformat(L, strfrmt, form, &formatItemSize);
+            char formatIndicator = *strfrmt++;
+            switch (formatIndicator)
+            {
+            case 'c':
+            {
+                snprintf(buff, sizeof(buff), form, (int)luaL_checknumber(L, arg));
+                break;
+            }
+            case 'd':
+            case 'i':
+            {
+                addInt64Format(form, formatIndicator, formatItemSize);
+                snprintf(buff, sizeof(buff), form, (long long)luaL_checknumber(L, arg));
+                break;
+            }
+            case 'o':
+            case 'u':
+            case 'x':
+            case 'X':
+            {
+                double argValue = luaL_checknumber(L, arg);
+                addInt64Format(form, formatIndicator, formatItemSize);
+                unsigned long long v = (argValue < 0) ? (unsigned long long)(long long)argValue : (unsigned long long)argValue;
+                snprintf(buff, sizeof(buff), form, v);
+                break;
+            }
+            case 'e':
+            case 'E':
+            case 'f':
+            case 'g':
+            case 'G':
+            {
+                snprintf(buff, sizeof(buff), form, (double)luaL_checknumber(L, arg));
+                break;
+            }
+            case 'q':
+            {
+                addquoted(L, &b, arg);
+                continue; // skip the 'luaL_addlstring' at the end
+            }
+            case 's':
+            {
+                size_t l;
+                const char* s = luaL_checklstring(L, arg, &l);
+                // no precision and string is too long to be formatted, or no format necessary to begin with
+                if (form[2] == '\0' || (!strchr(form, '.') && l >= 100))
+                {
+                    luaL_addlstring(&b, s, l);
+                    continue; // skip the `luaL_addlstring' at the end
+                }
+                else
+                {
+                    snprintf(buff, sizeof(buff), form, s);
+                    break;
+                }
+            }
+            case '*':
+            {
+                // %* is parsed above, so if we got here we must have %...*
+                luaL_error(L, "'%%*' does not take a form");
+            }
+            default:
+            { // also treat cases `pnLlh'
+                luaL_error(L, "invalid option '%%%c' to 'format'", *(strfrmt - 1));
+            }
+            }
+            luaL_addlstring(&b, buff, strlen(buff));
+        }
+    }
+    luaL_pushresult(&b);
+    return 1;
+}
+
+static int str_split(lua_State* L)
+{
+    size_t haystackLen;
+    const char* haystack = luaL_checklstring(L, 1, &haystackLen);
+    size_t needleLen;
+    const char* needle = luaL_optlstring(L, 2, ",", &needleLen);
+
+    const char* begin = haystack;
+    const char* end = haystack + haystackLen;
+    const char* spanStart = begin;
+    int numMatches = 0;
+
+    lua_createtable(L, 0, 0);
+
+    if (needleLen == 0)
+        begin++;
+
+    // Don't iterate the last needleLen - 1 bytes of the string - they are
+    // impossible to be splits and would let us memcmp past the end of the
+    // buffer.
+    for (const char* iter = begin; iter <= end - needleLen; iter++)
+    {
+        // Use of memcmp here instead of strncmp is so that we allow embedded
+        // nulls to be used in either of the haystack or the needle strings.
+        // Most Lua string APIs allow embedded nulls, and this should be no
+        // exception.
+        if (memcmp(iter, needle, needleLen) == 0)
+        {
+            lua_pushinteger(L, ++numMatches);
+            lua_pushlstring(L, spanStart, iter - spanStart);
+            lua_settable(L, -3);
+
+            spanStart = iter + needleLen;
+            if (needleLen > 0)
+                iter += needleLen - 1;
+        }
+    }
+
+    if (needleLen > 0)
+    {
+        lua_pushinteger(L, ++numMatches);
+        lua_pushlstring(L, spanStart, end - spanStart);
+        lua_settable(L, -3);
+    }
+
+    return 1;
+}
+
+/*
+** {======================================================
+** PACK/UNPACK
+** =======================================================
+*/
+
+// value used for padding
+#if !defined(LUAL_PACKPADBYTE)
+#define LUAL_PACKPADBYTE 0x00
+#endif
+
+// maximum size for the binary representation of an integer
+#define MAXINTSIZE 16
+
+// number of bits in a character
+#define NB CHAR_BIT
+
+// mask for one character (NB 1's)
+#define MC ((1 << NB) - 1)
+
+// internal size of integers used for pack/unpack
+#define SZINT (int)sizeof(long long)
+
+// dummy union to get native endianness
+static const union
+{
+    int dummy;
+    char little; // true iff machine is little endian
+} nativeendian = {1};
+
+// assume we need to align for double & pointers
+#define MAXALIGN 8
+
+/*
+** Union for serializing floats
+*/
+typedef union Ftypes
+{
+    float f;
+    double d;
+    double n;
+    char buff[5 * sizeof(double)]; // enough for any float type
+} Ftypes;
+
+/*
+** information to pack/unpack stuff
+*/
+typedef struct Header
+{
+    lua_State* L;
+    int islittle;
+    int maxalign;
+} Header;
+
+/*
+** options for pack/unpack
+*/
+typedef enum KOption
+{
+    Kint,       // signed integers
+    Kuint,      // unsigned integers
+    Kfloat,     // floating-point numbers
+    Kchar,      // fixed-length strings
+    Kstring,    // strings with prefixed length
+    Kzstr,      // zero-terminated strings
+    Kpadding,   // padding
+    Kpaddalign, // padding for alignment
+    Knop        // no-op (configuration or spaces)
+} KOption;
+
+/*
+** Read an integer numeral from string 'fmt' or return 'df' if
+** there is no numeral
+*/
+static int digit(int c)
+{
+    return '0' <= c && c <= '9';
+}
+
+static int getnum(Header* h, const char** fmt, int df)
+{
+    if (!digit(**fmt)) // no number?
+        return df;     // return default value
+    else
+    {
+        int a = 0;
+        do
+        {
+            a = a * 10 + (*((*fmt)++) - '0');
+        } while (digit(**fmt) && a <= (INT_MAX - 9) / 10);
+        if (a > MAXSSIZE || digit(**fmt))
+            luaL_error(h->L, "size specifier is too large");
+        return a;
+    }
+}
+
+/*
+** Read an integer numeral and raises an error if it is larger
+** than the maximum size for integers.
+*/
+static int getnumlimit(Header* h, const char** fmt, int df)
+{
+    int sz = getnum(h, fmt, df);
+    if (sz > MAXINTSIZE || sz <= 0)
+        luaL_error(h->L, "integral size (%d) out of limits [1,%d]", sz, MAXINTSIZE);
+    return sz;
+}
+
+/*
+** Initialize Header
+*/
+static void initheader(lua_State* L, Header* h)
+{
+    h->L = L;
+    h->islittle = nativeendian.little;
+    h->maxalign = 1;
+}
+
+/*
+** Read and classify next option. 'size' is filled with option's size.
+*/
+static KOption getoption(Header* h, const char** fmt, int* size)
+{
+    int opt = *((*fmt)++);
+    *size = 0; // default
+    switch (opt)
+    {
+    case 'b':
+        *size = 1;
+        return Kint;
+    case 'B':
+        *size = 1;
+        return Kuint;
+    case 'h':
+        *size = 2;
+        return Kint;
+    case 'H':
+        *size = 2;
+        return Kuint;
+    case 'l':
+        *size = 8;
+        return Kint;
+    case 'L':
+        *size = 8;
+        return Kuint;
+    case 'j':
+        *size = 4;
+        return Kint;
+    case 'J':
+        *size = 4;
+        return Kuint;
+    case 'T':
+        *size = 4;
+        return Kuint;
+    case 'f':
+        *size = 4;
+        return Kfloat;
+    case 'd':
+        *size = 8;
+        return Kfloat;
+    case 'n':
+        *size = 8;
+        return Kfloat;
+    case 'i':
+        *size = getnumlimit(h, fmt, 4);
+        return Kint;
+    case 'I':
+        *size = getnumlimit(h, fmt, 4);
+        return Kuint;
+    case 's':
+        *size = getnumlimit(h, fmt, 4);
+        return Kstring;
+    case 'c':
+        *size = getnum(h, fmt, -1);
+        if (*size == -1)
+            luaL_error(h->L, "missing size for format option 'c'");
+        return Kchar;
+    case 'z':
+        return Kzstr;
+    case 'x':
+        *size = 1;
+        return Kpadding;
+    case 'X':
+        return Kpaddalign;
+    case ' ':
+        break;
+    case '<':
+        h->islittle = 1;
+        break;
+    case '>':
+        h->islittle = 0;
+        break;
+    case '=':
+        h->islittle = nativeendian.little;
+        break;
+    case '!':
+        h->maxalign = getnumlimit(h, fmt, MAXALIGN);
+        break;
+    default:
+        luaL_error(h->L, "invalid format option '%c'", opt);
+    }
+    return Knop;
+}
+
+/*
+** Read, classify, and fill other details about the next option.
+** 'psize' is filled with option's size, 'notoalign' with its
+** alignment requirements.
+** Local variable 'size' gets the size to be aligned. (Kpadal option
+** always gets its full alignment, other options are limited by
+** the maximum alignment ('maxalign'). Kchar option needs no alignment
+** despite its size.
+*/
+static KOption getdetails(Header* h, size_t totalsize, const char** fmt, int* psize, int* ntoalign)
+{
+    KOption opt = getoption(h, fmt, psize);
+    int align = *psize; // usually, alignment follows size
+    if (opt == Kpaddalign)
+    { // 'X' gets alignment from following option
+        if (**fmt == '\0' || getoption(h, fmt, &align) == Kchar || align == 0)
+            luaL_argerror(h->L, 1, "invalid next option for option 'X'");
+    }
+    if (align <= 1 || opt == Kchar) // need no alignment?
+        *ntoalign = 0;
+    else
+    {
+        if (align > h->maxalign) // enforce maximum alignment
+            align = h->maxalign;
+        if ((align & (align - 1)) != 0) // is 'align' not a power of 2?
+            luaL_argerror(h->L, 1, "format asks for alignment not power of 2");
+        *ntoalign = (align - (int)(totalsize & (align - 1))) & (align - 1);
+    }
+    return opt;
+}
+
+/*
+** Pack integer 'n' with 'size' bytes and 'islittle' endianness.
+** The final 'if' handles the case when 'size' is larger than
+** the size of a Lua integer, correcting the extra sign-extension
+** bytes if necessary (by default they would be zeros).
+*/
+static void packint(luaL_Strbuf* b, unsigned long long n, int islittle, int size, int neg)
+{
+    LUAU_ASSERT(size <= MAXINTSIZE);
+    char buff[MAXINTSIZE];
+    int i;
+    buff[islittle ? 0 : size - 1] = (char)(n & MC); // first byte
+    for (i = 1; i < size; i++)
+    {
+        n >>= NB;
+        buff[islittle ? i : size - 1 - i] = (char)(n & MC);
+    }
+    if (neg && size > SZINT)
+    {                                  // negative number need sign extension?
+        for (i = SZINT; i < size; i++) // correct extra bytes
+            buff[islittle ? i : size - 1 - i] = (char)MC;
+    }
+    luaL_addlstring(b, buff, size); // add result to buffer
+}
+
+/*
+** Copy 'size' bytes from 'src' to 'dest', correcting endianness if
+** given 'islittle' is different from native endianness.
+*/
+static void copywithendian(volatile char* dest, volatile const char* src, int size, int islittle)
+{
+    if (islittle == nativeendian.little)
+    {
+        while (size-- != 0)
+            *(dest++) = *(src++);
+    }
+    else
+    {
+        dest += size - 1;
+        while (size-- != 0)
+            *(dest--) = *(src++);
+    }
+}
+
+static int str_pack(lua_State* L)
+{
+    luaL_Strbuf b;
+    Header h;
+    const char* fmt = luaL_checkstring(L, 1); // format string
+    int arg = 1;                              // current argument to pack
+    size_t totalsize = 0;                     // accumulate total size of result
+    initheader(L, &h);
+    lua_pushnil(L); // mark to separate arguments from string buffer
+    luaL_buffinit(L, &b);
+    while (*fmt != '\0')
+    {
+        int size, ntoalign;
+        KOption opt = getdetails(&h, totalsize, &fmt, &size, &ntoalign);
+        totalsize += ntoalign + size;
+        while (ntoalign-- > 0)
+            luaL_addchar(&b, LUAL_PACKPADBYTE); // fill alignment
+        arg++;
+        switch (opt)
+        {
+        case Kint:
+        { // signed integers
+            long long n = (long long)luaL_checknumber(L, arg);
+            if (size < SZINT)
+            { // need overflow check?
+                long long lim = (long long)1 << ((size * NB) - 1);
+                luaL_argcheck(L, -lim <= n && n < lim, arg, "integer overflow");
+            }
+            packint(&b, n, h.islittle, size, (n < 0));
+            break;
+        }
+        case Kuint:
+        { // unsigned integers
+            long long n = (long long)luaL_checknumber(L, arg);
+            if (size < SZINT) // need overflow check?
+                luaL_argcheck(L, (unsigned long long)n < ((unsigned long long)1 << (size * NB)), arg, "unsigned overflow");
+            packint(&b, (unsigned long long)n, h.islittle, size, 0);
+            break;
+        }
+        case Kfloat:
+        { // floating-point options
+            volatile Ftypes u;
+            char buff[MAXINTSIZE];
+            double n = luaL_checknumber(L, arg); // get argument
+            if (size == sizeof(u.f))
+                u.f = (float)n; // copy it into 'u'
+            else if (size == sizeof(u.d))
+                u.d = (double)n;
+            else
+                u.n = n;
+            // move 'u' to final result, correcting endianness if needed
+            copywithendian(buff, u.buff, size, h.islittle);
+            luaL_addlstring(&b, buff, size);
+            break;
+        }
+        case Kchar:
+        { // fixed-size string
+            size_t len;
+            const char* s = luaL_checklstring(L, arg, &len);
+            luaL_argcheck(L, len <= (size_t)size, arg, "string longer than given size");
+            luaL_addlstring(&b, s, len); // add string
+            while (len++ < (size_t)size) // pad extra space
+                luaL_addchar(&b, LUAL_PACKPADBYTE);
+            break;
+        }
+        case Kstring:
+        { // strings with length count
+            size_t len;
+            const char* s = luaL_checklstring(L, arg, &len);
+            luaL_argcheck(L, size >= (int)sizeof(size_t) || len < ((size_t)1 << (size * NB)), arg, "string length does not fit in given size");
+            packint(&b, len, h.islittle, size, 0); // pack length
+            luaL_addlstring(&b, s, len);
+            totalsize += len;
+            break;
+        }
+        case Kzstr:
+        { // zero-terminated string
+            size_t len;
+            const char* s = luaL_checklstring(L, arg, &len);
+            luaL_argcheck(L, strlen(s) == len, arg, "string contains zeros");
+            luaL_addlstring(&b, s, len);
+            luaL_addchar(&b, '\0'); // add zero at the end
+            totalsize += len + 1;
+            break;
+        }
+        case Kpadding:
+            luaL_addchar(&b, LUAL_PACKPADBYTE); // FALLTHROUGH
+        case Kpaddalign:
+        case Knop:
+            arg--; // undo increment
+            break;
+        }
+    }
+    luaL_pushresult(&b);
+    return 1;
+}
+
+static int str_packsize(lua_State* L)
+{
+    Header h;
+    const char* fmt = luaL_checkstring(L, 1); // format string
+    int totalsize = 0;                        // accumulate total size of result
+    initheader(L, &h);
+    while (*fmt != '\0')
+    {
+        int size, ntoalign;
+        KOption opt = getdetails(&h, totalsize, &fmt, &size, &ntoalign);
+        luaL_argcheck(L, opt != Kstring && opt != Kzstr, 1, "variable-length format");
+        size += ntoalign; // total space used by option
+        luaL_argcheck(L, totalsize <= MAXSSIZE - size, 1, "format result too large");
+        totalsize += size;
+    }
+    lua_pushinteger(L, totalsize);
+    return 1;
+}
+
+/*
+** Unpack an integer with 'size' bytes and 'islittle' endianness.
+** If size is smaller than the size of a Lua integer and integer
+** is signed, must do sign extension (propagating the sign to the
+** higher bits); if size is larger than the size of a Lua integer,
+** it must check the unread bytes to see whether they do not cause an
+** overflow.
+*/
+static long long unpackint(lua_State* L, const char* str, int islittle, int size, int issigned)
+{
+    unsigned long long res = 0;
+    int i;
+    int limit = (size <= SZINT) ? size : SZINT;
+    for (i = limit - 1; i >= 0; i--)
+    {
+        res <<= NB;
+        res |= (unsigned char)str[islittle ? i : size - 1 - i];
+    }
+    if (size < SZINT)
+    { // real size smaller than int?
+        if (issigned)
+        { // needs sign extension?
+            unsigned long long mask = (unsigned long long)1 << (size * NB - 1);
+            res = ((res ^ mask) - mask); // do sign extension
+        }
+    }
+    else if (size > SZINT)
+    { // must check unread bytes
+        int mask = (!issigned || (long long)res >= 0) ? 0 : MC;
+        for (i = limit; i < size; i++)
+        {
+            if ((unsigned char)str[islittle ? i : size - 1 - i] != mask)
+                luaL_error(L, "%d-byte integer does not fit into Lua Integer", size);
+        }
+    }
+    return (long long)res;
+}
+
+static int str_unpack(lua_State* L)
+{
+    Header h;
+    const char* fmt = luaL_checkstring(L, 1);
+    size_t ld;
+    const char* data = luaL_checklstring(L, 2, &ld);
+    int pos = posrelat(luaL_optinteger(L, 3, 1), ld) - 1;
+    if (pos < 0)
+        pos = 0;
+    int n = 0; // number of results
+    luaL_argcheck(L, size_t(pos) <= ld, 3, "initial position out of string");
+    initheader(L, &h);
+    while (*fmt != '\0')
+    {
+        int size, ntoalign;
+        KOption opt = getdetails(&h, pos, &fmt, &size, &ntoalign);
+        luaL_argcheck(L, (size_t)ntoalign + size <= ld - pos, 2, "data string too short");
+        pos += ntoalign; // skip alignment
+        // stack space for item + next position
+        luaL_checkstack(L, 2, "too many results");
+        n++;
+        switch (opt)
+        {
+        case Kint:
+        {
+            long long res = unpackint(L, data + pos, h.islittle, size, true);
+            lua_pushnumber(L, (double)res);
+            break;
+        }
+        case Kuint:
+        {
+            unsigned long long res = unpackint(L, data + pos, h.islittle, size, false);
+            lua_pushnumber(L, (double)res);
+            break;
+        }
+        case Kfloat:
+        {
+            volatile Ftypes u;
+            double num;
+            copywithendian(u.buff, data + pos, size, h.islittle);
+            if (size == sizeof(u.f))
+                num = (double)u.f;
+            else if (size == sizeof(u.d))
+                num = (double)u.d;
+            else
+                num = u.n;
+            lua_pushnumber(L, num);
+            break;
+        }
+        case Kchar:
+        {
+            lua_pushlstring(L, data + pos, size);
+            break;
+        }
+        case Kstring:
+        {
+            size_t len = (size_t)unpackint(L, data + pos, h.islittle, size, 0);
+            luaL_argcheck(L, len <= ld - pos - size, 2, "data string too short");
+            lua_pushlstring(L, data + pos + size, len);
+            pos += (int)len; // skip string
+            break;
+        }
+        case Kzstr:
+        {
+            size_t len = strlen(data + pos);
+            luaL_argcheck(L, pos + len < ld, 2, "unfinished string for format 'z'");
+            lua_pushlstring(L, data + pos, len);
+            pos += (int)len + 1; // skip string plus final '\0'
+            break;
+        }
+        case Kpaddalign:
+        case Kpadding:
+        case Knop:
+            n--; // undo increment
+            break;
+        }
+        pos += size;
+    }
+    lua_pushinteger(L, pos + 1); // next position
+    return n + 1;
+}
+
+// }======================================================
+
+static const luaL_Reg strlib[] = {
+    {"byte", str_byte},
+    {"char", str_char},
+    {"find", str_find},
+    {"format", str_format},
+    {"gmatch", gmatch},
+    {"gsub", str_gsub},
+    {"len", str_len},
+    {"lower", str_lower},
+    {"match", str_match},
+    {"rep", str_rep},
+    {"reverse", str_reverse},
+    {"sub", str_sub},
+    {"upper", str_upper},
+    {"split", str_split},
+    {"pack", str_pack},
+    {"packsize", str_packsize},
+    {"unpack", str_unpack},
+    {NULL, NULL},
+};
+
+static void createmetatable(lua_State* L)
+{
+    lua_createtable(L, 0, 1); // create metatable for strings
+    lua_pushliteral(L, "");   // dummy string
+    lua_pushvalue(L, -2);
+    lua_setmetatable(L, -2);        // set string metatable
+    lua_pop(L, 1);                  // pop dummy string
+    lua_pushvalue(L, -2);           // string library...
+    lua_setfield(L, -2, "__index"); // ...is the __index metamethod
+    lua_pop(L, 1);                  // pop metatable
+}
+
+/*
+** Open string library
+*/
+int luaopen_string(lua_State* L)
+{
+    luaL_register(L, LUA_STRLIBNAME, strlib);
+    createmetatable(L);
+
+    return 1;
+}

--- a/lib/luau/VM/src/ltable.cpp
+++ b/lib/luau/VM/src/ltable.cpp
@@ -1,0 +1,859 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+
+/*
+ * Implementation of tables (aka arrays, objects, or hash tables).
+ *
+ * Tables keep the elements in two parts: an array part and a hash part.
+ * Integer keys >=1 are all candidates to be kept in the array part. The actual size of the array is the
+ * largest n such that at least half the slots between 0 and n are in use.
+ * Hash uses a mix of chained scatter table with Brent's variation.
+ *
+ * A main invariant of these tables is that, if an element is not in its main position (i.e. the original
+ * position that its hash gives to it), then the colliding element is in its own main position.
+ * Hence even when the load factor reaches 100%, performance remains good.
+ *
+ * Table keys can be arbitrary values unless they contain NaN. Keys are hashed and compared using raw equality,
+ * so even if the key is a userdata with an overridden __eq, it's not used during hash lookups.
+ *
+ * Each table has a "boundary", defined as the index k where t[k] ~= nil and t[k+1] == nil. The boundary can be
+ * computed using a binary search and can be adjusted when the table is modified; crucially, Luau enforces an
+ * invariant where the boundary must be in the array part - this enforces a consistent iteration order through the
+ * prefix of the table when using pairs(), and allows to implement algorithms that access elements in 1..#t range
+ * more efficiently.
+ */
+
+#include "ltable.h"
+
+#include "lstate.h"
+#include "ldebug.h"
+#include "lgc.h"
+#include "lmem.h"
+#include "lnumutils.h"
+
+#include <string.h>
+
+// max size of both array and hash part is 2^MAXBITS
+#define MAXBITS 26
+#define MAXSIZE (1 << MAXBITS)
+
+static_assert(offsetof(LuaNode, val) == 0, "Unexpected Node memory layout, pointer cast in gval2slot is incorrect");
+
+// TKey is bitpacked for memory efficiency so we need to validate bit counts for worst case
+static_assert(TKey{{NULL}, {0}, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
+static_assert(TKey{{NULL}, {0}, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
+static_assert(TKey{{NULL}, {0}, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
+
+// empty hash data points to dummynode so that we can always dereference it
+const LuaNode luaH_dummynode = {
+    {{NULL}, {0}, LUA_TNIL},   // value
+    {{NULL}, {0}, LUA_TNIL, 0} // key
+};
+
+#define dummynode (&luaH_dummynode)
+
+// hash is always reduced mod 2^k
+#define hashpow2(t, n) (gnode(t, lmod((n), sizenode(t))))
+
+#define hashstr(t, str) hashpow2(t, (str)->hash)
+#define hashboolean(t, p) hashpow2(t, p)
+
+static LuaNode* hashpointer(const Table* t, const void* p)
+{
+    // we discard the high 32-bit portion of the pointer on 64-bit platforms as it doesn't carry much entropy anyway
+    unsigned int h = unsigned(uintptr_t(p));
+
+    // MurmurHash3 32-bit finalizer
+    h ^= h >> 16;
+    h *= 0x85ebca6bu;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35u;
+    h ^= h >> 16;
+
+    return hashpow2(t, h);
+}
+
+static LuaNode* hashnum(const Table* t, double n)
+{
+    static_assert(sizeof(double) == sizeof(unsigned int) * 2, "expected a 8-byte double");
+    unsigned int i[2];
+    memcpy(i, &n, sizeof(i));
+
+    // mask out sign bit to make sure -0 and 0 hash to the same value
+    uint32_t h1 = i[0];
+    uint32_t h2 = i[1] & 0x7fffffff;
+
+    // finalizer from MurmurHash64B
+    const uint32_t m = 0x5bd1e995;
+
+    h1 ^= h2 >> 18;
+    h1 *= m;
+    h2 ^= h1 >> 22;
+    h2 *= m;
+    h1 ^= h2 >> 17;
+    h1 *= m;
+    h2 ^= h1 >> 19;
+    h2 *= m;
+
+    // ... truncated to 32-bit output (normally hash is equal to (uint64_t(h1) << 32) | h2, but we only really need the lower 32-bit half)
+    return hashpow2(t, h2);
+}
+
+static LuaNode* hashvec(const Table* t, const float* v)
+{
+    unsigned int i[LUA_VECTOR_SIZE];
+    memcpy(i, v, sizeof(i));
+
+    // convert -0 to 0 to make sure they hash to the same value
+    i[0] = (i[0] == 0x80000000) ? 0 : i[0];
+    i[1] = (i[1] == 0x80000000) ? 0 : i[1];
+    i[2] = (i[2] == 0x80000000) ? 0 : i[2];
+
+    // scramble bits to make sure that integer coordinates have entropy in lower bits
+    i[0] ^= i[0] >> 17;
+    i[1] ^= i[1] >> 17;
+    i[2] ^= i[2] >> 17;
+
+    // Optimized Spatial Hashing for Collision Detection of Deformable Objects
+    unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
+
+#if LUA_VECTOR_SIZE == 4
+    i[3] = (i[3] == 0x80000000) ? 0 : i[3];
+    i[3] ^= i[3] >> 17;
+    h ^= i[3] * 39916801;
+#endif
+
+    return hashpow2(t, h);
+}
+
+/*
+** returns the `main' position of an element in a table (that is, the index
+** of its hash value)
+*/
+static LuaNode* mainposition(const Table* t, const TValue* key)
+{
+    switch (ttype(key))
+    {
+    case LUA_TNUMBER:
+        return hashnum(t, nvalue(key));
+    case LUA_TVECTOR:
+        return hashvec(t, vvalue(key));
+    case LUA_TSTRING:
+        return hashstr(t, tsvalue(key));
+    case LUA_TBOOLEAN:
+        return hashboolean(t, bvalue(key));
+    case LUA_TLIGHTUSERDATA:
+        return hashpointer(t, pvalue(key));
+    default:
+        return hashpointer(t, gcvalue(key));
+    }
+}
+
+/*
+** returns the index for `key' if `key' is an appropriate key to live in
+** the array part of the table, -1 otherwise.
+*/
+static int arrayindex(double key)
+{
+    int i;
+    luai_num2int(i, key);
+
+    return luai_numeq(cast_num(i), key) ? i : -1;
+}
+
+/*
+** returns the index of a `key' for table traversals. First goes all
+** elements in the array part, then elements in the hash part. The
+** beginning of a traversal is signalled by -1.
+*/
+static int findindex(lua_State* L, Table* t, StkId key)
+{
+    int i;
+    if (ttisnil(key))
+        return -1; // first iteration
+    i = ttisnumber(key) ? arrayindex(nvalue(key)) : -1;
+    if (0 < i && i <= t->sizearray) // is `key' inside array part?
+        return i - 1;               // yes; that's the index (corrected to C)
+    else
+    {
+        LuaNode* n = mainposition(t, key);
+        for (;;)
+        { // check whether `key' is somewhere in the chain
+            // key may be dead already, but it is ok to use it in `next'
+            if (luaO_rawequalKey(gkey(n), key) || (ttype(gkey(n)) == LUA_TDEADKEY && iscollectable(key) && gcvalue(gkey(n)) == gcvalue(key)))
+            {
+                i = cast_int(n - gnode(t, 0)); // key index in hash table
+                // hash elements are numbered after array ones
+                return i + t->sizearray;
+            }
+            if (gnext(n) == 0)
+                break;
+            n += gnext(n);
+        }
+        luaG_runerror(L, "invalid key to 'next'"); // key not found
+    }
+}
+
+int luaH_next(lua_State* L, Table* t, StkId key)
+{
+    int i = findindex(L, t, key); // find original element
+    for (i++; i < t->sizearray; i++)
+    { // try first array part
+        if (!ttisnil(&t->array[i]))
+        { // a non-nil value?
+            setnvalue(key, cast_num(i + 1));
+            setobj2s(L, key + 1, &t->array[i]);
+            return 1;
+        }
+    }
+    for (i -= t->sizearray; i < sizenode(t); i++)
+    { // then hash part
+        if (!ttisnil(gval(gnode(t, i))))
+        { // a non-nil value?
+            getnodekey(L, key, gnode(t, i));
+            setobj2s(L, key + 1, gval(gnode(t, i)));
+            return 1;
+        }
+    }
+    return 0; // no more elements
+}
+
+/*
+** {=============================================================
+** Rehash
+** ==============================================================
+*/
+
+#define maybesetaboundary(t, boundary) \
+    { \
+        if (t->aboundary <= 0) \
+            t->aboundary = -int(boundary); \
+    }
+
+#define getaboundary(t) (t->aboundary < 0 ? -t->aboundary : t->sizearray)
+
+static int computesizes(int nums[], int* narray)
+{
+    int i;
+    int twotoi; // 2^i
+    int a = 0;  // number of elements smaller than 2^i
+    int na = 0; // number of elements to go to array part
+    int n = 0;  // optimal size for array part
+    for (i = 0, twotoi = 1; twotoi / 2 < *narray; i++, twotoi *= 2)
+    {
+        if (nums[i] > 0)
+        {
+            a += nums[i];
+            if (a > twotoi / 2)
+            {               // more than half elements present?
+                n = twotoi; // optimal size (till now)
+                na = a;     // all elements smaller than n will go to array part
+            }
+        }
+        if (a == *narray)
+            break; // all elements already counted
+    }
+    *narray = n;
+    LUAU_ASSERT(*narray / 2 <= na && na <= *narray);
+    return na;
+}
+
+static int countint(double key, int* nums)
+{
+    int k = arrayindex(key);
+    if (0 < k && k <= MAXSIZE)
+    {                        // is `key' an appropriate array index?
+        nums[ceillog2(k)]++; // count as such
+        return 1;
+    }
+    else
+        return 0;
+}
+
+static int numusearray(const Table* t, int* nums)
+{
+    int lg;
+    int ttlg;     // 2^lg
+    int ause = 0; // summation of `nums'
+    int i = 1;    // count to traverse all array keys
+    for (lg = 0, ttlg = 1; lg <= MAXBITS; lg++, ttlg *= 2)
+    {               // for each slice
+        int lc = 0; // counter
+        int lim = ttlg;
+        if (lim > t->sizearray)
+        {
+            lim = t->sizearray; // adjust upper limit
+            if (i > lim)
+                break; // no more elements to count
+        }
+        // count elements in range (2^(lg-1), 2^lg]
+        for (; i <= lim; i++)
+        {
+            if (!ttisnil(&t->array[i - 1]))
+                lc++;
+        }
+        nums[lg] += lc;
+        ause += lc;
+    }
+    return ause;
+}
+
+static int numusehash(const Table* t, int* nums, int* pnasize)
+{
+    int totaluse = 0; // total number of elements
+    int ause = 0;     // summation of `nums'
+    int i = sizenode(t);
+    while (i--)
+    {
+        LuaNode* n = &t->node[i];
+        if (!ttisnil(gval(n)))
+        {
+            if (ttisnumber(gkey(n)))
+                ause += countint(nvalue(gkey(n)), nums);
+            totaluse++;
+        }
+    }
+    *pnasize += ause;
+    return totaluse;
+}
+
+static void setarrayvector(lua_State* L, Table* t, int size)
+{
+    if (size > MAXSIZE)
+        luaG_runerror(L, "table overflow");
+    luaM_reallocarray(L, t->array, t->sizearray, size, TValue, t->memcat);
+    TValue* array = t->array;
+    for (int i = t->sizearray; i < size; i++)
+        setnilvalue(&array[i]);
+    t->sizearray = size;
+}
+
+static void setnodevector(lua_State* L, Table* t, int size)
+{
+    int lsize;
+    if (size == 0)
+    {                                           // no elements to hash part?
+        t->node = cast_to(LuaNode*, dummynode); // use common `dummynode'
+        lsize = 0;
+    }
+    else
+    {
+        int i;
+        lsize = ceillog2(size);
+        if (lsize > MAXBITS)
+            luaG_runerror(L, "table overflow");
+        size = twoto(lsize);
+        t->node = luaM_newarray(L, size, LuaNode, t->memcat);
+        for (i = 0; i < size; i++)
+        {
+            LuaNode* n = gnode(t, i);
+            gnext(n) = 0;
+            setnilvalue(gkey(n));
+            setnilvalue(gval(n));
+        }
+    }
+    t->lsizenode = cast_byte(lsize);
+    t->nodemask8 = cast_byte((1 << lsize) - 1);
+    t->lastfree = size; // all positions are free
+}
+
+static TValue* newkey(lua_State* L, Table* t, const TValue* key);
+
+static TValue* arrayornewkey(lua_State* L, Table* t, const TValue* key)
+{
+    if (ttisnumber(key))
+    {
+        int k;
+        double n = nvalue(key);
+        luai_num2int(k, n);
+        if (luai_numeq(cast_num(k), n) && cast_to(unsigned int, k - 1) < cast_to(unsigned int, t->sizearray))
+            return &t->array[k - 1];
+    }
+
+    return newkey(L, t, key);
+}
+
+static void resize(lua_State* L, Table* t, int nasize, int nhsize)
+{
+    if (nasize > MAXSIZE || nhsize > MAXSIZE)
+        luaG_runerror(L, "table overflow");
+    int oldasize = t->sizearray;
+    int oldhsize = t->lsizenode;
+    LuaNode* nold = t->node; // save old hash ...
+    if (nasize > oldasize)   // array part must grow?
+        setarrayvector(L, t, nasize);
+    // create new hash part with appropriate size
+    setnodevector(L, t, nhsize);
+    // used for the migration check at the end
+    LuaNode* nnew = t->node;
+    if (nasize < oldasize)
+    { // array part must shrink?
+        t->sizearray = nasize;
+        // re-insert elements from vanishing slice
+        for (int i = nasize; i < oldasize; i++)
+        {
+            if (!ttisnil(&t->array[i]))
+            {
+                TValue ok;
+                setnvalue(&ok, cast_num(i + 1));
+                setobjt2t(L, newkey(L, t, &ok), &t->array[i]);
+            }
+        }
+        // shrink array
+        luaM_reallocarray(L, t->array, oldasize, nasize, TValue, t->memcat);
+    }
+    // used for the migration check at the end
+    TValue* anew = t->array;
+    // re-insert elements from hash part
+    for (int i = twoto(oldhsize) - 1; i >= 0; i--)
+    {
+        LuaNode* old = nold + i;
+        if (!ttisnil(gval(old)))
+        {
+            TValue ok;
+            getnodekey(L, &ok, old);
+            setobjt2t(L, arrayornewkey(L, t, &ok), gval(old));
+        }
+    }
+
+    // make sure we haven't recursively rehashed during element migration
+    LUAU_ASSERT(nnew == t->node);
+    LUAU_ASSERT(anew == t->array);
+
+    if (nold != dummynode)
+        luaM_freearray(L, nold, twoto(oldhsize), LuaNode, t->memcat); // free old array
+}
+
+static int adjustasize(Table* t, int size, const TValue* ek)
+{
+    bool tbound = t->node != dummynode || size < t->sizearray;
+    int ekindex = ek && ttisnumber(ek) ? arrayindex(nvalue(ek)) : -1;
+    // move the array size up until the boundary is guaranteed to be inside the array part
+    while (size + 1 == ekindex || (tbound && !ttisnil(luaH_getnum(t, size + 1))))
+        size++;
+    return size;
+}
+
+void luaH_resizearray(lua_State* L, Table* t, int nasize)
+{
+    int nsize = (t->node == dummynode) ? 0 : sizenode(t);
+    int asize = adjustasize(t, nasize, NULL);
+    resize(L, t, asize, nsize);
+}
+
+void luaH_resizehash(lua_State* L, Table* t, int nhsize)
+{
+    resize(L, t, t->sizearray, nhsize);
+}
+
+static void rehash(lua_State* L, Table* t, const TValue* ek)
+{
+    int nums[MAXBITS + 1]; // nums[i] = number of keys between 2^(i-1) and 2^i
+    for (int i = 0; i <= MAXBITS; i++)
+        nums[i] = 0;                          // reset counts
+    int nasize = numusearray(t, nums);        // count keys in array part
+    int totaluse = nasize;                    // all those keys are integer keys
+    totaluse += numusehash(t, nums, &nasize); // count keys in hash part
+
+    // count extra key
+    if (ttisnumber(ek))
+        nasize += countint(nvalue(ek), nums);
+    totaluse++;
+
+    // compute new size for array part
+    int na = computesizes(nums, &nasize);
+    int nh = totaluse - na;
+
+    // enforce the boundary invariant; for performance, only do hash lookups if we must
+    int nadjusted = adjustasize(t, nasize, ek);
+
+    // count how many extra elements belong to array part instead of hash part
+    int aextra = nadjusted - nasize;
+
+    if (aextra != 0)
+    {
+        // we no longer need to store those extra array elements in hash part
+        nh -= aextra;
+
+        // because hash nodes are twice as large as array nodes, the memory we saved for hash parts can be used by array part
+        // this follows the general sparse array part optimization where array is allocated when 50% occupation is reached
+        nasize = nadjusted + aextra;
+
+        // since the size was changed, it's again important to enforce the boundary invariant at the new size
+        nasize = adjustasize(t, nasize, ek);
+    }
+
+    // resize the table to new computed sizes
+    resize(L, t, nasize, nh);
+}
+
+/*
+** }=============================================================
+*/
+
+Table* luaH_new(lua_State* L, int narray, int nhash)
+{
+    Table* t = luaM_newgco(L, Table, sizeof(Table), L->activememcat);
+    luaC_init(L, t, LUA_TTABLE);
+    t->metatable = NULL;
+    t->tmcache = cast_byte(~0);
+    t->array = NULL;
+    t->sizearray = 0;
+    t->lastfree = 0;
+    t->lsizenode = 0;
+    t->readonly = 0;
+    t->safeenv = 0;
+    t->nodemask8 = 0;
+    t->node = cast_to(LuaNode*, dummynode);
+    if (narray > 0)
+        setarrayvector(L, t, narray);
+    if (nhash > 0)
+        setnodevector(L, t, nhash);
+    return t;
+}
+
+void luaH_free(lua_State* L, Table* t, lua_Page* page)
+{
+    if (t->node != dummynode)
+        luaM_freearray(L, t->node, sizenode(t), LuaNode, t->memcat);
+    if (t->array)
+        luaM_freearray(L, t->array, t->sizearray, TValue, t->memcat);
+    luaM_freegco(L, t, sizeof(Table), t->memcat, page);
+}
+
+static LuaNode* getfreepos(Table* t)
+{
+    while (t->lastfree > 0)
+    {
+        t->lastfree--;
+
+        LuaNode* n = gnode(t, t->lastfree);
+        if (ttisnil(gkey(n)))
+            return n;
+    }
+    return NULL; // could not find a free place
+}
+
+/*
+** inserts a new key into a hash table; first, check whether key's main
+** position is free. If not, check whether colliding node is in its main
+** position or not: if it is not, move colliding node to an empty place and
+** put new key in its main position; otherwise (colliding node is in its main
+** position), new key goes to an empty position.
+*/
+static TValue* newkey(lua_State* L, Table* t, const TValue* key)
+{
+    // enforce boundary invariant
+    if (ttisnumber(key) && nvalue(key) == t->sizearray + 1)
+    {
+        rehash(L, t, key); // grow table
+
+        // after rehash, numeric keys might be located in the new array part, but won't be found in the node part
+        return arrayornewkey(L, t, key);
+    }
+
+    LuaNode* mp = mainposition(t, key);
+    if (!ttisnil(gval(mp)) || mp == dummynode)
+    {
+        LuaNode* n = getfreepos(t); // get a free place
+        if (n == NULL)
+        {                      // cannot find a free place?
+            rehash(L, t, key); // grow table
+
+            // after rehash, numeric keys might be located in the new array part, but won't be found in the node part
+            return arrayornewkey(L, t, key);
+        }
+        LUAU_ASSERT(n != dummynode);
+        TValue mk;
+        getnodekey(L, &mk, mp);
+        LuaNode* othern = mainposition(t, &mk);
+        if (othern != mp)
+        { // is colliding node out of its main position?
+            // yes; move colliding node into free position
+            while (othern + gnext(othern) != mp)
+                othern += gnext(othern);          // find previous
+            gnext(othern) = cast_int(n - othern); // redo the chain with `n' in place of `mp'
+            *n = *mp;                             // copy colliding node into free pos. (mp->next also goes)
+            if (gnext(mp) != 0)
+            {
+                gnext(n) += cast_int(mp - n); // correct 'next'
+                gnext(mp) = 0;                // now 'mp' is free
+            }
+            setnilvalue(gval(mp));
+        }
+        else
+        { // colliding node is in its own main position
+            // new node will go into free position
+            if (gnext(mp) != 0)
+                gnext(n) = cast_int((mp + gnext(mp)) - n); // chain new position
+            else
+                LUAU_ASSERT(gnext(n) == 0);
+            gnext(mp) = cast_int(n - mp);
+            mp = n;
+        }
+    }
+    setnodekey(L, mp, key);
+    luaC_barriert(L, t, key);
+    LUAU_ASSERT(ttisnil(gval(mp)));
+    return gval(mp);
+}
+
+/*
+** search function for integers
+*/
+const TValue* luaH_getnum(Table* t, int key)
+{
+    // (1 <= key && key <= t->sizearray)
+    if (cast_to(unsigned int, key - 1) < cast_to(unsigned int, t->sizearray))
+        return &t->array[key - 1];
+    else if (t->node != dummynode)
+    {
+        double nk = cast_num(key);
+        LuaNode* n = hashnum(t, nk);
+        for (;;)
+        { // check whether `key' is somewhere in the chain
+            if (ttisnumber(gkey(n)) && luai_numeq(nvalue(gkey(n)), nk))
+                return gval(n); // that's it
+            if (gnext(n) == 0)
+                break;
+            n += gnext(n);
+        }
+        return luaO_nilobject;
+    }
+    else
+        return luaO_nilobject;
+}
+
+/*
+** search function for strings
+*/
+const TValue* luaH_getstr(Table* t, TString* key)
+{
+    LuaNode* n = hashstr(t, key);
+    for (;;)
+    { // check whether `key' is somewhere in the chain
+        if (ttisstring(gkey(n)) && tsvalue(gkey(n)) == key)
+            return gval(n); // that's it
+        if (gnext(n) == 0)
+            break;
+        n += gnext(n);
+    }
+    return luaO_nilobject;
+}
+
+/*
+** main search function
+*/
+const TValue* luaH_get(Table* t, const TValue* key)
+{
+    switch (ttype(key))
+    {
+    case LUA_TNIL:
+        return luaO_nilobject;
+    case LUA_TSTRING:
+        return luaH_getstr(t, tsvalue(key));
+    case LUA_TNUMBER:
+    {
+        int k;
+        double n = nvalue(key);
+        luai_num2int(k, n);
+        if (luai_numeq(cast_num(k), nvalue(key))) // index is int?
+            return luaH_getnum(t, k);             // use specialized version
+                                                  // else go through
+    }
+    default:
+    {
+        LuaNode* n = mainposition(t, key);
+        for (;;)
+        { // check whether `key' is somewhere in the chain
+            if (luaO_rawequalKey(gkey(n), key))
+                return gval(n); // that's it
+            if (gnext(n) == 0)
+                break;
+            n += gnext(n);
+        }
+        return luaO_nilobject;
+    }
+    }
+}
+
+TValue* luaH_set(lua_State* L, Table* t, const TValue* key)
+{
+    const TValue* p = luaH_get(t, key);
+    invalidateTMcache(t);
+    if (p != luaO_nilobject)
+        return cast_to(TValue*, p);
+    else
+        return luaH_newkey(L, t, key);
+}
+
+TValue* luaH_newkey(lua_State* L, Table* t, const TValue* key)
+{
+    if (ttisnil(key))
+        luaG_runerror(L, "table index is nil");
+    else if (ttisnumber(key) && luai_numisnan(nvalue(key)))
+        luaG_runerror(L, "table index is NaN");
+    else if (ttisvector(key) && luai_vecisnan(vvalue(key)))
+        luaG_runerror(L, "table index contains NaN");
+    return newkey(L, t, key);
+}
+
+TValue* luaH_setnum(lua_State* L, Table* t, int key)
+{
+    // (1 <= key && key <= t->sizearray)
+    if (cast_to(unsigned int, key - 1) < cast_to(unsigned int, t->sizearray))
+        return &t->array[key - 1];
+    // hash fallback
+    const TValue* p = luaH_getnum(t, key);
+    if (p != luaO_nilobject)
+        return cast_to(TValue*, p);
+    else
+    {
+        TValue k;
+        setnvalue(&k, cast_num(key));
+        return newkey(L, t, &k);
+    }
+}
+
+TValue* luaH_setstr(lua_State* L, Table* t, TString* key)
+{
+    const TValue* p = luaH_getstr(t, key);
+    invalidateTMcache(t);
+    if (p != luaO_nilobject)
+        return cast_to(TValue*, p);
+    else
+    {
+        TValue k;
+        setsvalue(L, &k, key);
+        return newkey(L, t, &k);
+    }
+}
+
+static int updateaboundary(Table* t, int boundary)
+{
+    if (boundary < t->sizearray && ttisnil(&t->array[boundary - 1]))
+    {
+        if (boundary >= 2 && !ttisnil(&t->array[boundary - 2]))
+        {
+            maybesetaboundary(t, boundary - 1);
+            return boundary - 1;
+        }
+    }
+    else if (boundary + 1 < t->sizearray && !ttisnil(&t->array[boundary]) && ttisnil(&t->array[boundary + 1]))
+    {
+        maybesetaboundary(t, boundary + 1);
+        return boundary + 1;
+    }
+
+    return 0;
+}
+
+/*
+** Try to find a boundary in table `t'. A `boundary' is an integer index
+** such that t[i] is non-nil and t[i+1] is nil (and 0 if t[1] is nil).
+*/
+int luaH_getn(Table* t)
+{
+    int boundary = getaboundary(t);
+
+    if (boundary > 0)
+    {
+        if (!ttisnil(&t->array[t->sizearray - 1]) && t->node == dummynode)
+            return t->sizearray; // fast-path: the end of the array in `t' already refers to a boundary
+        if (boundary < t->sizearray && !ttisnil(&t->array[boundary - 1]) && ttisnil(&t->array[boundary]))
+            return boundary; // fast-path: boundary already refers to a boundary in `t'
+
+        int foundboundary = updateaboundary(t, boundary);
+        if (foundboundary > 0)
+            return foundboundary;
+    }
+
+    int j = t->sizearray;
+
+    if (j > 0 && ttisnil(&t->array[j - 1]))
+    {
+        // "branchless" binary search from Array Layouts for Comparison-Based Searching, Paul Khuong, Pat Morin, 2017.
+        // note that clang is cmov-shy on cmovs around memory operands, so it will compile this to a branchy loop.
+        TValue* base = t->array;
+        int rest = j;
+        while (int half = rest >> 1)
+        {
+            base = ttisnil(&base[half]) ? base : base + half;
+            rest -= half;
+        }
+        int boundary = !ttisnil(base) + int(base - t->array);
+        maybesetaboundary(t, boundary);
+        return boundary;
+    }
+    else
+    {
+        // validate boundary invariant
+        LUAU_ASSERT(t->node == dummynode || ttisnil(luaH_getnum(t, j + 1)));
+        return j;
+    }
+}
+
+Table* luaH_clone(lua_State* L, Table* tt)
+{
+    Table* t = luaM_newgco(L, Table, sizeof(Table), L->activememcat);
+    luaC_init(L, t, LUA_TTABLE);
+    t->metatable = tt->metatable;
+    t->tmcache = tt->tmcache;
+    t->array = NULL;
+    t->sizearray = 0;
+    t->lsizenode = 0;
+    t->nodemask8 = 0;
+    t->readonly = 0;
+    t->safeenv = 0;
+    t->node = cast_to(LuaNode*, dummynode);
+    t->lastfree = 0;
+
+    if (tt->sizearray)
+    {
+        t->array = luaM_newarray(L, tt->sizearray, TValue, t->memcat);
+        maybesetaboundary(t, getaboundary(tt));
+        t->sizearray = tt->sizearray;
+
+        memcpy(t->array, tt->array, t->sizearray * sizeof(TValue));
+    }
+
+    if (tt->node != dummynode)
+    {
+        int size = 1 << tt->lsizenode;
+        t->node = luaM_newarray(L, size, LuaNode, t->memcat);
+        t->lsizenode = tt->lsizenode;
+        t->nodemask8 = tt->nodemask8;
+        memcpy(t->node, tt->node, size * sizeof(LuaNode));
+        t->lastfree = tt->lastfree;
+    }
+
+    return t;
+}
+
+void luaH_clear(Table* tt)
+{
+    // clear array part
+    for (int i = 0; i < tt->sizearray; ++i)
+    {
+        setnilvalue(&tt->array[i]);
+    }
+
+    maybesetaboundary(tt, 0);
+
+    // clear hash part
+    if (tt->node != dummynode)
+    {
+        int size = sizenode(tt);
+        tt->lastfree = size;
+        for (int i = 0; i < size; ++i)
+        {
+            LuaNode* n = gnode(tt, i);
+            setnilvalue(gkey(n));
+            setnilvalue(gval(n));
+            gnext(n) = 0;
+        }
+    }
+
+    // back to empty -> no tag methods present
+    tt->tmcache = cast_byte(~0);
+}

--- a/lib/luau/VM/src/ltable.h
+++ b/lib/luau/VM/src/ltable.h
@@ -1,0 +1,35 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+#define gnode(t, i) (&(t)->node[i])
+#define gkey(n) (&(n)->key)
+#define gval(n) (&(n)->val)
+#define gnext(n) ((n)->key.next)
+
+#define gval2slot(t, v) int(cast_to(LuaNode*, static_cast<const TValue*>(v)) - t->node)
+
+// reset cache of absent metamethods, cache is updated in luaT_gettm
+#define invalidateTMcache(t) t->tmcache = 0
+
+LUAI_FUNC const TValue* luaH_getnum(Table* t, int key);
+LUAI_FUNC TValue* luaH_setnum(lua_State* L, Table* t, int key);
+LUAI_FUNC const TValue* luaH_getstr(Table* t, TString* key);
+LUAI_FUNC TValue* luaH_setstr(lua_State* L, Table* t, TString* key);
+LUAI_FUNC const TValue* luaH_get(Table* t, const TValue* key);
+LUAI_FUNC TValue* luaH_set(lua_State* L, Table* t, const TValue* key);
+LUAI_FUNC TValue* luaH_newkey(lua_State* L, Table* t, const TValue* key);
+LUAI_FUNC Table* luaH_new(lua_State* L, int narray, int lnhash);
+LUAI_FUNC void luaH_resizearray(lua_State* L, Table* t, int nasize);
+LUAI_FUNC void luaH_resizehash(lua_State* L, Table* t, int nhsize);
+LUAI_FUNC void luaH_free(lua_State* L, Table* t, struct lua_Page* page);
+LUAI_FUNC int luaH_next(lua_State* L, Table* t, StkId key);
+LUAI_FUNC int luaH_getn(Table* t);
+LUAI_FUNC Table* luaH_clone(lua_State* L, Table* tt);
+LUAI_FUNC void luaH_clear(Table* tt);
+
+#define luaH_setslot(L, t, slot, key) (invalidateTMcache(t), (slot == luaO_nilobject ? luaH_newkey(L, t, key) : cast_to(TValue*, slot)))
+
+extern const LuaNode luaH_dummynode;

--- a/lib/luau/VM/src/ltablib.cpp
+++ b/lib/luau/VM/src/ltablib.cpp
@@ -1,0 +1,606 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lapi.h"
+#include "lstate.h"
+#include "ltable.h"
+#include "lstring.h"
+#include "lgc.h"
+#include "ldebug.h"
+#include "lvm.h"
+
+static int foreachi(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+    int i;
+    int n = lua_objlen(L, 1);
+    for (i = 1; i <= n; i++)
+    {
+        lua_pushvalue(L, 2);   // function
+        lua_pushinteger(L, i); // 1st argument
+        lua_rawgeti(L, 1, i);  // 2nd argument
+        lua_call(L, 2, 1);
+        if (!lua_isnil(L, -1))
+            return 1;
+        lua_pop(L, 1); // remove nil result
+    }
+    return 0;
+}
+
+static int foreach (lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+    lua_pushnil(L); // first key
+    while (lua_next(L, 1))
+    {
+        lua_pushvalue(L, 2);  // function
+        lua_pushvalue(L, -3); // key
+        lua_pushvalue(L, -3); // value
+        lua_call(L, 2, 1);
+        if (!lua_isnil(L, -1))
+            return 1;
+        lua_pop(L, 2); // remove value and result
+    }
+    return 0;
+}
+
+static int maxn(lua_State* L)
+{
+    double max = 0;
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_pushnil(L); // first key
+    while (lua_next(L, 1))
+    {
+        lua_pop(L, 1); // remove value
+        if (lua_type(L, -1) == LUA_TNUMBER)
+        {
+            double v = lua_tonumber(L, -1);
+            if (v > max)
+                max = v;
+        }
+    }
+    lua_pushnumber(L, max);
+    return 1;
+}
+
+static int getn(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_pushinteger(L, lua_objlen(L, 1));
+    return 1;
+}
+
+static void moveelements(lua_State* L, int srct, int dstt, int f, int e, int t)
+{
+    Table* src = hvalue(L->base + (srct - 1));
+    Table* dst = hvalue(L->base + (dstt - 1));
+
+    if (dst->readonly)
+        luaG_readonlyerror(L);
+
+    int n = e - f + 1; // number of elements to move
+
+    if (cast_to(unsigned int, f - 1) < cast_to(unsigned int, src->sizearray) &&
+        cast_to(unsigned int, t - 1) < cast_to(unsigned int, dst->sizearray) &&
+        cast_to(unsigned int, f - 1 + n) <= cast_to(unsigned int, src->sizearray) &&
+        cast_to(unsigned int, t - 1 + n) <= cast_to(unsigned int, dst->sizearray))
+    {
+        TValue* srcarray = src->array;
+        TValue* dstarray = dst->array;
+
+        if (t > e || t <= f || (dstt != srct && dst != src))
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                TValue* s = &srcarray[f + i - 1];
+                TValue* d = &dstarray[t + i - 1];
+                setobj2t(L, d, s);
+            }
+        }
+        else
+        {
+            for (int i = n - 1; i >= 0; i--)
+            {
+                TValue* s = &srcarray[(f + i) - 1];
+                TValue* d = &dstarray[(t + i) - 1];
+                setobj2t(L, d, s);
+            }
+        }
+
+        luaC_barrierfast(L, dst);
+    }
+    else
+    {
+        if (t > e || t <= f || dst != src)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                lua_rawgeti(L, srct, f + i);
+                lua_rawseti(L, dstt, t + i);
+            }
+        }
+        else
+        {
+            for (int i = n - 1; i >= 0; i--)
+            {
+                lua_rawgeti(L, srct, f + i);
+                lua_rawseti(L, dstt, t + i);
+            }
+        }
+    }
+}
+
+static int tinsert(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    int n = lua_objlen(L, 1);
+    int pos; // where to insert new element
+    switch (lua_gettop(L))
+    {
+    case 2:
+    {                // called with only 2 arguments
+        pos = n + 1; // insert new element at the end
+        break;
+    }
+    case 3:
+    {
+        pos = luaL_checkinteger(L, 2); // 2nd argument is the position
+
+        // move up elements if necessary
+        if (1 <= pos && pos <= n)
+            moveelements(L, 1, 1, pos, n, pos + 1);
+        break;
+    }
+    default:
+    {
+        luaL_error(L, "wrong number of arguments to 'insert'");
+    }
+    }
+    lua_rawseti(L, 1, pos); // t[pos] = v
+    return 0;
+}
+
+static int tremove(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    int n = lua_objlen(L, 1);
+    int pos = luaL_optinteger(L, 2, n);
+
+    if (!(1 <= pos && pos <= n)) // position is outside bounds?
+        return 0;                // nothing to remove
+    lua_rawgeti(L, 1, pos);      // result = t[pos]
+
+    moveelements(L, 1, 1, pos + 1, n, pos);
+
+    lua_pushnil(L);
+    lua_rawseti(L, 1, n); // t[n] = nil
+    return 1;
+}
+
+/*
+** Copy elements (1[f], ..., 1[e]) into (tt[t], tt[t+1], ...). Whenever
+** possible, copy in increasing order, which is better for rehashing.
+** "possible" means destination after original range, or smaller
+** than origin, or copying to another table.
+*/
+static int tmove(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    int f = luaL_checkinteger(L, 2);
+    int e = luaL_checkinteger(L, 3);
+    int t = luaL_checkinteger(L, 4);
+    int tt = !lua_isnoneornil(L, 5) ? 5 : 1; // destination table
+    luaL_checktype(L, tt, LUA_TTABLE);
+
+    if (e >= f)
+    { // otherwise, nothing to move
+        luaL_argcheck(L, f > 0 || e < INT_MAX + f, 3, "too many elements to move");
+        int n = e - f + 1; // number of elements to move
+        luaL_argcheck(L, t <= INT_MAX - n + 1, 4, "destination wrap around");
+
+        Table* dst = hvalue(L->base + (tt - 1));
+
+        if (dst->readonly) // also checked in moveelements, but this blocks resizes of r/o tables
+            luaG_readonlyerror(L);
+
+        if (t > 0 && (t - 1) <= dst->sizearray && (t - 1 + n) > dst->sizearray)
+        { // grow the destination table array
+            luaH_resizearray(L, dst, t - 1 + n);
+        }
+
+        moveelements(L, 1, tt, f, e, t);
+    }
+    lua_pushvalue(L, tt); // return destination table
+    return 1;
+}
+
+static void addfield(lua_State* L, luaL_Strbuf* b, int i)
+{
+    int tt = lua_rawgeti(L, 1, i);
+    if (tt != LUA_TSTRING && tt != LUA_TNUMBER)
+        luaL_error(L, "invalid value (%s) at index %d in table for 'concat'", luaL_typename(L, -1), i);
+    luaL_addvalue(b);
+}
+
+static int tconcat(lua_State* L)
+{
+    luaL_Strbuf b;
+    size_t lsep;
+    int i, last;
+    const char* sep = luaL_optlstring(L, 2, "", &lsep);
+    luaL_checktype(L, 1, LUA_TTABLE);
+    i = luaL_optinteger(L, 3, 1);
+    last = luaL_opt(L, luaL_checkinteger, 4, lua_objlen(L, 1));
+    luaL_buffinit(L, &b);
+    for (; i < last; i++)
+    {
+        addfield(L, &b, i);
+        luaL_addlstring(&b, sep, lsep);
+    }
+    if (i == last) // add last value (if interval was not empty)
+        addfield(L, &b, i);
+    luaL_pushresult(&b);
+    return 1;
+}
+
+static int tpack(lua_State* L)
+{
+    int n = lua_gettop(L);    // number of elements to pack
+    lua_createtable(L, n, 1); // create result table
+
+    Table* t = hvalue(L->top - 1);
+
+    for (int i = 0; i < n; ++i)
+    {
+        TValue* e = &t->array[i];
+        setobj2t(L, e, L->base + i);
+    }
+
+    // t.n = number of elements
+    TValue* nv = luaH_setstr(L, t, luaS_newliteral(L, "n"));
+    setnvalue(nv, n);
+
+    return 1; // return table
+}
+
+static int tunpack(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    Table* t = hvalue(L->base);
+
+    int i = luaL_optinteger(L, 2, 1);
+    int e = luaL_opt(L, luaL_checkinteger, 3, lua_objlen(L, 1));
+    if (i > e)
+        return 0;                 // empty range
+    unsigned n = (unsigned)e - i; // number of elements minus 1 (avoid overflows)
+    if (n >= (unsigned int)INT_MAX || !lua_checkstack(L, (int)(++n)))
+        luaL_error(L, "too many results to unpack");
+
+    // fast-path: direct array-to-stack copy
+    if (i == 1 && int(n) <= t->sizearray)
+    {
+        for (i = 0; i < int(n); i++)
+            setobj2s(L, L->top + i, &t->array[i]);
+        L->top += n;
+    }
+    else
+    {
+        // push arg[i..e - 1] (to avoid overflows)
+        for (; i < e; i++)
+            lua_rawgeti(L, 1, i);
+        lua_rawgeti(L, 1, e); // push last element
+    }
+    return (int)n;
+}
+
+typedef int (*SortPredicate)(lua_State* L, const TValue* l, const TValue* r);
+
+static int sort_func(lua_State* L, const TValue* l, const TValue* r)
+{
+    LUAU_ASSERT(L->top == L->base + 2); // table, function
+
+    setobj2s(L, L->top, &L->base[1]);
+    setobj2s(L, L->top + 1, l);
+    setobj2s(L, L->top + 2, r);
+    L->top += 3; // safe because of LUA_MINSTACK guarantee
+    luaD_call(L, L->top - 3, 1);
+    L->top -= 1; // maintain stack depth
+
+    return !l_isfalse(L->top);
+}
+
+inline void sort_swap(lua_State* L, Table* t, int i, int j)
+{
+    TValue* arr = t->array;
+    int n = t->sizearray;
+    LUAU_ASSERT(unsigned(i) < unsigned(n) && unsigned(j) < unsigned(n)); // contract maintained in sort_less after predicate call
+
+    // no barrier required because both elements are in the array before and after the swap
+    TValue temp;
+    setobj2s(L, &temp, &arr[i]);
+    setobj2t(L, &arr[i], &arr[j]);
+    setobj2t(L, &arr[j], &temp);
+}
+
+inline int sort_less(lua_State* L, Table* t, int i, int j, SortPredicate pred)
+{
+    TValue* arr = t->array;
+    int n = t->sizearray;
+    LUAU_ASSERT(unsigned(i) < unsigned(n) && unsigned(j) < unsigned(n)); // contract maintained in sort_less after predicate call
+
+    int res = pred(L, &arr[i], &arr[j]);
+
+    // predicate call may resize the table, which is invalid
+    if (t->sizearray != n)
+        luaL_error(L, "table modified during sorting");
+
+    return res;
+}
+
+static void sort_siftheap(lua_State* L, Table* t, int l, int u, SortPredicate pred, int root)
+{
+    LUAU_ASSERT(l <= u);
+    int count = u - l + 1;
+
+    // process all elements with two children
+    while (root * 2 + 2 < count)
+    {
+        int left = root * 2 + 1, right = root * 2 + 2;
+        int next = root;
+        next = sort_less(L, t, l + next, l + left, pred) ? left : next;
+        next = sort_less(L, t, l + next, l + right, pred) ? right : next;
+
+        if (next == root)
+            break;
+
+        sort_swap(L, t, l + root, l + next);
+        root = next;
+    }
+
+    // process last element if it has just one child
+    int lastleft = root * 2 + 1;
+    if (lastleft == count - 1 && sort_less(L, t, l + root, l + lastleft, pred))
+        sort_swap(L, t, l + root, l + lastleft);
+}
+
+static void sort_heap(lua_State* L, Table* t, int l, int u, SortPredicate pred)
+{
+    LUAU_ASSERT(l <= u);
+    int count = u - l + 1;
+
+    for (int i = count / 2 - 1; i >= 0; --i)
+        sort_siftheap(L, t, l, u, pred, i);
+
+    for (int i = count - 1; i > 0; --i)
+    {
+        sort_swap(L, t, l, l + i);
+        sort_siftheap(L, t, l, l + i - 1, pred, 0);
+    }
+}
+
+static void sort_rec(lua_State* L, Table* t, int l, int u, int limit, SortPredicate pred)
+{
+    // sort range [l..u] (inclusive, 0-based)
+    while (l < u)
+    {
+        // if the limit has been reached, quick sort is going over the permitted nlogn complexity, so we fall back to heap sort
+        if (limit == 0)
+            return sort_heap(L, t, l, u, pred);
+
+        // sort elements a[l], a[(l+u)/2] and a[u]
+        // note: this simultaneously acts as a small sort and a median selector
+        if (sort_less(L, t, u, l, pred)) // a[u] < a[l]?
+            sort_swap(L, t, u, l);       // swap a[l] - a[u]
+        if (u - l == 1)
+            break;                       // only 2 elements
+        int m = l + ((u - l) >> 1);      // midpoint
+        if (sort_less(L, t, m, l, pred)) // a[m]<a[l]?
+            sort_swap(L, t, m, l);
+        else if (sort_less(L, t, u, m, pred)) // a[u]<a[m]?
+            sort_swap(L, t, m, u);
+        if (u - l == 2)
+            break; // only 3 elements
+
+        // here l, m, u are ordered; m will become the new pivot
+        int p = u - 1;
+        sort_swap(L, t, m, u - 1); // pivot is now (and always) at u-1
+
+        // a[l] <= P == a[u-1] <= a[u], only need to sort from l+1 to u-2
+        int i = l;
+        int j = u - 1;
+        for (;;)
+        { // invariant: a[l..i] <= P <= a[j..u]
+            // repeat ++i until a[i] >= P
+            while (sort_less(L, t, ++i, p, pred))
+            {
+                if (i >= u)
+                    luaL_error(L, "invalid order function for sorting");
+            }
+            // repeat --j until a[j] <= P
+            while (sort_less(L, t, p, --j, pred))
+            {
+                if (j <= l)
+                    luaL_error(L, "invalid order function for sorting");
+            }
+            if (j < i)
+                break;
+            sort_swap(L, t, i, j);
+        }
+
+        // swap pivot a[p] with a[i], which is the new midpoint
+        sort_swap(L, t, p, i);
+
+        // adjust limit to allow 1.5 log2N recursive steps
+        limit = (limit >> 1) + (limit >> 2);
+
+        // a[l..i-1] <= a[i] == P <= a[i+1..u]
+        // sort smaller half recursively; the larger half is sorted in the next loop iteration
+        if (i - l < u - i)
+        {
+            sort_rec(L, t, l, i - 1, limit, pred);
+            l = i + 1;
+        }
+        else
+        {
+            sort_rec(L, t, i + 1, u, limit, pred);
+            u = i - 1;
+        }
+    }
+}
+
+static int tsort(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    Table* t = hvalue(L->base);
+    int n = luaH_getn(t);
+    if (t->readonly)
+        luaG_readonlyerror(L);
+
+    SortPredicate pred = luaV_lessthan;
+    if (!lua_isnoneornil(L, 2)) // is there a 2nd argument?
+    {
+        luaL_checktype(L, 2, LUA_TFUNCTION);
+        pred = sort_func;
+    }
+    lua_settop(L, 2); // make sure there are two arguments
+
+    if (n > 0)
+        sort_rec(L, t, 0, n - 1, n, pred);
+    return 0;
+}
+
+static int tcreate(lua_State* L)
+{
+    int size = luaL_checkinteger(L, 1);
+    if (size < 0)
+        luaL_argerror(L, 1, "size out of range");
+
+    if (!lua_isnoneornil(L, 2))
+    {
+        lua_createtable(L, size, 0);
+        Table* t = hvalue(L->top - 1);
+
+        StkId v = L->base + 1;
+
+        for (int i = 0; i < size; ++i)
+        {
+            TValue* e = &t->array[i];
+            setobj2t(L, e, v);
+        }
+    }
+    else
+    {
+        lua_createtable(L, size, 0);
+    }
+
+    return 1;
+}
+
+static int tfind(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checkany(L, 2);
+    int init = luaL_optinteger(L, 3, 1);
+    if (init < 1)
+        luaL_argerror(L, 3, "index out of range");
+
+    Table* t = hvalue(L->base);
+    StkId v = L->base + 1;
+
+    for (int i = init;; ++i)
+    {
+        const TValue* e = luaH_getnum(t, i);
+        if (ttisnil(e))
+            break;
+
+        if (equalobj(L, v, e))
+        {
+            lua_pushinteger(L, i);
+            return 1;
+        }
+    }
+
+    lua_pushnil(L);
+    return 1;
+}
+
+static int tclear(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    Table* tt = hvalue(L->base);
+    if (tt->readonly)
+        luaG_readonlyerror(L);
+
+    luaH_clear(tt);
+    return 0;
+}
+
+static int tfreeze(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_argcheck(L, !lua_getreadonly(L, 1), 1, "table is already frozen");
+    luaL_argcheck(L, !luaL_getmetafield(L, 1, "__metatable"), 1, "table has a protected metatable");
+
+    lua_setreadonly(L, 1, true);
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
+static int tisfrozen(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_pushboolean(L, lua_getreadonly(L, 1));
+    return 1;
+}
+
+static int tclone(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_argcheck(L, !luaL_getmetafield(L, 1, "__metatable"), 1, "table has a protected metatable");
+
+    Table* tt = luaH_clone(L, hvalue(L->base));
+
+    TValue v;
+    sethvalue(L, &v, tt);
+    luaA_pushobject(L, &v);
+
+    return 1;
+}
+
+static const luaL_Reg tab_funcs[] = {
+    {"concat", tconcat},
+    {"foreach", foreach},
+    {"foreachi", foreachi},
+    {"getn", getn},
+    {"maxn", maxn},
+    {"insert", tinsert},
+    {"remove", tremove},
+    {"sort", tsort},
+    {"pack", tpack},
+    {"unpack", tunpack},
+    {"move", tmove},
+    {"create", tcreate},
+    {"find", tfind},
+    {"clear", tclear},
+    {"freeze", tfreeze},
+    {"isfrozen", tisfrozen},
+    {"clone", tclone},
+    {NULL, NULL},
+};
+
+int luaopen_table(lua_State* L)
+{
+    luaL_register(L, LUA_TABLIBNAME, tab_funcs);
+
+    // Lua 5.1 compat
+    lua_pushcfunction(L, tunpack, "unpack");
+    lua_setglobal(L, "unpack");
+
+    return 1;
+}

--- a/lib/luau/VM/src/ltm.cpp
+++ b/lib/luau/VM/src/ltm.cpp
@@ -1,0 +1,158 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "ltm.h"
+
+#include "lstate.h"
+#include "lstring.h"
+#include "ludata.h"
+#include "ltable.h"
+#include "lgc.h"
+
+#include <string.h>
+
+// clang-format off
+const char* const luaT_typenames[] = {
+    // ORDER TYPE
+    "nil",
+    "boolean",
+
+    
+    "userdata",
+    "number",
+    "vector",
+
+    "string",
+
+    
+    "table",
+    "function",
+    "userdata",
+    "thread",
+    "buffer",
+};
+
+const char* const luaT_eventname[] = {
+    // ORDER TM
+    
+    "__index",
+    "__newindex",
+    "__mode",
+    "__namecall",
+    "__call",
+    "__iter",
+    "__len",
+
+    "__eq",
+
+    
+    "__add",
+    "__sub",
+    "__mul",
+    "__div",
+    "__idiv",
+    "__mod",
+    "__pow",
+    "__unm",
+
+    
+    "__lt",
+    "__le",
+    "__concat",
+    "__type",
+    "__metatable",
+};
+// clang-format on
+
+static_assert(sizeof(luaT_typenames) / sizeof(luaT_typenames[0]) == LUA_T_COUNT, "luaT_typenames size mismatch");
+static_assert(sizeof(luaT_eventname) / sizeof(luaT_eventname[0]) == TM_N, "luaT_eventname size mismatch");
+static_assert(TM_EQ < 8, "fasttm optimization stores a bitfield with metamethods in a byte");
+
+void luaT_init(lua_State* L)
+{
+    int i;
+    for (i = 0; i < LUA_T_COUNT; i++)
+    {
+        L->global->ttname[i] = luaS_new(L, luaT_typenames[i]);
+        luaS_fix(L->global->ttname[i]); // never collect these names
+    }
+    for (i = 0; i < TM_N; i++)
+    {
+        L->global->tmname[i] = luaS_new(L, luaT_eventname[i]);
+        luaS_fix(L->global->tmname[i]); // never collect these names
+    }
+}
+
+/*
+** function to be used with macro "fasttm": optimized for absence of
+** tag methods.
+*/
+const TValue* luaT_gettm(Table* events, TMS event, TString* ename)
+{
+    const TValue* tm = luaH_getstr(events, ename);
+    LUAU_ASSERT(event <= TM_EQ);
+    if (ttisnil(tm))
+    {                                              // no tag method?
+        events->tmcache |= cast_byte(1u << event); // cache this fact
+        return NULL;
+    }
+    else
+        return tm;
+}
+
+const TValue* luaT_gettmbyobj(lua_State* L, const TValue* o, TMS event)
+{
+    /*
+      NB: Tag-methods were replaced by meta-methods in Lua 5.0, but the
+      old names are still around (this function, for example).
+    */
+    Table* mt;
+    switch (ttype(o))
+    {
+    case LUA_TTABLE:
+        mt = hvalue(o)->metatable;
+        break;
+    case LUA_TUSERDATA:
+        mt = uvalue(o)->metatable;
+        break;
+    default:
+        mt = L->global->mt[ttype(o)];
+    }
+    return (mt ? luaH_getstr(mt, L->global->tmname[event]) : luaO_nilobject);
+}
+
+const TString* luaT_objtypenamestr(lua_State* L, const TValue* o)
+{
+    if (ttisuserdata(o) && uvalue(o)->tag != UTAG_PROXY && uvalue(o)->metatable)
+    {
+        const TValue* type = luaH_getstr(uvalue(o)->metatable, L->global->tmname[TM_TYPE]);
+
+        if (ttisstring(type))
+            return tsvalue(type);
+    }
+    else if (FFlag::TaggedLuData && ttislightuserdata(o))
+    {
+        int tag = lightuserdatatag(o);
+
+        if (unsigned(tag) < LUA_LUTAG_LIMIT)
+        {
+            const TString* name = L->global->lightuserdataname[tag];
+
+            if (name)
+                return name;
+        }
+    }
+    else if (Table* mt = L->global->mt[ttype(o)])
+    {
+        const TValue* type = luaH_getstr(mt, L->global->tmname[TM_TYPE]);
+
+        if (ttisstring(type))
+            return tsvalue(type);
+    }
+
+    return L->global->ttname[ttype(o)];
+}
+
+const char* luaT_objtypename(lua_State* L, const TValue* o)
+{
+    return getstr(luaT_objtypenamestr(L, o));
+}

--- a/lib/luau/VM/src/ltm.h
+++ b/lib/luau/VM/src/ltm.h
@@ -1,0 +1,60 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+/*
+ * WARNING: if you change the order of this enumeration,
+ * grep "ORDER TM"
+ */
+// clang-format off
+typedef enum
+{
+    
+    TM_INDEX,
+    TM_NEWINDEX,
+    TM_MODE,
+    TM_NAMECALL,
+    TM_CALL,
+    TM_ITER,
+    TM_LEN,
+
+    TM_EQ, // last tag method with `fast' access
+
+    
+    TM_ADD,
+    TM_SUB,
+    TM_MUL,
+    TM_DIV,
+    TM_IDIV,
+    TM_MOD,
+    TM_POW,
+    TM_UNM,
+
+    
+    TM_LT,
+    TM_LE,
+    TM_CONCAT,
+    TM_TYPE,
+    TM_METATABLE,
+
+    TM_N // number of elements in the enum
+} TMS;
+// clang-format on
+
+#define gfasttm(g, et, e) ((et) == NULL ? NULL : ((et)->tmcache & (1u << (e))) ? NULL : luaT_gettm(et, e, (g)->tmname[e]))
+
+#define fasttm(l, et, e) gfasttm(l->global, et, e)
+#define fastnotm(et, e) ((et) == NULL || ((et)->tmcache & (1u << (e))))
+
+LUAI_DATA const char* const luaT_typenames[];
+LUAI_DATA const char* const luaT_eventname[];
+
+LUAI_FUNC const TValue* luaT_gettm(Table* events, TMS event, TString* ename);
+LUAI_FUNC const TValue* luaT_gettmbyobj(lua_State* L, const TValue* o, TMS event);
+
+LUAI_FUNC const TString* luaT_objtypenamestr(lua_State* L, const TValue* o);
+LUAI_FUNC const char* luaT_objtypename(lua_State* L, const TValue* o);
+
+LUAI_FUNC void luaT_init(lua_State* L);

--- a/lib/luau/VM/src/ludata.cpp
+++ b/lib/luau/VM/src/ludata.cpp
@@ -1,0 +1,43 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "ludata.h"
+
+#include "lgc.h"
+#include "lmem.h"
+
+#include <string.h>
+
+Udata* luaU_newudata(lua_State* L, size_t s, int tag)
+{
+    if (s > INT_MAX - sizeof(Udata))
+        luaM_toobig(L);
+    Udata* u = luaM_newgco(L, Udata, sizeudata(s), L->activememcat);
+    luaC_init(L, u, LUA_TUSERDATA);
+    u->len = int(s);
+    u->metatable = NULL;
+    LUAU_ASSERT(tag >= 0 && tag <= 255);
+    u->tag = uint8_t(tag);
+    return u;
+}
+
+void luaU_freeudata(lua_State* L, Udata* u, lua_Page* page)
+{
+    if (u->tag < LUA_UTAG_LIMIT)
+    {
+        lua_Destructor dtor = L->global->udatagc[u->tag];
+        // TODO: access to L here is highly unsafe since this is called during internal GC traversal
+        // certain operations such as lua_getthreaddata are okay, but by and large this risks crashes on improper use
+        if (dtor)
+            dtor(L, u->data);
+    }
+    else if (u->tag == UTAG_IDTOR)
+    {
+        void (*dtor)(void*) = nullptr;
+        memcpy(&dtor, &u->data + u->len - sizeof(dtor), sizeof(dtor));
+        if (dtor)
+            dtor(u->data);
+    }
+
+
+    luaM_freegco(L, u, sizeudata(u->len), u->memcat, page);
+}

--- a/lib/luau/VM/src/ludata.h
+++ b/lib/luau/VM/src/ludata.h
@@ -1,0 +1,16 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+
+// special tag value is used for user data with inline dtors
+#define UTAG_IDTOR LUA_UTAG_LIMIT
+
+// special tag value is used for newproxy-created user data (all other user data objects are host-exposed)
+#define UTAG_PROXY (LUA_UTAG_LIMIT + 1)
+
+#define sizeudata(len) (offsetof(Udata, data) + len)
+
+LUAI_FUNC Udata* luaU_newudata(lua_State* L, size_t s, int tag);
+LUAI_FUNC void luaU_freeudata(lua_State* L, Udata* u, struct lua_Page* page);

--- a/lib/luau/VM/src/lutf8lib.cpp
+++ b/lib/luau/VM/src/lutf8lib.cpp
@@ -1,0 +1,298 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lualib.h"
+
+#include "lcommon.h"
+
+#define MAXUNICODE 0x10FFFF
+
+#define iscont(p) ((*(p)&0xC0) == 0x80)
+
+LUAU_DYNAMIC_FASTFLAGVARIABLE(LuauStricterUtf8, false)
+
+// from strlib
+// translate a relative string position: negative means back from end
+static int u_posrelat(int pos, size_t len)
+{
+    if (pos >= 0)
+        return pos;
+    else if (0u - (size_t)pos > len)
+        return 0;
+    else
+        return (int)len + pos + 1;
+}
+
+/*
+** Decode one UTF-8 sequence, returning NULL if byte sequence is invalid.
+*/
+static const char* utf8_decode(const char* o, int* val)
+{
+    static const unsigned int limits[] = {0xFF, 0x7F, 0x7FF, 0xFFFF};
+    const unsigned char* s = (const unsigned char*)o;
+    unsigned int c = s[0];
+    unsigned int res = 0; // final result
+    if (c < 0x80)         // ascii?
+        res = c;
+    else
+    {
+        int count = 0; // to count number of continuation bytes
+        while (c & 0x40)
+        {                                   // still have continuation bytes?
+            int cc = s[++count];            // read next byte
+            if ((cc & 0xC0) != 0x80)        // not a continuation byte?
+                return NULL;                // invalid byte sequence
+            res = (res << 6) | (cc & 0x3F); // add lower 6 bits from cont. byte
+            c <<= 1;                        // to test next bit
+        }
+        res |= ((c & 0x7F) << (count * 5)); // add first byte
+        if (count > 3 || res > MAXUNICODE || res <= limits[count])
+            return NULL; // invalid byte sequence
+        if (DFFlag::LuauStricterUtf8 && unsigned(res - 0xD800) < 0x800)
+            return NULL; // surrogate
+        s += count;      // skip continuation bytes read
+    }
+    if (val)
+        *val = res;
+    return (const char*)s + 1; // +1 to include first byte
+}
+
+/*
+** utf8len(s [, i [, j]]) --> number of characters that start in the
+** range [i,j], or nil + current position if 's' is not well formed in
+** that interval
+*/
+static int utflen(lua_State* L)
+{
+    int n = 0;
+    size_t len;
+    const char* s = luaL_checklstring(L, 1, &len);
+    int posi = u_posrelat(luaL_optinteger(L, 2, 1), len);
+    int posj = u_posrelat(luaL_optinteger(L, 3, -1), len);
+    luaL_argcheck(L, 1 <= posi && --posi <= (int)len, 2, "initial position out of string");
+    luaL_argcheck(L, --posj < (int)len, 3, "final position out of string");
+    while (posi <= posj)
+    {
+        const char* s1 = utf8_decode(s + posi, NULL);
+        if (s1 == NULL)
+        {                                 // conversion error?
+            lua_pushnil(L);               // return nil ...
+            lua_pushinteger(L, posi + 1); // ... and current position
+            return 2;
+        }
+        posi = (int)(s1 - s);
+        n++;
+    }
+    lua_pushinteger(L, n);
+    return 1;
+}
+
+/*
+** codepoint(s, [i, [j]])  -> returns codepoints for all characters
+** that start in the range [i,j]
+*/
+static int codepoint(lua_State* L)
+{
+    size_t len;
+    const char* s = luaL_checklstring(L, 1, &len);
+    int posi = u_posrelat(luaL_optinteger(L, 2, 1), len);
+    int pose = u_posrelat(luaL_optinteger(L, 3, posi), len);
+    int n;
+    const char* se;
+    luaL_argcheck(L, posi >= 1, 2, "out of range");
+    luaL_argcheck(L, pose <= (int)len, 3, "out of range");
+    if (posi > pose)
+        return 0;               // empty interval; return no values
+    if (pose - posi >= INT_MAX) // (int -> int) overflow?
+        luaL_error(L, "string slice too long");
+    n = (int)(pose - posi) + 1;
+    luaL_checkstack(L, n, "string slice too long");
+    n = 0;
+    se = s + pose;
+    for (s += posi - 1; s < se;)
+    {
+        int code;
+        s = utf8_decode(s, &code);
+        if (s == NULL)
+            luaL_error(L, "invalid UTF-8 code");
+        lua_pushinteger(L, code);
+        n++;
+    }
+    return n;
+}
+
+// from Lua 5.3 lobject.h
+#define UTF8BUFFSZ 8
+
+// from Lua 5.3 lobject.c, copied verbatim + static
+static int luaO_utf8esc(char* buff, unsigned long x)
+{
+    int n = 1; // number of bytes put in buffer (backwards)
+    LUAU_ASSERT(x <= 0x10FFFF);
+    if (x < 0x80) // ascii?
+        buff[UTF8BUFFSZ - 1] = cast_to(char, x);
+    else
+    {                            // need continuation bytes
+        unsigned int mfb = 0x3f; // maximum that fits in first byte
+        do
+        { // add continuation bytes
+            buff[UTF8BUFFSZ - (n++)] = cast_to(char, 0x80 | (x & 0x3f));
+            x >>= 6;                                           // remove added bits
+            mfb >>= 1;                                         // now there is one less bit available in first byte
+        } while (x > mfb);                                     // still needs continuation byte?
+        buff[UTF8BUFFSZ - n] = cast_to(char, (~mfb << 1) | x); // add first byte
+    }
+    return n;
+}
+
+// lighter replacement for pushutfchar; doesn't push any string onto the stack
+static int buffutfchar(lua_State* L, int arg, char* buff, const char** charstr)
+{
+    int code = luaL_checkinteger(L, arg);
+    luaL_argcheck(L, 0 <= code && code <= MAXUNICODE, arg, "value out of range");
+    int l = luaO_utf8esc(buff, cast_to(long, code));
+    *charstr = buff + UTF8BUFFSZ - l;
+    return l;
+}
+
+/*
+** utfchar(n1, n2, ...)  -> char(n1)..char(n2)...
+**
+** This version avoids the need to make more invasive upgrades elsewhere (like
+** implementing the %U escape in lua_pushfstring) and avoids pushing string
+** objects for each codepoint in the multi-argument case. -Jovanni
+*/
+static int utfchar(lua_State* L)
+{
+    char buff[UTF8BUFFSZ];
+    const char* charstr;
+
+    int n = lua_gettop(L); // number of arguments
+    if (n == 1)
+    { // optimize common case of single char
+        int l = buffutfchar(L, 1, buff, &charstr);
+        lua_pushlstring(L, charstr, l);
+    }
+    else
+    {
+        luaL_Strbuf b;
+        luaL_buffinit(L, &b);
+        for (int i = 1; i <= n; i++)
+        {
+            int l = buffutfchar(L, i, buff, &charstr);
+            luaL_addlstring(&b, charstr, l);
+        }
+        luaL_pushresult(&b);
+    }
+    return 1;
+}
+
+/*
+** offset(s, n, [i])  -> index where n-th character counting from
+**   position 'i' starts; 0 means character at 'i'.
+*/
+static int byteoffset(lua_State* L)
+{
+    size_t len;
+    const char* s = luaL_checklstring(L, 1, &len);
+    int n = luaL_checkinteger(L, 2);
+    int posi = (n >= 0) ? 1 : (int)len + 1;
+    posi = u_posrelat(luaL_optinteger(L, 3, posi), len);
+    luaL_argcheck(L, 1 <= posi && --posi <= (int)len, 3, "position out of range");
+    if (n == 0)
+    {
+        // find beginning of current byte sequence
+        while (posi > 0 && iscont(s + posi))
+            posi--;
+    }
+    else
+    {
+        if (iscont(s + posi))
+            luaL_error(L, "initial position is a continuation byte");
+        if (n < 0)
+        {
+            while (n < 0 && posi > 0)
+            { // move back
+                do
+                { // find beginning of previous character
+                    posi--;
+                } while (posi > 0 && iscont(s + posi));
+                n++;
+            }
+        }
+        else
+        {
+            n--; // do not move for 1st character
+            while (n > 0 && posi < (int)len)
+            {
+                do
+                { // find beginning of next character
+                    posi++;
+                } while (iscont(s + posi)); // (cannot pass final '\0')
+                n--;
+            }
+        }
+    }
+    if (n == 0) // did it find given character?
+        lua_pushinteger(L, posi + 1);
+    else // no such character
+        lua_pushnil(L);
+    return 1;
+}
+
+static int iter_aux(lua_State* L)
+{
+    size_t len;
+    const char* s = luaL_checklstring(L, 1, &len);
+    int n = lua_tointeger(L, 2) - 1;
+    if (n < 0) // first iteration?
+        n = 0; // start from here
+    else if (n < (int)len)
+    {
+        n++; // skip current byte
+        while (iscont(s + n))
+            n++; // and its continuations
+    }
+    if (n >= (int)len)
+        return 0; // no more codepoints
+    else
+    {
+        int code;
+        const char* next = utf8_decode(s + n, &code);
+        if (next == NULL || iscont(next))
+            luaL_error(L, "invalid UTF-8 code");
+        lua_pushinteger(L, n + 1);
+        lua_pushinteger(L, code);
+        return 2;
+    }
+}
+
+static int iter_codes(lua_State* L)
+{
+    luaL_checkstring(L, 1);
+    lua_pushcfunction(L, iter_aux, NULL);
+    lua_pushvalue(L, 1);
+    lua_pushinteger(L, 0);
+    return 3;
+}
+
+// pattern to match a single UTF-8 character
+#define UTF8PATT "[\0-\x7F\xC2-\xF4][\x80-\xBF]*"
+
+static const luaL_Reg funcs[] = {
+    {"offset", byteoffset},
+    {"codepoint", codepoint},
+    {"char", utfchar},
+    {"len", utflen},
+    {"codes", iter_codes},
+    {NULL, NULL},
+};
+
+int luaopen_utf8(lua_State* L)
+{
+    luaL_register(L, LUA_UTF8LIBNAME, funcs);
+
+    lua_pushlstring(L, UTF8PATT, sizeof(UTF8PATT) / sizeof(char) - 1);
+    lua_setfield(L, -2, "charpattern");
+
+    return 1;
+}

--- a/lib/luau/VM/src/lvm.h
+++ b/lib/luau/VM/src/lvm.h
@@ -1,0 +1,34 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#pragma once
+
+#include "lobject.h"
+#include "ltm.h"
+
+#define tostring(L, o) ((ttype(o) == LUA_TSTRING) || (luaV_tostring(L, o)))
+
+#define tonumber(o, n) (ttype(o) == LUA_TNUMBER || (((o) = luaV_tonumber(o, n)) != NULL))
+
+#define equalobj(L, o1, o2) (ttype(o1) == ttype(o2) && luaV_equalval(L, o1, o2))
+
+LUAI_FUNC int luaV_strcmp(const TString* ls, const TString* rs);
+LUAI_FUNC int luaV_lessthan(lua_State* L, const TValue* l, const TValue* r);
+LUAI_FUNC int luaV_lessequal(lua_State* L, const TValue* l, const TValue* r);
+LUAI_FUNC int luaV_equalval(lua_State* L, const TValue* t1, const TValue* t2);
+LUAI_FUNC void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TMS op);
+LUAI_FUNC void luaV_dolen(lua_State* L, StkId ra, const TValue* rb);
+LUAI_FUNC const TValue* luaV_tonumber(const TValue* obj, TValue* n);
+LUAI_FUNC const float* luaV_tovector(const TValue* obj);
+LUAI_FUNC int luaV_tostring(lua_State* L, StkId obj);
+LUAI_FUNC void luaV_gettable(lua_State* L, const TValue* t, TValue* key, StkId val);
+LUAI_FUNC void luaV_settable(lua_State* L, const TValue* t, TValue* key, StkId val);
+LUAI_FUNC void luaV_concat(lua_State* L, int total, int last);
+LUAI_FUNC void luaV_getimport(lua_State* L, Table* env, TValue* k, StkId res, uint32_t id, bool propagatenil);
+LUAI_FUNC void luaV_prepareFORN(lua_State* L, StkId plimit, StkId pstep, StkId pinit);
+LUAI_FUNC void luaV_callTM(lua_State* L, int nparams, int res);
+LUAI_FUNC void luaV_tryfuncTM(lua_State* L, StkId func);
+
+LUAI_FUNC void luau_execute(lua_State* L);
+LUAI_FUNC int luau_precall(lua_State* L, struct lua_TValue* func, int nresults);
+LUAI_FUNC void luau_poscall(lua_State* L, StkId first);
+LUAI_FUNC void luau_callhook(lua_State* L, lua_Hook hook, void* userdata);

--- a/lib/luau/VM/src/lvmexecute.cpp
+++ b/lib/luau/VM/src/lvmexecute.cpp
@@ -1,0 +1,3097 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lvm.h"
+
+#include "lstate.h"
+#include "ltable.h"
+#include "lfunc.h"
+#include "lstring.h"
+#include "lgc.h"
+#include "lmem.h"
+#include "ldebug.h"
+#include "ldo.h"
+#include "lbuiltins.h"
+#include "lnumutils.h"
+#include "lbytecode.h"
+
+#include <string.h>
+
+// Disable c99-designator to avoid the warning in CGOTO dispatch table
+#ifdef __clang__
+#if __has_warning("-Wc99-designator")
+#pragma clang diagnostic ignored "-Wc99-designator"
+#endif
+#endif
+
+// When working with VM code, pay attention to these rules for correctness:
+// 1. Many external Lua functions can fail; for them to fail and be able to generate a proper stack, we need to copy pc to L->ci->savedpc before the
+// call
+// 2. Many external Lua functions can reallocate the stack. This invalidates stack pointers in VM C stack frame, most importantly base, but also
+// ra/rb/rc!
+// 3. VM_PROTECT macro saves savedpc and restores base for you; most external calls need to be wrapped into that. However, it does NOT restore
+// ra/rb/rc!
+// 4. When copying an object to any existing object as a field, generally speaking you need to call luaC_barrier! Be careful with all setobj calls
+// 5. To make 4 easier to follow, please use setobj2s for copies to stack, setobj2t for writes to tables, and setobj for other copies.
+// 6. You can define HARDSTACKTESTS in llimits.h which will aggressively realloc stack; with address sanitizer this should be effective at finding
+// stack corruption bugs
+// 7. Many external Lua functions can call GC! GC will *not* traverse pointers to new objects that aren't reachable from Lua root. Be careful when
+// creating new Lua objects, store them to stack soon.
+
+// When calling luau_callTM, we usually push the arguments to the top of the stack.
+// This is safe to do for complicated reasons:
+// - stack guarantees EXTRA_STACK room beyond stack_last (see luaD_reallocstack)
+// - stack reallocation copies values past stack_last
+
+// All external function calls that can cause stack realloc or Lua calls have to be wrapped in VM_PROTECT
+// This makes sure that we save the pc (in case the Lua call needs to generate a backtrace) before the call,
+// and restores the stack pointer after in case stack gets reallocated
+// Should only be used on the slow paths.
+#define VM_PROTECT(x) \
+    { \
+        L->ci->savedpc = pc; \
+        { \
+            x; \
+        }; \
+        base = L->base; \
+    }
+
+// Some external functions can cause an error, but never reallocate the stack; for these, VM_PROTECT_PC() is
+// a cheaper version of VM_PROTECT that can be called before the external call.
+#define VM_PROTECT_PC() L->ci->savedpc = pc
+
+#define VM_REG(i) (LUAU_ASSERT(unsigned(i) < unsigned(L->top - base)), &base[i])
+#define VM_KV(i) (LUAU_ASSERT(unsigned(i) < unsigned(cl->l.p->sizek)), &k[i])
+#define VM_UV(i) (LUAU_ASSERT(unsigned(i) < unsigned(cl->nupvalues)), &cl->l.uprefs[i])
+
+#define VM_PATCH_C(pc, slot) *const_cast<Instruction*>(pc) = ((uint8_t(slot) << 24) | (0x00ffffffu & *(pc)))
+#define VM_PATCH_E(pc, slot) *const_cast<Instruction*>(pc) = ((uint32_t(slot) << 8) | (0x000000ffu & *(pc)))
+
+#define VM_INTERRUPT() \
+    { \
+        void (*interrupt)(lua_State*, int) = L->global->cb.interrupt; \
+        if (LUAU_UNLIKELY(!!interrupt)) \
+        { /* the interrupt hook is called right before we advance pc */ \
+            VM_PROTECT(L->ci->savedpc++; interrupt(L, -1)); \
+            if (L->status != 0) \
+            { \
+                L->ci->savedpc--; \
+                goto exit; \
+            } \
+        } \
+    }
+
+
+#define VM_DISPATCH_OP(op) &&CASE_##op
+
+
+#define VM_DISPATCH_TABLE() \
+    VM_DISPATCH_OP(LOP_NOP), VM_DISPATCH_OP(LOP_BREAK), VM_DISPATCH_OP(LOP_LOADNIL), VM_DISPATCH_OP(LOP_LOADB), VM_DISPATCH_OP(LOP_LOADN), \
+        VM_DISPATCH_OP(LOP_LOADK), VM_DISPATCH_OP(LOP_MOVE), VM_DISPATCH_OP(LOP_GETGLOBAL), VM_DISPATCH_OP(LOP_SETGLOBAL), \
+        VM_DISPATCH_OP(LOP_GETUPVAL), VM_DISPATCH_OP(LOP_SETUPVAL), VM_DISPATCH_OP(LOP_CLOSEUPVALS), VM_DISPATCH_OP(LOP_GETIMPORT), \
+        VM_DISPATCH_OP(LOP_GETTABLE), VM_DISPATCH_OP(LOP_SETTABLE), VM_DISPATCH_OP(LOP_GETTABLEKS), VM_DISPATCH_OP(LOP_SETTABLEKS), \
+        VM_DISPATCH_OP(LOP_GETTABLEN), VM_DISPATCH_OP(LOP_SETTABLEN), VM_DISPATCH_OP(LOP_NEWCLOSURE), VM_DISPATCH_OP(LOP_NAMECALL), \
+        VM_DISPATCH_OP(LOP_CALL), VM_DISPATCH_OP(LOP_RETURN), VM_DISPATCH_OP(LOP_JUMP), VM_DISPATCH_OP(LOP_JUMPBACK), VM_DISPATCH_OP(LOP_JUMPIF), \
+        VM_DISPATCH_OP(LOP_JUMPIFNOT), VM_DISPATCH_OP(LOP_JUMPIFEQ), VM_DISPATCH_OP(LOP_JUMPIFLE), VM_DISPATCH_OP(LOP_JUMPIFLT), \
+        VM_DISPATCH_OP(LOP_JUMPIFNOTEQ), VM_DISPATCH_OP(LOP_JUMPIFNOTLE), VM_DISPATCH_OP(LOP_JUMPIFNOTLT), VM_DISPATCH_OP(LOP_ADD), \
+        VM_DISPATCH_OP(LOP_SUB), VM_DISPATCH_OP(LOP_MUL), VM_DISPATCH_OP(LOP_DIV), VM_DISPATCH_OP(LOP_MOD), VM_DISPATCH_OP(LOP_POW), \
+        VM_DISPATCH_OP(LOP_ADDK), VM_DISPATCH_OP(LOP_SUBK), VM_DISPATCH_OP(LOP_MULK), VM_DISPATCH_OP(LOP_DIVK), VM_DISPATCH_OP(LOP_MODK), \
+        VM_DISPATCH_OP(LOP_POWK), VM_DISPATCH_OP(LOP_AND), VM_DISPATCH_OP(LOP_OR), VM_DISPATCH_OP(LOP_ANDK), VM_DISPATCH_OP(LOP_ORK), \
+        VM_DISPATCH_OP(LOP_CONCAT), VM_DISPATCH_OP(LOP_NOT), VM_DISPATCH_OP(LOP_MINUS), VM_DISPATCH_OP(LOP_LENGTH), VM_DISPATCH_OP(LOP_NEWTABLE), \
+        VM_DISPATCH_OP(LOP_DUPTABLE), VM_DISPATCH_OP(LOP_SETLIST), VM_DISPATCH_OP(LOP_FORNPREP), VM_DISPATCH_OP(LOP_FORNLOOP), \
+        VM_DISPATCH_OP(LOP_FORGLOOP), VM_DISPATCH_OP(LOP_FORGPREP_INEXT), VM_DISPATCH_OP(LOP_DEP_FORGLOOP_INEXT), VM_DISPATCH_OP(LOP_FORGPREP_NEXT), \
+        VM_DISPATCH_OP(LOP_NATIVECALL), VM_DISPATCH_OP(LOP_GETVARARGS), VM_DISPATCH_OP(LOP_DUPCLOSURE), VM_DISPATCH_OP(LOP_PREPVARARGS), \
+        VM_DISPATCH_OP(LOP_LOADKX), VM_DISPATCH_OP(LOP_JUMPX), VM_DISPATCH_OP(LOP_FASTCALL), VM_DISPATCH_OP(LOP_COVERAGE), \
+        VM_DISPATCH_OP(LOP_CAPTURE), VM_DISPATCH_OP(LOP_SUBRK), VM_DISPATCH_OP(LOP_DIVRK), VM_DISPATCH_OP(LOP_FASTCALL1), \
+        VM_DISPATCH_OP(LOP_FASTCALL2), VM_DISPATCH_OP(LOP_FASTCALL2K), VM_DISPATCH_OP(LOP_FORGPREP), VM_DISPATCH_OP(LOP_JUMPXEQKNIL), \
+        VM_DISPATCH_OP(LOP_JUMPXEQKB), VM_DISPATCH_OP(LOP_JUMPXEQKN), VM_DISPATCH_OP(LOP_JUMPXEQKS), VM_DISPATCH_OP(LOP_IDIV), \
+        VM_DISPATCH_OP(LOP_IDIVK),
+
+#if defined(__GNUC__) || defined(__clang__)
+#define VM_USE_CGOTO 1
+#else
+#define VM_USE_CGOTO 0
+#endif
+
+/**
+ * These macros help dispatching Luau opcodes using either case
+ * statements or computed goto.
+ * VM_CASE(op) Generates either a case statement or a label
+ * VM_NEXT() fetch a byte and dispatch or jump to the beginning of the switch statement
+ * VM_CONTINUE() Use an opcode override to dispatch with computed goto or
+ * switch statement to skip a LOP_BREAK instruction.
+ */
+#if VM_USE_CGOTO
+#define VM_CASE(op) CASE_##op:
+#define VM_NEXT() goto*(SingleStep ? &&dispatch : kDispatchTable[LUAU_INSN_OP(*pc)])
+#define VM_CONTINUE(op) goto* kDispatchTable[uint8_t(op)]
+#else
+#define VM_CASE(op) case op:
+#define VM_NEXT() goto dispatch
+#define VM_CONTINUE(op) \
+    dispatchOp = uint8_t(op); \
+    goto dispatchContinue
+#endif
+
+// Does VM support native execution via ExecutionCallbacks? We mostly assume it does but keep the define to make it easy to quantify the cost.
+#define VM_HAS_NATIVE 1
+
+LUAU_FASTFLAGVARIABLE(TaggedLuData, false)
+
+LUAU_NOINLINE void luau_callhook(lua_State* L, lua_Hook hook, void* userdata)
+{
+    ptrdiff_t base = savestack(L, L->base);
+    ptrdiff_t top = savestack(L, L->top);
+    ptrdiff_t ci_top = savestack(L, L->ci->top);
+    int status = L->status;
+
+    // if the hook is called externally on a paused thread, we need to make sure the paused thread can emit Lua calls
+    if (status == LUA_YIELD || status == LUA_BREAK)
+    {
+        L->status = 0;
+        L->base = L->ci->base;
+    }
+
+    // note: the pc expectations of the hook are matching the general "pc points to next instruction"
+    // however, for the hook to be able to continue execution from the same point, this is called with savedpc at the *current* instruction
+    // this needs to be called before luaD_checkstack in case it fails to reallocate stack
+    if (L->ci->savedpc)
+        L->ci->savedpc++;
+
+    luaD_checkstack(L, LUA_MINSTACK); // ensure minimum stack size
+    L->ci->top = L->top + LUA_MINSTACK;
+    LUAU_ASSERT(L->ci->top <= L->stack_last);
+
+    Closure* cl = clvalue(L->ci->func);
+
+    lua_Debug ar;
+    ar.currentline = cl->isC ? -1 : luaG_getline(cl->l.p, pcRel(L->ci->savedpc, cl->l.p));
+    ar.userdata = userdata;
+
+    hook(L, &ar);
+
+    if (L->ci->savedpc)
+        L->ci->savedpc--;
+
+    L->ci->top = restorestack(L, ci_top);
+    L->top = restorestack(L, top);
+
+    // note that we only restore the paused state if the hook hasn't yielded by itself
+    if (status == LUA_YIELD && L->status != LUA_YIELD)
+    {
+        L->status = LUA_YIELD;
+        L->base = restorestack(L, base);
+    }
+    else if (status == LUA_BREAK)
+    {
+        LUAU_ASSERT(L->status != LUA_BREAK); // hook shouldn't break again
+
+        L->status = LUA_BREAK;
+        L->base = restorestack(L, base);
+    }
+}
+
+inline bool luau_skipstep(uint8_t op)
+{
+    return op == LOP_PREPVARARGS || op == LOP_BREAK;
+}
+
+template<bool SingleStep>
+static void luau_execute(lua_State* L)
+{
+#if VM_USE_CGOTO
+    static const void* kDispatchTable[256] = {VM_DISPATCH_TABLE()};
+#endif
+
+    // the critical interpreter state, stored in locals for performance
+    // the hope is that these map to registers without spilling (which is not true for x86 :/)
+    Closure* cl;
+    StkId base;
+    TValue* k;
+    const Instruction* pc;
+
+    LUAU_ASSERT(isLua(L->ci));
+    LUAU_ASSERT(L->isactive);
+    LUAU_ASSERT(!isblack(obj2gco(L))); // we don't use luaC_threadbarrier because active threads never turn black
+
+#if VM_HAS_NATIVE
+    if ((L->ci->flags & LUA_CALLINFO_NATIVE) && !SingleStep)
+    {
+        Proto* p = clvalue(L->ci->func)->l.p;
+        LUAU_ASSERT(p->execdata);
+
+        if (L->global->ecb.enter(L, p) == 0)
+            return;
+    }
+
+reentry:
+#endif
+
+    LUAU_ASSERT(isLua(L->ci));
+
+    pc = L->ci->savedpc;
+    cl = clvalue(L->ci->func);
+    base = L->base;
+    k = cl->l.p->k;
+
+    VM_NEXT(); // starts the interpreter "loop"
+
+    {
+    dispatch:
+        // Note: this code doesn't always execute! on some platforms we use computed goto which bypasses all of this unless we run in single-step mode
+        // Therefore only ever put assertions here.
+        LUAU_ASSERT(base == L->base && L->base == L->ci->base);
+        LUAU_ASSERT(base <= L->top && L->top <= L->stack + L->stacksize);
+
+        // ... and singlestep logic :)
+        if (SingleStep)
+        {
+            if (L->global->cb.debugstep && !luau_skipstep(LUAU_INSN_OP(*pc)))
+            {
+                VM_PROTECT(luau_callhook(L, L->global->cb.debugstep, NULL));
+
+                // allow debugstep hook to put thread into error/yield state
+                if (L->status != 0)
+                    goto exit;
+            }
+
+#if VM_USE_CGOTO
+            VM_CONTINUE(LUAU_INSN_OP(*pc));
+#endif
+        }
+
+#if !VM_USE_CGOTO
+        size_t dispatchOp = LUAU_INSN_OP(*pc);
+
+    dispatchContinue:
+        switch (dispatchOp)
+#endif
+        {
+            VM_CASE(LOP_NOP)
+            {
+                Instruction insn = *pc++;
+                LUAU_ASSERT(insn == 0);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_LOADNIL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                setnilvalue(ra);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_LOADB)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                setbvalue(ra, LUAU_INSN_B(insn));
+
+                pc += LUAU_INSN_C(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_LOADN)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                setnvalue(ra, LUAU_INSN_D(insn));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_LOADK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_D(insn));
+
+                setobj2s(L, ra, kv);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_MOVE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+
+                setobj2s(L, ra, rb);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_GETGLOBAL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+                LUAU_ASSERT(ttisstring(kv));
+
+                // fast-path: value is in expected slot
+                Table* h = cl->env;
+                int slot = LUAU_INSN_C(insn) & h->nodemask8;
+                LuaNode* n = &h->node[slot];
+
+                if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv)) && !ttisnil(gval(n)))
+                {
+                    setobj2s(L, ra, gval(n));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke Lua calls via __index metamethod
+                    TValue g;
+                    sethvalue(L, &g, h);
+                    L->cachedslot = slot;
+                    VM_PROTECT(luaV_gettable(L, &g, kv, ra));
+                    // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                    VM_PATCH_C(pc - 2, L->cachedslot);
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_SETGLOBAL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+                LUAU_ASSERT(ttisstring(kv));
+
+                // fast-path: value is in expected slot
+                Table* h = cl->env;
+                int slot = LUAU_INSN_C(insn) & h->nodemask8;
+                LuaNode* n = &h->node[slot];
+
+                if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n)) && !h->readonly))
+                {
+                    setobj2t(L, gval(n), ra);
+                    luaC_barriert(L, h, ra);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke Lua calls via __newindex metamethod
+                    TValue g;
+                    sethvalue(L, &g, h);
+                    L->cachedslot = slot;
+                    VM_PROTECT(luaV_settable(L, &g, kv, ra));
+                    // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                    VM_PATCH_C(pc - 2, L->cachedslot);
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_GETUPVAL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* ur = VM_UV(LUAU_INSN_B(insn));
+                TValue* v = ttisupval(ur) ? upvalue(ur)->v : ur;
+
+                setobj2s(L, ra, v);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_SETUPVAL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* ur = VM_UV(LUAU_INSN_B(insn));
+                UpVal* uv = upvalue(ur);
+
+                setobj(L, uv->v, ra);
+                luaC_barrier(L, uv, ra);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_CLOSEUPVALS)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                if (L->openupval && L->openupval->v >= ra)
+                    luaF_close(L, ra);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_GETIMPORT)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_D(insn));
+
+                // fast-path: import resolution was successful and closure environment is "safe" for import
+                if (!ttisnil(kv) && cl->env->safeenv)
+                {
+                    setobj2s(L, ra, kv);
+                    pc++; // skip over AUX
+                    VM_NEXT();
+                }
+                else
+                {
+                    uint32_t aux = *pc++;
+
+                    VM_PROTECT(luaV_getimport(L, cl->env, k, ra, aux, /* propagatenil= */ false));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_GETTABLEKS)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+                LUAU_ASSERT(ttisstring(kv));
+
+                // fast-path: built-in table
+                if (LUAU_LIKELY(ttistable(rb)))
+                {
+                    Table* h = hvalue(rb);
+
+                    int slot = LUAU_INSN_C(insn) & h->nodemask8;
+                    LuaNode* n = &h->node[slot];
+
+                    // fast-path: value is in expected slot
+                    if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n))))
+                    {
+                        setobj2s(L, ra, gval(n));
+                        VM_NEXT();
+                    }
+                    else if (!h->metatable)
+                    {
+                        // fast-path: value is not in expected slot, but the table lookup doesn't involve metatable
+                        const TValue* res = luaH_getstr(h, tsvalue(kv));
+
+                        if (res != luaO_nilobject)
+                        {
+                            int cachedslot = gval2slot(h, res);
+                            // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                            VM_PATCH_C(pc - 2, cachedslot);
+                        }
+
+                        setobj2s(L, ra, res);
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke Lua calls via __index metamethod
+                        L->cachedslot = slot;
+                        VM_PROTECT(luaV_gettable(L, rb, kv, ra));
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, L->cachedslot);
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // fast-path: user data with C __index TM
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = fasttm(L, uvalue(rb)->metatable, TM_INDEX)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, kv);
+                        L->top = top + 3;
+
+                        L->cachedslot = LUAU_INSN_C(insn);
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, L->cachedslot);
+                        VM_NEXT();
+                    }
+                    else if (ttisvector(rb))
+                    {
+                        // fast-path: quick case-insensitive comparison with "X"/"Y"/"Z"
+                        const char* name = getstr(tsvalue(kv));
+                        int ic = (name[0] | ' ') - 'x';
+
+#if LUA_VECTOR_SIZE == 4
+                        // 'w' is before 'x' in ascii, so ic is -1 when indexing with 'w'
+                        if (ic == -1)
+                            ic = 3;
+#endif
+
+                        if (unsigned(ic) < LUA_VECTOR_SIZE && name[1] == '\0')
+                        {
+                            const float* v = vvalue(rb); // silences ubsan when indexing v[]
+                            setnvalue(ra, v[ic]);
+                            VM_NEXT();
+                        }
+
+                        fn = fasttm(L, L->global->mt[LUA_TVECTOR], TM_INDEX);
+
+                        if (fn && ttisfunction(fn) && clvalue(fn)->isC)
+                        {
+                            // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                            LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                            StkId top = L->top;
+                            setobj2s(L, top + 0, fn);
+                            setobj2s(L, top + 1, rb);
+                            setobj2s(L, top + 2, kv);
+                            L->top = top + 3;
+
+                            L->cachedslot = LUAU_INSN_C(insn);
+                            VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                            // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                            VM_PATCH_C(pc - 2, L->cachedslot);
+                            VM_NEXT();
+                        }
+
+                        // fall through to slow path
+                    }
+
+                    // fall through to slow path
+                }
+
+                // slow-path, may invoke Lua calls via __index metamethod
+                VM_PROTECT(luaV_gettable(L, rb, kv, ra));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_SETTABLEKS)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+                LUAU_ASSERT(ttisstring(kv));
+
+                // fast-path: built-in table
+                if (LUAU_LIKELY(ttistable(rb)))
+                {
+                    Table* h = hvalue(rb);
+
+                    int slot = LUAU_INSN_C(insn) & h->nodemask8;
+                    LuaNode* n = &h->node[slot];
+
+                    // fast-path: value is in expected slot
+                    if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n)) && !h->readonly))
+                    {
+                        setobj2t(L, gval(n), ra);
+                        luaC_barriert(L, h, ra);
+                        VM_NEXT();
+                    }
+                    else if (fastnotm(h->metatable, TM_NEWINDEX) && !h->readonly)
+                    {
+                        VM_PROTECT_PC(); // set may fail
+
+                        TValue* res = luaH_setstr(L, h, tsvalue(kv));
+                        int cachedslot = gval2slot(h, res);
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, cachedslot);
+                        setobj2t(L, res, ra);
+                        luaC_barriert(L, h, ra);
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke Lua calls via __newindex metamethod
+                        L->cachedslot = slot;
+                        VM_PROTECT(luaV_settable(L, rb, kv, ra));
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, L->cachedslot);
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // fast-path: user data with C __newindex TM
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = fasttm(L, uvalue(rb)->metatable, TM_NEWINDEX)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 4 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, kv);
+                        setobj2s(L, top + 3, ra);
+                        L->top = top + 4;
+
+                        L->cachedslot = LUAU_INSN_C(insn);
+                        VM_PROTECT(luaV_callTM(L, 3, -1));
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, L->cachedslot);
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke Lua calls via __newindex metamethod
+                        VM_PROTECT(luaV_settable(L, rb, kv, ra));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_GETTABLE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path: array lookup
+                if (ttistable(rb) && ttisnumber(rc))
+                {
+                    Table* h = hvalue(rb);
+
+                    double indexd = nvalue(rc);
+                    int index = int(indexd);
+
+                    // index has to be an exact integer and in-bounds for the array portion
+                    if (LUAU_LIKELY(unsigned(index - 1) < unsigned(h->sizearray) && !h->metatable && double(index) == indexd))
+                    {
+                        setobj2s(L, ra, &h->array[unsigned(index - 1)]);
+                        VM_NEXT();
+                    }
+
+                    // fall through to slow path
+                }
+
+                // slow-path: handles out of bounds array lookups, non-integer numeric keys, non-array table lookup, __index MT calls
+                VM_PROTECT(luaV_gettable(L, rb, rc, ra));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_SETTABLE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path: array assign
+                if (ttistable(rb) && ttisnumber(rc))
+                {
+                    Table* h = hvalue(rb);
+
+                    double indexd = nvalue(rc);
+                    int index = int(indexd);
+
+                    // index has to be an exact integer and in-bounds for the array portion
+                    if (LUAU_LIKELY(unsigned(index - 1) < unsigned(h->sizearray) && !h->metatable && !h->readonly && double(index) == indexd))
+                    {
+                        setobj2t(L, &h->array[unsigned(index - 1)], ra);
+                        luaC_barriert(L, h, ra);
+                        VM_NEXT();
+                    }
+
+                    // fall through to slow path
+                }
+
+                // slow-path: handles out of bounds array assignments, non-integer numeric keys, non-array table access, __newindex MT calls
+                VM_PROTECT(luaV_settable(L, rb, rc, ra));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_GETTABLEN)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                int c = LUAU_INSN_C(insn);
+
+                // fast-path: array lookup
+                if (ttistable(rb))
+                {
+                    Table* h = hvalue(rb);
+
+                    if (LUAU_LIKELY(unsigned(c) < unsigned(h->sizearray) && !h->metatable))
+                    {
+                        setobj2s(L, ra, &h->array[c]);
+                        VM_NEXT();
+                    }
+
+                    // fall through to slow path
+                }
+
+                // slow-path: handles out of bounds array lookups
+                TValue n;
+                setnvalue(&n, c + 1);
+                VM_PROTECT(luaV_gettable(L, rb, &n, ra));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_SETTABLEN)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                int c = LUAU_INSN_C(insn);
+
+                // fast-path: array assign
+                if (ttistable(rb))
+                {
+                    Table* h = hvalue(rb);
+
+                    if (LUAU_LIKELY(unsigned(c) < unsigned(h->sizearray) && !h->metatable && !h->readonly))
+                    {
+                        setobj2t(L, &h->array[c], ra);
+                        luaC_barriert(L, h, ra);
+                        VM_NEXT();
+                    }
+
+                    // fall through to slow path
+                }
+
+                // slow-path: handles out of bounds array lookups
+                TValue n;
+                setnvalue(&n, c + 1);
+                VM_PROTECT(luaV_settable(L, rb, &n, ra));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_NEWCLOSURE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                Proto* pv = cl->l.p->p[LUAU_INSN_D(insn)];
+                LUAU_ASSERT(unsigned(LUAU_INSN_D(insn)) < unsigned(cl->l.p->sizep));
+
+                VM_PROTECT_PC(); // luaF_newLclosure may fail due to OOM
+
+                // note: we save closure to stack early in case the code below wants to capture it by value
+                Closure* ncl = luaF_newLclosure(L, pv->nups, cl->env, pv);
+                setclvalue(L, ra, ncl);
+
+                for (int ui = 0; ui < pv->nups; ++ui)
+                {
+                    Instruction uinsn = *pc++;
+                    LUAU_ASSERT(LUAU_INSN_OP(uinsn) == LOP_CAPTURE);
+
+                    switch (LUAU_INSN_A(uinsn))
+                    {
+                    case LCT_VAL:
+                        setobj(L, &ncl->l.uprefs[ui], VM_REG(LUAU_INSN_B(uinsn)));
+                        break;
+
+                    case LCT_REF:
+                        setupvalue(L, &ncl->l.uprefs[ui], luaF_findupval(L, VM_REG(LUAU_INSN_B(uinsn))));
+                        break;
+
+                    case LCT_UPVAL:
+                        setobj(L, &ncl->l.uprefs[ui], VM_UV(LUAU_INSN_B(uinsn)));
+                        break;
+
+                    default:
+                        LUAU_ASSERT(!"Unknown upvalue capture type");
+                        LUAU_UNREACHABLE(); // improves switch() codegen by eliding opcode bounds checks
+                    }
+                }
+
+                VM_PROTECT(luaC_checkGC(L));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_NAMECALL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+                LUAU_ASSERT(ttisstring(kv));
+
+                if (LUAU_LIKELY(ttistable(rb)))
+                {
+                    Table* h = hvalue(rb);
+                    // note: we can't use nodemask8 here because we need to query the main position of the table, and 8-bit nodemask8 only works
+                    // for predictive lookups
+                    LuaNode* n = &h->node[tsvalue(kv)->hash & (sizenode(h) - 1)];
+
+                    const TValue* mt = 0;
+                    const LuaNode* mtn = 0;
+
+                    // fast-path: key is in the table in expected slot
+                    if (ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n)))
+                    {
+                        // note: order of copies allows rb to alias ra+1 or ra
+                        setobj2s(L, ra + 1, rb);
+                        setobj2s(L, ra, gval(n));
+                    }
+                    // fast-path: key is absent from the base, table has an __index table, and it has the result in the expected slot
+                    else if (gnext(n) == 0 && (mt = fasttm(L, hvalue(rb)->metatable, TM_INDEX)) && ttistable(mt) &&
+                             (mtn = &hvalue(mt)->node[LUAU_INSN_C(insn) & hvalue(mt)->nodemask8]) && ttisstring(gkey(mtn)) &&
+                             tsvalue(gkey(mtn)) == tsvalue(kv) && !ttisnil(gval(mtn)))
+                    {
+                        // note: order of copies allows rb to alias ra+1 or ra
+                        setobj2s(L, ra + 1, rb);
+                        setobj2s(L, ra, gval(mtn));
+                    }
+                    else
+                    {
+                        // slow-path: handles full table lookup
+                        setobj2s(L, ra + 1, rb);
+                        L->cachedslot = LUAU_INSN_C(insn);
+                        VM_PROTECT(luaV_gettable(L, rb, kv, ra));
+                        // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                        VM_PATCH_C(pc - 2, L->cachedslot);
+                        // recompute ra since stack might have been reallocated
+                        ra = VM_REG(LUAU_INSN_A(insn));
+                        if (ttisnil(ra))
+                            luaG_methoderror(L, ra + 1, tsvalue(kv));
+                    }
+                }
+                else
+                {
+                    Table* mt = ttisuserdata(rb) ? uvalue(rb)->metatable : L->global->mt[ttype(rb)];
+                    const TValue* tmi = 0;
+
+                    // fast-path: metatable with __namecall
+                    if (const TValue* fn = fasttm(L, mt, TM_NAMECALL))
+                    {
+                        // note: order of copies allows rb to alias ra+1 or ra
+                        setobj2s(L, ra + 1, rb);
+                        setobj2s(L, ra, fn);
+
+                        L->namecall = tsvalue(kv);
+                    }
+                    else if ((tmi = fasttm(L, mt, TM_INDEX)) && ttistable(tmi))
+                    {
+                        Table* h = hvalue(tmi);
+                        int slot = LUAU_INSN_C(insn) & h->nodemask8;
+                        LuaNode* n = &h->node[slot];
+
+                        // fast-path: metatable with __index that has method in expected slot
+                        if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n))))
+                        {
+                            // note: order of copies allows rb to alias ra+1 or ra
+                            setobj2s(L, ra + 1, rb);
+                            setobj2s(L, ra, gval(n));
+                        }
+                        else
+                        {
+                            // slow-path: handles slot mismatch
+                            setobj2s(L, ra + 1, rb);
+                            L->cachedslot = slot;
+                            VM_PROTECT(luaV_gettable(L, rb, kv, ra));
+                            // save cachedslot to accelerate future lookups; patches currently executing instruction since pc-2 rolls back two pc++
+                            VM_PATCH_C(pc - 2, L->cachedslot);
+                            // recompute ra since stack might have been reallocated
+                            ra = VM_REG(LUAU_INSN_A(insn));
+                            if (ttisnil(ra))
+                                luaG_methoderror(L, ra + 1, tsvalue(kv));
+                        }
+                    }
+                    else
+                    {
+                        // slow-path: handles non-table __index
+                        setobj2s(L, ra + 1, rb);
+                        VM_PROTECT(luaV_gettable(L, rb, kv, ra));
+                        // recompute ra since stack might have been reallocated
+                        ra = VM_REG(LUAU_INSN_A(insn));
+                        if (ttisnil(ra))
+                            luaG_methoderror(L, ra + 1, tsvalue(kv));
+                    }
+                }
+
+                // intentional fallthrough to CALL
+                LUAU_ASSERT(LUAU_INSN_OP(*pc) == LOP_CALL);
+            }
+
+            VM_CASE(LOP_CALL)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                int nparams = LUAU_INSN_B(insn) - 1;
+                int nresults = LUAU_INSN_C(insn) - 1;
+
+                StkId argtop = L->top;
+                argtop = (nparams == LUA_MULTRET) ? argtop : ra + 1 + nparams;
+
+                // slow-path: not a function call
+                if (LUAU_UNLIKELY(!ttisfunction(ra)))
+                {
+                    VM_PROTECT_PC(); // luaV_tryfuncTM may fail
+
+                    luaV_tryfuncTM(L, ra);
+                    argtop++; // __call adds an extra self
+                }
+
+                Closure* ccl = clvalue(ra);
+                L->ci->savedpc = pc;
+
+                CallInfo* ci = incr_ci(L);
+                ci->func = ra;
+                ci->base = ra + 1;
+                ci->top = argtop + ccl->stacksize; // note: technically UB since we haven't reallocated the stack yet
+                ci->savedpc = NULL;
+                ci->flags = 0;
+                ci->nresults = nresults;
+
+                L->base = ci->base;
+                L->top = argtop;
+
+                // note: this reallocs stack, but we don't need to VM_PROTECT this
+                // this is because we're going to modify base/savedpc manually anyhow
+                // crucially, we can't use ra/argtop after this line
+                luaD_checkstack(L, ccl->stacksize);
+
+                LUAU_ASSERT(ci->top <= L->stack_last);
+
+                if (!ccl->isC)
+                {
+                    Proto* p = ccl->l.p;
+
+                    // fill unused parameters with nil
+                    StkId argi = L->top;
+                    StkId argend = L->base + p->numparams;
+                    while (argi < argend)
+                        setnilvalue(argi++); // complete missing arguments
+                    L->top = p->is_vararg ? argi : ci->top;
+
+                    // reentry
+                    // codeentry may point to NATIVECALL instruction when proto is compiled to native code
+                    // this will result in execution continuing in native code, and is equivalent to if (p->execdata) but has no additional overhead
+                    // note that p->codeentry may point *outside* of p->code..p->code+p->sizecode, but that pointer never gets saved to savedpc.
+                    pc = SingleStep ? p->code : p->codeentry;
+                    cl = ccl;
+                    base = L->base;
+                    k = p->k;
+                    VM_NEXT();
+                }
+                else
+                {
+                    lua_CFunction func = ccl->c.f;
+                    int n = func(L);
+
+                    // yield
+                    if (n < 0)
+                        goto exit;
+
+                    // ci is our callinfo, cip is our parent
+                    CallInfo* ci = L->ci;
+                    CallInfo* cip = ci - 1;
+
+                    // copy return values into parent stack (but only up to nresults!), fill the rest with nil
+                    // note: in MULTRET context nresults starts as -1 so i != 0 condition never activates intentionally
+                    StkId res = ci->func;
+                    StkId vali = L->top - n;
+                    StkId valend = L->top;
+
+                    int i;
+                    for (i = nresults; i != 0 && vali < valend; i--)
+                        setobj2s(L, res++, vali++);
+                    while (i-- > 0)
+                        setnilvalue(res++);
+
+                    // pop the stack frame
+                    L->ci = cip;
+                    L->base = cip->base;
+                    L->top = (nresults == LUA_MULTRET) ? res : cip->top;
+
+                    base = L->base; // stack may have been reallocated, so we need to refresh base ptr
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_RETURN)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+                StkId ra = &base[LUAU_INSN_A(insn)]; // note: this can point to L->top if b == LUA_MULTRET making VM_REG unsafe to use
+                int b = LUAU_INSN_B(insn) - 1;
+
+                // ci is our callinfo, cip is our parent
+                CallInfo* ci = L->ci;
+                CallInfo* cip = ci - 1;
+
+                StkId res = ci->func; // note: we assume CALL always puts func+args and expects results to start at func
+
+                StkId vali = ra;
+                StkId valend =
+                    (b == LUA_MULTRET) ? L->top : ra + b; // copy as much as possible for MULTRET calls, and only as much as needed otherwise
+
+                int nresults = ci->nresults;
+
+                // copy return values into parent stack (but only up to nresults!), fill the rest with nil
+                // note: in MULTRET context nresults starts as -1 so i != 0 condition never activates intentionally
+                int i;
+                for (i = nresults; i != 0 && vali < valend; i--)
+                    setobj2s(L, res++, vali++);
+                while (i-- > 0)
+                    setnilvalue(res++);
+
+                // pop the stack frame
+                L->ci = cip;
+                L->base = cip->base;
+                L->top = (nresults == LUA_MULTRET) ? res : cip->top;
+
+                // we're done!
+                if (LUAU_UNLIKELY(ci->flags & LUA_CALLINFO_RETURN))
+                {
+                    goto exit;
+                }
+
+                LUAU_ASSERT(isLua(L->ci));
+
+                Closure* nextcl = clvalue(cip->func);
+                Proto* nextproto = nextcl->l.p;
+
+#if VM_HAS_NATIVE
+                if (LUAU_UNLIKELY((cip->flags & LUA_CALLINFO_NATIVE) && !SingleStep))
+                {
+                    if (L->global->ecb.enter(L, nextproto) == 1)
+                        goto reentry;
+                    else
+                        goto exit;
+                }
+#endif
+
+                // reentry
+                pc = cip->savedpc;
+                cl = nextcl;
+                base = L->base;
+                k = nextproto->k;
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMP)
+            {
+                Instruction insn = *pc++;
+
+                pc += LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPIF)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                pc += l_isfalse(ra) ? 0 : LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPIFNOT)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                pc += l_isfalse(ra) ? LUAU_INSN_D(insn) : 0;
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPIFEQ)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // Note that all jumps below jump by 1 in the "false" case to skip over aux
+                if (ttype(ra) == ttype(rb))
+                {
+                    switch (ttype(ra))
+                    {
+                    case LUA_TNIL:
+                        pc += LUAU_INSN_D(insn);
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TBOOLEAN:
+                        pc += bvalue(ra) == bvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TLIGHTUSERDATA:
+                        pc += (pvalue(ra) == pvalue(rb) && (!FFlag::TaggedLuData || lightuserdatatag(ra) == lightuserdatatag(rb))) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TNUMBER:
+                        pc += nvalue(ra) == nvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TVECTOR:
+                        pc += luai_veceq(vvalue(ra), vvalue(rb)) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TSTRING:
+                    case LUA_TFUNCTION:
+                    case LUA_TTHREAD:
+                    case LUA_TBUFFER:
+                        pc += gcvalue(ra) == gcvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TTABLE:
+                        // fast-path: same metatable, no EQ metamethod
+                        if (hvalue(ra)->metatable == hvalue(rb)->metatable)
+                        {
+                            const TValue* fn = fasttm(L, hvalue(ra)->metatable, TM_EQ);
+
+                            if (!fn)
+                            {
+                                pc += hvalue(ra) == hvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                        }
+                        // slow path after switch()
+                        break;
+
+                    case LUA_TUSERDATA:
+                        // fast-path: same metatable, no EQ metamethod or C metamethod
+                        if (uvalue(ra)->metatable == uvalue(rb)->metatable)
+                        {
+                            const TValue* fn = fasttm(L, uvalue(ra)->metatable, TM_EQ);
+
+                            if (!fn)
+                            {
+                                pc += uvalue(ra) == uvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                            else if (ttisfunction(fn) && clvalue(fn)->isC)
+                            {
+                                // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                                LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                                StkId top = L->top;
+                                setobj2s(L, top + 0, fn);
+                                setobj2s(L, top + 1, ra);
+                                setobj2s(L, top + 2, rb);
+                                int res = int(top - base);
+                                L->top = top + 3;
+
+                                VM_PROTECT(luaV_callTM(L, 2, res));
+                                pc += !l_isfalse(&base[res]) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                        }
+                        // slow path after switch()
+                        break;
+
+                    default:
+                        LUAU_ASSERT(!"Unknown value type");
+                        LUAU_UNREACHABLE(); // improves switch() codegen by eliding opcode bounds checks
+                    }
+
+                    // slow-path: tables with metatables and userdata values
+                    // note that we don't have a fast path for userdata values without metatables, since that's very rare
+                    int res;
+                    VM_PROTECT(res = luaV_equalval(L, ra, rb));
+
+                    pc += (res == 1) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    pc += 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_JUMPIFNOTEQ)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // Note that all jumps below jump by 1 in the "true" case to skip over aux
+                if (ttype(ra) == ttype(rb))
+                {
+                    switch (ttype(ra))
+                    {
+                    case LUA_TNIL:
+                        pc += 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TBOOLEAN:
+                        pc += bvalue(ra) != bvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TLIGHTUSERDATA:
+                        pc += (pvalue(ra) != pvalue(rb) || (FFlag::TaggedLuData && lightuserdatatag(ra) != lightuserdatatag(rb))) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TNUMBER:
+                        pc += nvalue(ra) != nvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TVECTOR:
+                        pc += !luai_veceq(vvalue(ra), vvalue(rb)) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TSTRING:
+                    case LUA_TFUNCTION:
+                    case LUA_TTHREAD:
+                    case LUA_TBUFFER:
+                        pc += gcvalue(ra) != gcvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+
+                    case LUA_TTABLE:
+                        // fast-path: same metatable, no EQ metamethod
+                        if (hvalue(ra)->metatable == hvalue(rb)->metatable)
+                        {
+                            const TValue* fn = fasttm(L, hvalue(ra)->metatable, TM_EQ);
+
+                            if (!fn)
+                            {
+                                pc += hvalue(ra) != hvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                        }
+                        // slow path after switch()
+                        break;
+
+                    case LUA_TUSERDATA:
+                        // fast-path: same metatable, no EQ metamethod or C metamethod
+                        if (uvalue(ra)->metatable == uvalue(rb)->metatable)
+                        {
+                            const TValue* fn = fasttm(L, uvalue(ra)->metatable, TM_EQ);
+
+                            if (!fn)
+                            {
+                                pc += uvalue(ra) != uvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                            else if (ttisfunction(fn) && clvalue(fn)->isC)
+                            {
+                                // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                                LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                                StkId top = L->top;
+                                setobj2s(L, top + 0, fn);
+                                setobj2s(L, top + 1, ra);
+                                setobj2s(L, top + 2, rb);
+                                int res = int(top - base);
+                                L->top = top + 3;
+
+                                VM_PROTECT(luaV_callTM(L, 2, res));
+                                pc += l_isfalse(&base[res]) ? LUAU_INSN_D(insn) : 1;
+                                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                                VM_NEXT();
+                            }
+                        }
+                        // slow path after switch()
+                        break;
+
+                    default:
+                        LUAU_ASSERT(!"Unknown value type");
+                        LUAU_UNREACHABLE(); // improves switch() codegen by eliding opcode bounds checks
+                    }
+
+                    // slow-path: tables with metatables and userdata values
+                    // note that we don't have a fast path for userdata values without metatables, since that's very rare
+                    int res;
+                    VM_PROTECT(res = luaV_equalval(L, ra, rb));
+
+                    pc += (res == 0) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    pc += LUAU_INSN_D(insn);
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_JUMPIFLE)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // fast-path: number
+                // Note that all jumps below jump by 1 in the "false" case to skip over aux
+                if (LUAU_LIKELY(ttisnumber(ra) && ttisnumber(rb)))
+                {
+                    pc += nvalue(ra) <= nvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                // fast-path: string
+                else if (ttisstring(ra) && ttisstring(rb))
+                {
+                    pc += luaV_strcmp(tsvalue(ra), tsvalue(rb)) <= 0 ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    int res;
+                    VM_PROTECT(res = luaV_lessequal(L, ra, rb));
+
+                    pc += (res == 1) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_JUMPIFNOTLE)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // fast-path: number
+                // Note that all jumps below jump by 1 in the "true" case to skip over aux
+                if (LUAU_LIKELY(ttisnumber(ra) && ttisnumber(rb)))
+                {
+                    pc += !(nvalue(ra) <= nvalue(rb)) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                // fast-path: string
+                else if (ttisstring(ra) && ttisstring(rb))
+                {
+                    pc += !(luaV_strcmp(tsvalue(ra), tsvalue(rb)) <= 0) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    int res;
+                    VM_PROTECT(res = luaV_lessequal(L, ra, rb));
+
+                    pc += (res == 0) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_JUMPIFLT)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // fast-path: number
+                // Note that all jumps below jump by 1 in the "false" case to skip over aux
+                if (LUAU_LIKELY(ttisnumber(ra) && ttisnumber(rb)))
+                {
+                    pc += nvalue(ra) < nvalue(rb) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                // fast-path: string
+                else if (ttisstring(ra) && ttisstring(rb))
+                {
+                    pc += luaV_strcmp(tsvalue(ra), tsvalue(rb)) < 0 ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    int res;
+                    VM_PROTECT(res = luaV_lessthan(L, ra, rb));
+
+                    pc += (res == 1) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_JUMPIFNOTLT)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(aux);
+
+                // fast-path: number
+                // Note that all jumps below jump by 1 in the "true" case to skip over aux
+                if (LUAU_LIKELY(ttisnumber(ra) && ttisnumber(rb)))
+                {
+                    pc += !(nvalue(ra) < nvalue(rb)) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                // fast-path: string
+                else if (ttisstring(ra) && ttisstring(rb))
+                {
+                    pc += !(luaV_strcmp(tsvalue(ra), tsvalue(rb)) < 0) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    int res;
+                    VM_PROTECT(res = luaV_lessthan(L, ra, rb));
+
+                    pc += (res == 0) ? LUAU_INSN_D(insn) : 1;
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_ADD)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb) && ttisnumber(rc)))
+                {
+                    setnvalue(ra, nvalue(rb) + nvalue(rc));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisvector(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_ADD)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, rc);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_ADD));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_SUB)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb) && ttisnumber(rc)))
+                {
+                    setnvalue(ra, nvalue(rb) - nvalue(rc));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisvector(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_SUB)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, rc);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_SUB));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_MUL)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb) && ttisnumber(rc)))
+                {
+                    setnvalue(ra, nvalue(rb) * nvalue(rc));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisnumber(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    float vc = cast_to(float, nvalue(rc));
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisvector(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
+                    VM_NEXT();
+                }
+                else if (ttisnumber(rb) && ttisvector(rc))
+                {
+                    float vb = cast_to(float, nvalue(rb));
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2], vb * vc[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    StkId rbc = ttisnumber(rb) ? rc : rb;
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rbc) && (fn = luaT_gettmbyobj(L, rbc, TM_MUL)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, rc);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_MUL));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_DIV)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb) && ttisnumber(rc)))
+                {
+                    setnvalue(ra, nvalue(rb) / nvalue(rc));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisnumber(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    float vc = cast_to(float, nvalue(rc));
+                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisvector(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
+                    VM_NEXT();
+                }
+                else if (ttisnumber(rb) && ttisvector(rc))
+                {
+                    float vb = cast_to(float, nvalue(rb));
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2], vb / vc[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    StkId rbc = ttisnumber(rb) ? rc : rb;
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rbc) && (fn = luaT_gettmbyobj(L, rbc, TM_DIV)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, rc);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_DIV));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_IDIV)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb) && ttisnumber(rc)))
+                {
+                    setnvalue(ra, luai_numidiv(nvalue(rb), nvalue(rc)));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb) && ttisnumber(rc))
+                {
+                    const float* vb = vvalue(rb);
+                    float vc = cast_to(float, nvalue(rc));
+                    setvvalue(ra, float(luai_numidiv(vb[0], vc)), float(luai_numidiv(vb[1], vc)), float(luai_numidiv(vb[2], vc)),
+                        float(luai_numidiv(vb[3], vc)));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    StkId rbc = ttisnumber(rb) ? rc : rb;
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rbc) && (fn = luaT_gettmbyobj(L, rbc, TM_IDIV)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, rc);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_IDIV));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_MOD)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb) && ttisnumber(rc))
+                {
+                    double nb = nvalue(rb);
+                    double nc = nvalue(rc);
+                    setnvalue(ra, luai_nummod(nb, nc));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_MOD));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_POW)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb) && ttisnumber(rc))
+                {
+                    setnvalue(ra, pow(nvalue(rb), nvalue(rc)));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, rc, TM_POW));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_ADDK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb))
+                {
+                    setnvalue(ra, nvalue(rb) + nvalue(kv));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_ADD));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_SUBK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb))
+                {
+                    setnvalue(ra, nvalue(rb) - nvalue(kv));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_SUB));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_MULK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb)))
+                {
+                    setnvalue(ra, nvalue(rb) * nvalue(kv));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb))
+                {
+                    const float* vb = vvalue(rb);
+                    float vc = cast_to(float, nvalue(kv));
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_MUL)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, kv);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_MUL));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_DIVK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb)))
+                {
+                    setnvalue(ra, nvalue(rb) / nvalue(kv));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb))
+                {
+                    const float* vb = vvalue(rb);
+                    float nc = cast_to(float, nvalue(kv));
+                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc, vb[3] / nc);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_DIV)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, kv);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_DIV));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_IDIVK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb)))
+                {
+                    setnvalue(ra, luai_numidiv(nvalue(rb), nvalue(kv)));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb))
+                {
+                    const float* vb = vvalue(rb);
+                    float vc = cast_to(float, nvalue(kv));
+                    setvvalue(ra, float(luai_numidiv(vb[0], vc)), float(luai_numidiv(vb[1], vc)), float(luai_numidiv(vb[2], vc)),
+                        float(luai_numidiv(vb[3], vc)));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_IDIV)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 3 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        setobj2s(L, top + 2, kv);
+                        L->top = top + 3;
+
+                        VM_PROTECT(luaV_callTM(L, 2, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_IDIV));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_MODK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb))
+                {
+                    double nb = nvalue(rb);
+                    double nk = nvalue(kv);
+                    setnvalue(ra, luai_nummod(nb, nk));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_MOD));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_POWK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rb))
+                {
+                    double nb = nvalue(rb);
+                    double nk = nvalue(kv);
+
+                    // pow is very slow so we specialize this for ^2, ^0.5 and ^3
+                    double r = (nk == 2.0) ? nb * nb : (nk == 0.5) ? sqrt(nb) : (nk == 3.0) ? nb * nb * nb : pow(nb, nk);
+
+                    setnvalue(ra, r);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, rb, kv, TM_POW));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_AND)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                setobj2s(L, ra, l_isfalse(rb) ? rb : rc);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_OR)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                setobj2s(L, ra, l_isfalse(rb) ? rc : rb);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_ANDK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                setobj2s(L, ra, l_isfalse(rb) ? rb : kv);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_ORK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+                TValue* kv = VM_KV(LUAU_INSN_C(insn));
+
+                setobj2s(L, ra, l_isfalse(rb) ? kv : rb);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_CONCAT)
+            {
+                Instruction insn = *pc++;
+                int b = LUAU_INSN_B(insn);
+                int c = LUAU_INSN_C(insn);
+
+                // This call may realloc the stack! So we need to query args further down
+                VM_PROTECT(luaV_concat(L, c - b + 1, c));
+
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                setobj2s(L, ra, base + b);
+                VM_PROTECT(luaC_checkGC(L));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_NOT)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+
+                int res = l_isfalse(rb);
+                setbvalue(ra, res);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_MINUS)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rb)))
+                {
+                    setnvalue(ra, -nvalue(rb));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rb))
+                {
+                    const float* vb = vvalue(rb);
+                    setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fast-path for userdata with C functions
+                    const TValue* fn = 0;
+                    if (ttisuserdata(rb) && (fn = luaT_gettmbyobj(L, rb, TM_UNM)) && ttisfunction(fn) && clvalue(fn)->isC)
+                    {
+                        // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                        LUAU_ASSERT(L->top + 2 < L->stack + L->stacksize);
+                        StkId top = L->top;
+                        setobj2s(L, top + 0, fn);
+                        setobj2s(L, top + 1, rb);
+                        L->top = top + 2;
+
+                        VM_PROTECT(luaV_callTM(L, 1, LUAU_INSN_A(insn)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_doarith(L, ra, rb, rb, TM_UNM));
+                        VM_NEXT();
+                    }
+                }
+            }
+
+            VM_CASE(LOP_LENGTH)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = VM_REG(LUAU_INSN_B(insn));
+
+                // fast-path #1: tables
+                if (LUAU_LIKELY(ttistable(rb)))
+                {
+                    Table* h = hvalue(rb);
+
+                    if (fastnotm(h->metatable, TM_LEN))
+                    {
+                        setnvalue(ra, cast_num(luaH_getn(h)));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // slow-path, may invoke C/Lua via metamethods
+                        VM_PROTECT(luaV_dolen(L, ra, rb));
+                        VM_NEXT();
+                    }
+                }
+                // fast-path #2: strings (not very important but easy to do)
+                else if (ttisstring(rb))
+                {
+                    TString* ts = tsvalue(rb);
+                    setnvalue(ra, cast_num(ts->len));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_dolen(L, ra, rb));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_NEWTABLE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                int b = LUAU_INSN_B(insn);
+                uint32_t aux = *pc++;
+
+                VM_PROTECT_PC(); // luaH_new may fail due to OOM
+
+                sethvalue(L, ra, luaH_new(L, aux, b == 0 ? 0 : (1 << (b - 1))));
+                VM_PROTECT(luaC_checkGC(L));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_DUPTABLE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_D(insn));
+
+                VM_PROTECT_PC(); // luaH_clone may fail due to OOM
+
+                sethvalue(L, ra, luaH_clone(L, hvalue(kv)));
+                VM_PROTECT(luaC_checkGC(L));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_SETLIST)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                StkId rb = &base[LUAU_INSN_B(insn)]; // note: this can point to L->top if c == LUA_MULTRET making VM_REG unsafe to use
+                int c = LUAU_INSN_C(insn) - 1;
+                uint32_t index = *pc++;
+
+                if (c == LUA_MULTRET)
+                {
+                    c = int(L->top - rb);
+                    L->top = L->ci->top;
+                }
+
+                Table* h = hvalue(ra);
+
+                // TODO: we really don't need this anymore
+                if (!ttistable(ra))
+                    return; // temporary workaround to weaken a rather powerful exploitation primitive in case of a MITM attack on bytecode
+
+                int last = index + c - 1;
+                if (last > h->sizearray)
+                {
+                    VM_PROTECT_PC(); // luaH_resizearray may fail due to OOM
+
+                    luaH_resizearray(L, h, last);
+                }
+
+                TValue* array = h->array;
+
+                for (int i = 0; i < c; ++i)
+                    setobj2t(L, &array[index + i - 1], rb + i);
+
+                luaC_barrierfast(L, h);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_FORNPREP)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                if (!ttisnumber(ra + 0) || !ttisnumber(ra + 1) || !ttisnumber(ra + 2))
+                {
+                    // slow-path: can convert arguments to numbers and trigger Lua errors
+                    // Note: this doesn't reallocate stack so we don't need to recompute ra/base
+                    VM_PROTECT_PC();
+
+                    luaV_prepareFORN(L, ra + 0, ra + 1, ra + 2);
+                }
+
+                double limit = nvalue(ra + 0);
+                double step = nvalue(ra + 1);
+                double idx = nvalue(ra + 2);
+
+                // Note: make sure the loop condition is exactly the same between this and LOP_FORNLOOP so that we handle NaN/etc. consistently
+                pc += (step > 0 ? idx <= limit : limit <= idx) ? 0 : LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_FORNLOOP)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                LUAU_ASSERT(ttisnumber(ra + 0) && ttisnumber(ra + 1) && ttisnumber(ra + 2));
+
+                double limit = nvalue(ra + 0);
+                double step = nvalue(ra + 1);
+                double idx = nvalue(ra + 2) + step;
+
+                setnvalue(ra + 2, idx);
+
+                // Note: make sure the loop condition is exactly the same between this and LOP_FORNPREP so that we handle NaN/etc. consistently
+                if (step > 0 ? idx <= limit : limit <= idx)
+                {
+                    pc += LUAU_INSN_D(insn);
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // fallthrough to exit
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_FORGPREP)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                if (ttisfunction(ra))
+                {
+                    // will be called during FORGLOOP
+                }
+                else
+                {
+                    Table* mt = ttistable(ra) ? hvalue(ra)->metatable : ttisuserdata(ra) ? uvalue(ra)->metatable : cast_to(Table*, NULL);
+
+                    if (const TValue* fn = fasttm(L, mt, TM_ITER))
+                    {
+                        setobj2s(L, ra + 1, ra);
+                        setobj2s(L, ra, fn);
+
+                        L->top = ra + 2; // func + self arg
+                        LUAU_ASSERT(L->top <= L->stack_last);
+
+                        VM_PROTECT(luaD_call(L, ra, 3));
+                        L->top = L->ci->top;
+
+                        // recompute ra since stack might have been reallocated
+                        ra = VM_REG(LUAU_INSN_A(insn));
+
+                        // protect against __iter returning nil, since nil is used as a marker for builtin iteration in FORGLOOP
+                        if (ttisnil(ra))
+                        {
+                            VM_PROTECT_PC(); // next call always errors
+                            luaG_typeerror(L, ra, "call");
+                        }
+                    }
+                    else if (fasttm(L, mt, TM_CALL))
+                    {
+                        // table or userdata with __call, will be called during FORGLOOP
+                        // TODO: we might be able to stop supporting this depending on whether it's used in practice
+                    }
+                    else if (ttistable(ra))
+                    {
+                        // set up registers for builtin iteration
+                        setobj2s(L, ra + 1, ra);
+                        setpvalue(ra + 2, reinterpret_cast<void*>(uintptr_t(0)), LU_TAG_ITERATOR);
+                        setnilvalue(ra);
+                    }
+                    else
+                    {
+                        VM_PROTECT_PC(); // next call always errors
+                        luaG_typeerror(L, ra, "iterate over");
+                    }
+                }
+
+                pc += LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_FORGLOOP)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                uint32_t aux = *pc;
+
+                // fast-path: builtin table iteration
+                // note: ra=nil guarantees ra+1=table and ra+2=userdata because of the setup by FORGPREP* opcodes
+                // TODO: remove the table check per guarantee above
+                if (ttisnil(ra) && ttistable(ra + 1))
+                {
+                    Table* h = hvalue(ra + 1);
+                    int index = int(reinterpret_cast<uintptr_t>(pvalue(ra + 2)));
+
+                    int sizearray = h->sizearray;
+
+                    // clear extra variables since we might have more than two
+                    // note: while aux encodes ipairs bit, when set we always use 2 variables, so it's safe to check this via a signed comparison
+                    if (LUAU_UNLIKELY(int(aux) > 2))
+                        for (int i = 2; i < int(aux); ++i)
+                            setnilvalue(ra + 3 + i);
+
+                    // terminate ipairs-style traversal early when encountering nil
+                    if (int(aux) < 0 && (unsigned(index) >= unsigned(sizearray) || ttisnil(&h->array[index])))
+                    {
+                        pc++;
+                        VM_NEXT();
+                    }
+
+                    // first we advance index through the array portion
+                    while (unsigned(index) < unsigned(sizearray))
+                    {
+                        TValue* e = &h->array[index];
+
+                        if (!ttisnil(e))
+                        {
+                            setpvalue(ra + 2, reinterpret_cast<void*>(uintptr_t(index + 1)), LU_TAG_ITERATOR);
+                            setnvalue(ra + 3, double(index + 1));
+                            setobj2s(L, ra + 4, e);
+
+                            pc += LUAU_INSN_D(insn);
+                            LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                            VM_NEXT();
+                        }
+
+                        index++;
+                    }
+
+                    int sizenode = 1 << h->lsizenode;
+
+                    // then we advance index through the hash portion
+                    while (unsigned(index - sizearray) < unsigned(sizenode))
+                    {
+                        LuaNode* n = &h->node[index - sizearray];
+
+                        if (!ttisnil(gval(n)))
+                        {
+                            setpvalue(ra + 2, reinterpret_cast<void*>(uintptr_t(index + 1)), LU_TAG_ITERATOR);
+                            getnodekey(L, ra + 3, n);
+                            setobj2s(L, ra + 4, gval(n));
+
+                            pc += LUAU_INSN_D(insn);
+                            LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                            VM_NEXT();
+                        }
+
+                        index++;
+                    }
+
+                    // fallthrough to exit
+                    pc++;
+                    VM_NEXT();
+                }
+                else
+                {
+                    // note: it's safe to push arguments past top for complicated reasons (see top of the file)
+                    setobj2s(L, ra + 3 + 2, ra + 2);
+                    setobj2s(L, ra + 3 + 1, ra + 1);
+                    setobj2s(L, ra + 3, ra);
+
+                    L->top = ra + 3 + 3; // func + 2 args (state and index)
+                    LUAU_ASSERT(L->top <= L->stack_last);
+
+                    VM_PROTECT(luaD_call(L, ra + 3, uint8_t(aux)));
+                    L->top = L->ci->top;
+
+                    // recompute ra since stack might have been reallocated
+                    ra = VM_REG(LUAU_INSN_A(insn));
+
+                    // copy first variable back into the iteration index
+                    setobj2s(L, ra + 2, ra + 3);
+
+                    // note that we need to increment pc by 1 to exit the loop since we need to skip over aux
+                    pc += ttisnil(ra + 3) ? 1 : LUAU_INSN_D(insn);
+                    LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_FORGPREP_INEXT)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                // fast-path: ipairs/inext
+                if (cl->env->safeenv && ttistable(ra + 1) && ttisnumber(ra + 2) && nvalue(ra + 2) == 0.0)
+                {
+                    setnilvalue(ra);
+                    // ra+1 is already the table
+                    setpvalue(ra + 2, reinterpret_cast<void*>(uintptr_t(0)), LU_TAG_ITERATOR);
+                }
+                else if (!ttisfunction(ra))
+                {
+                    VM_PROTECT_PC(); // next call always errors
+                    luaG_typeerror(L, ra, "iterate over");
+                }
+
+                pc += LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_DEP_FORGLOOP_INEXT)
+            {
+                LUAU_ASSERT(!"Unsupported deprecated opcode");
+                LUAU_UNREACHABLE();
+            }
+
+            VM_CASE(LOP_FORGPREP_NEXT)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                // fast-path: pairs/next
+                if (cl->env->safeenv && ttistable(ra + 1) && ttisnil(ra + 2))
+                {
+                    setnilvalue(ra);
+                    // ra+1 is already the table
+                    setpvalue(ra + 2, reinterpret_cast<void*>(uintptr_t(0)), LU_TAG_ITERATOR);
+                }
+                else if (!ttisfunction(ra))
+                {
+                    VM_PROTECT_PC(); // next call always errors
+                    luaG_typeerror(L, ra, "iterate over");
+                }
+
+                pc += LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_NATIVECALL)
+            {
+                Proto* p = cl->l.p;
+                LUAU_ASSERT(p->execdata);
+
+                CallInfo* ci = L->ci;
+                ci->flags = LUA_CALLINFO_NATIVE;
+                ci->savedpc = p->code;
+
+#if VM_HAS_NATIVE
+                if (L->global->ecb.enter(L, p) == 1)
+                    goto reentry;
+                else
+                    goto exit;
+#else
+                LUAU_ASSERT(!"Opcode is only valid when VM_HAS_NATIVE is defined");
+                LUAU_UNREACHABLE();
+#endif
+            }
+
+            VM_CASE(LOP_GETVARARGS)
+            {
+                Instruction insn = *pc++;
+                int b = LUAU_INSN_B(insn) - 1;
+                int n = cast_int(base - L->ci->func) - cl->l.p->numparams - 1;
+
+                if (b == LUA_MULTRET)
+                {
+                    VM_PROTECT(luaD_checkstack(L, n));
+                    StkId ra = VM_REG(LUAU_INSN_A(insn)); // previous call may change the stack
+
+                    for (int j = 0; j < n; j++)
+                        setobj2s(L, ra + j, base - n + j);
+
+                    L->top = ra + n;
+                    VM_NEXT();
+                }
+                else
+                {
+                    StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                    for (int j = 0; j < b && j < n; j++)
+                        setobj2s(L, ra + j, base - n + j);
+                    for (int j = n; j < b; j++)
+                        setnilvalue(ra + j);
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_DUPCLOSURE)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_D(insn));
+
+                Closure* kcl = clvalue(kv);
+
+                VM_PROTECT_PC(); // luaF_newLclosure may fail due to OOM
+
+                // clone closure if the environment is not shared
+                // note: we save closure to stack early in case the code below wants to capture it by value
+                Closure* ncl = (kcl->env == cl->env) ? kcl : luaF_newLclosure(L, kcl->nupvalues, cl->env, kcl->l.p);
+                setclvalue(L, ra, ncl);
+
+                // this loop does three things:
+                // - if the closure was created anew, it just fills it with upvalues
+                // - if the closure from the constant table is used, it fills it with upvalues so that it can be shared in the future
+                // - if the closure is reused, it checks if the reuse is safe via rawequal, and falls back to duplicating the closure
+                // normally this would use two separate loops, for reuse check and upvalue setup, but MSVC codegen goes crazy if you do that
+                for (int ui = 0; ui < kcl->nupvalues; ++ui)
+                {
+                    Instruction uinsn = pc[ui];
+                    LUAU_ASSERT(LUAU_INSN_OP(uinsn) == LOP_CAPTURE);
+                    LUAU_ASSERT(LUAU_INSN_A(uinsn) == LCT_VAL || LUAU_INSN_A(uinsn) == LCT_UPVAL);
+
+                    TValue* uv = (LUAU_INSN_A(uinsn) == LCT_VAL) ? VM_REG(LUAU_INSN_B(uinsn)) : VM_UV(LUAU_INSN_B(uinsn));
+
+                    // check if the existing closure is safe to reuse
+                    if (ncl == kcl && luaO_rawequalObj(&ncl->l.uprefs[ui], uv))
+                        continue;
+
+                    // lazily clone the closure and update the upvalues
+                    if (ncl == kcl && kcl->preload == 0)
+                    {
+                        ncl = luaF_newLclosure(L, kcl->nupvalues, cl->env, kcl->l.p);
+                        setclvalue(L, ra, ncl);
+
+                        ui = -1; // restart the loop to fill all upvalues
+                        continue;
+                    }
+
+                    // this updates a newly created closure, or an existing closure created during preload, in which case we need a barrier
+                    setobj(L, &ncl->l.uprefs[ui], uv);
+                    luaC_barrier(L, ncl, uv);
+                }
+
+                // this is a noop if ncl is newly created or shared successfully, but it has to run after the closure is preloaded for the first time
+                ncl->preload = 0;
+
+                if (kcl != ncl)
+                    VM_PROTECT(luaC_checkGC(L));
+
+                pc += kcl->nupvalues;
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_PREPVARARGS)
+            {
+                Instruction insn = *pc++;
+                int numparams = LUAU_INSN_A(insn);
+
+                // all fixed parameters are copied after the top so we need more stack space
+                VM_PROTECT(luaD_checkstack(L, cl->stacksize + numparams));
+
+                // the caller must have filled extra fixed arguments with nil
+                LUAU_ASSERT(cast_int(L->top - base) >= numparams);
+
+                // move fixed parameters to final position
+                StkId fixed = base; // first fixed argument
+                base = L->top;      // final position of first argument
+
+                for (int i = 0; i < numparams; ++i)
+                {
+                    setobj2s(L, base + i, fixed + i);
+                    setnilvalue(fixed + i);
+                }
+
+                // rewire our stack frame to point to the new base
+                L->ci->base = base;
+                L->ci->top = base + cl->stacksize;
+
+                L->base = base;
+                L->top = L->ci->top;
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPBACK)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+
+                pc += LUAU_INSN_D(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_LOADKX)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                uint32_t aux = *pc++;
+                TValue* kv = VM_KV(aux);
+
+                setobj2s(L, ra, kv);
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPX)
+            {
+                VM_INTERRUPT();
+                Instruction insn = *pc++;
+
+                pc += LUAU_INSN_E(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_FASTCALL)
+            {
+                Instruction insn = *pc++;
+                int bfid = LUAU_INSN_A(insn);
+                int skip = LUAU_INSN_C(insn);
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code + skip) < unsigned(cl->l.p->sizecode));
+
+                Instruction call = pc[skip];
+                LUAU_ASSERT(LUAU_INSN_OP(call) == LOP_CALL);
+
+                StkId ra = VM_REG(LUAU_INSN_A(call));
+
+                int nparams = LUAU_INSN_B(call) - 1;
+                int nresults = LUAU_INSN_C(call) - 1;
+
+                nparams = (nparams == LUA_MULTRET) ? int(L->top - ra - 1) : nparams;
+
+                luau_FastFunction f = luauF_table[bfid];
+                LUAU_ASSERT(f);
+
+                if (cl->env->safeenv)
+                {
+                    VM_PROTECT_PC(); // f may fail due to OOM
+
+                    int n = f(L, ra, ra + 1, nresults, ra + 2, nparams);
+
+                    if (n >= 0)
+                    {
+                        // when nresults != MULTRET, L->top might be pointing to the middle of stack frame if nparams is equal to MULTRET
+                        // instead of restoring L->top to L->ci->top if nparams is MULTRET, we do it unconditionally to skip an extra check
+                        L->top = (nresults == LUA_MULTRET) ? ra + n : L->ci->top;
+
+                        pc += skip + 1; // skip instructions that compute function as well as CALL
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // continue execution through the fallback code
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // continue execution through the fallback code
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_COVERAGE)
+            {
+                Instruction insn = *pc++;
+                int hits = LUAU_INSN_E(insn);
+
+                // update hits with saturated add and patch the instruction in place
+                hits = (hits < (1 << 23) - 1) ? hits + 1 : hits;
+                VM_PATCH_E(pc - 1, hits);
+
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_CAPTURE)
+            {
+                LUAU_ASSERT(!"CAPTURE is a pseudo-opcode and must be executed as part of NEWCLOSURE");
+                LUAU_UNREACHABLE();
+            }
+
+            VM_CASE(LOP_SUBRK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (ttisnumber(rc))
+                {
+                    setnvalue(ra, nvalue(kv) - nvalue(rc));
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, kv, rc, TM_SUB));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_DIVRK)
+            {
+                Instruction insn = *pc++;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(LUAU_INSN_B(insn));
+                StkId rc = VM_REG(LUAU_INSN_C(insn));
+
+                // fast-path
+                if (LUAU_LIKELY(ttisnumber(rc)))
+                {
+                    setnvalue(ra, nvalue(kv) / nvalue(rc));
+                    VM_NEXT();
+                }
+                else if (ttisvector(rc))
+                {
+                    float nb = cast_to(float, nvalue(kv));
+                    const float* vc = vvalue(rc);
+                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2], nb / vc[3]);
+                    VM_NEXT();
+                }
+                else
+                {
+                    // slow-path, may invoke C/Lua via metamethods
+                    VM_PROTECT(luaV_doarith(L, ra, kv, rc, TM_DIV));
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_FASTCALL1)
+            {
+                Instruction insn = *pc++;
+                int bfid = LUAU_INSN_A(insn);
+                TValue* arg = VM_REG(LUAU_INSN_B(insn));
+                int skip = LUAU_INSN_C(insn);
+
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code + skip) < unsigned(cl->l.p->sizecode));
+
+                Instruction call = pc[skip];
+                LUAU_ASSERT(LUAU_INSN_OP(call) == LOP_CALL);
+
+                StkId ra = VM_REG(LUAU_INSN_A(call));
+
+                int nparams = 1;
+                int nresults = LUAU_INSN_C(call) - 1;
+
+                luau_FastFunction f = luauF_table[bfid];
+                LUAU_ASSERT(f);
+
+                if (cl->env->safeenv)
+                {
+                    VM_PROTECT_PC(); // f may fail due to OOM
+
+                    int n = f(L, ra, arg, nresults, NULL, nparams);
+
+                    if (n >= 0)
+                    {
+                        if (nresults == LUA_MULTRET)
+                            L->top = ra + n;
+
+                        pc += skip + 1; // skip instructions that compute function as well as CALL
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // continue execution through the fallback code
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // continue execution through the fallback code
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_FASTCALL2)
+            {
+                Instruction insn = *pc++;
+                int bfid = LUAU_INSN_A(insn);
+                int skip = LUAU_INSN_C(insn) - 1;
+                uint32_t aux = *pc++;
+                TValue* arg1 = VM_REG(LUAU_INSN_B(insn));
+                TValue* arg2 = VM_REG(aux);
+
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code + skip) < unsigned(cl->l.p->sizecode));
+
+                Instruction call = pc[skip];
+                LUAU_ASSERT(LUAU_INSN_OP(call) == LOP_CALL);
+
+                StkId ra = VM_REG(LUAU_INSN_A(call));
+
+                int nparams = 2;
+                int nresults = LUAU_INSN_C(call) - 1;
+
+                luau_FastFunction f = luauF_table[bfid];
+                LUAU_ASSERT(f);
+
+                if (cl->env->safeenv)
+                {
+                    VM_PROTECT_PC(); // f may fail due to OOM
+
+                    int n = f(L, ra, arg1, nresults, arg2, nparams);
+
+                    if (n >= 0)
+                    {
+                        if (nresults == LUA_MULTRET)
+                            L->top = ra + n;
+
+                        pc += skip + 1; // skip instructions that compute function as well as CALL
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // continue execution through the fallback code
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // continue execution through the fallback code
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_FASTCALL2K)
+            {
+                Instruction insn = *pc++;
+                int bfid = LUAU_INSN_A(insn);
+                int skip = LUAU_INSN_C(insn) - 1;
+                uint32_t aux = *pc++;
+                TValue* arg1 = VM_REG(LUAU_INSN_B(insn));
+                TValue* arg2 = VM_KV(aux);
+
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code + skip) < unsigned(cl->l.p->sizecode));
+
+                Instruction call = pc[skip];
+                LUAU_ASSERT(LUAU_INSN_OP(call) == LOP_CALL);
+
+                StkId ra = VM_REG(LUAU_INSN_A(call));
+
+                int nparams = 2;
+                int nresults = LUAU_INSN_C(call) - 1;
+
+                luau_FastFunction f = luauF_table[bfid];
+                LUAU_ASSERT(f);
+
+                if (cl->env->safeenv)
+                {
+                    VM_PROTECT_PC(); // f may fail due to OOM
+
+                    int n = f(L, ra, arg1, nresults, arg2, nparams);
+
+                    if (n >= 0)
+                    {
+                        if (nresults == LUA_MULTRET)
+                            L->top = ra + n;
+
+                        pc += skip + 1; // skip instructions that compute function as well as CALL
+                        LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                        VM_NEXT();
+                    }
+                    else
+                    {
+                        // continue execution through the fallback code
+                        VM_NEXT();
+                    }
+                }
+                else
+                {
+                    // continue execution through the fallback code
+                    VM_NEXT();
+                }
+            }
+
+            VM_CASE(LOP_BREAK)
+            {
+                LUAU_ASSERT(cl->l.p->debuginsn);
+
+                uint8_t op = cl->l.p->debuginsn[unsigned(pc - cl->l.p->code)];
+                LUAU_ASSERT(op != LOP_BREAK);
+
+                if (L->global->cb.debugbreak)
+                {
+                    VM_PROTECT(luau_callhook(L, L->global->cb.debugbreak, NULL));
+
+                    // allow debugbreak hook to put thread into error/yield state
+                    if (L->status != 0)
+                        goto exit;
+                }
+
+                VM_CONTINUE(op);
+            }
+
+            VM_CASE(LOP_JUMPXEQKNIL)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                static_assert(LUA_TNIL == 0, "we expect type-1 to be negative iff type is nil");
+                // condition is equivalent to: int(ttisnil(ra)) != (aux >> 31)
+                pc += int((ttype(ra) - 1) ^ aux) < 0 ? LUAU_INSN_D(insn) : 1;
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPXEQKB)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+
+                pc += int(ttisboolean(ra) && bvalue(ra) == int(aux & 1)) != (aux >> 31) ? LUAU_INSN_D(insn) : 1;
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPXEQKN)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(aux & 0xffffff);
+                LUAU_ASSERT(ttisnumber(kv));
+
+#if defined(__aarch64__)
+                // On several ARM chips (Apple M1/M2, Neoverse N1), comparing the result of a floating-point comparison is expensive, and a branch
+                // is much cheaper; on some 32-bit ARM chips (Cortex A53) the performance is about the same so we prefer less branchy variant there
+                if (aux >> 31)
+                    pc += !(ttisnumber(ra) && nvalue(ra) == nvalue(kv)) ? LUAU_INSN_D(insn) : 1;
+                else
+                    pc += (ttisnumber(ra) && nvalue(ra) == nvalue(kv)) ? LUAU_INSN_D(insn) : 1;
+#else
+                pc += int(ttisnumber(ra) && nvalue(ra) == nvalue(kv)) != (aux >> 31) ? LUAU_INSN_D(insn) : 1;
+#endif
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+            VM_CASE(LOP_JUMPXEQKS)
+            {
+                Instruction insn = *pc++;
+                uint32_t aux = *pc;
+                StkId ra = VM_REG(LUAU_INSN_A(insn));
+                TValue* kv = VM_KV(aux & 0xffffff);
+                LUAU_ASSERT(ttisstring(kv));
+
+                pc += int(ttisstring(ra) && gcvalue(ra) == gcvalue(kv)) != (aux >> 31) ? LUAU_INSN_D(insn) : 1;
+                LUAU_ASSERT(unsigned(pc - cl->l.p->code) < unsigned(cl->l.p->sizecode));
+                VM_NEXT();
+            }
+
+#if !VM_USE_CGOTO
+        default:
+            LUAU_ASSERT(!"Unknown opcode");
+            LUAU_UNREACHABLE(); // improves switch() codegen by eliding opcode bounds checks
+#endif
+        }
+    }
+
+exit:;
+}
+
+void luau_execute(lua_State* L)
+{
+    if (L->singlestep)
+        luau_execute<true>(L);
+    else
+        luau_execute<false>(L);
+}
+
+int luau_precall(lua_State* L, StkId func, int nresults)
+{
+    if (!ttisfunction(func))
+    {
+        luaV_tryfuncTM(L, func);
+        // L->top is incremented by tryfuncTM
+    }
+
+    Closure* ccl = clvalue(func);
+
+    CallInfo* ci = incr_ci(L);
+    ci->func = func;
+    ci->base = func + 1;
+    ci->top = L->top + ccl->stacksize;
+    ci->savedpc = NULL;
+    ci->flags = 0;
+    ci->nresults = nresults;
+
+    L->base = ci->base;
+    // Note: L->top is assigned externally
+
+    luaD_checkstack(L, ccl->stacksize);
+    LUAU_ASSERT(ci->top <= L->stack_last);
+
+    if (!ccl->isC)
+    {
+        Proto* p = ccl->l.p;
+
+        // fill unused parameters with nil
+        StkId argi = L->top;
+        StkId argend = L->base + p->numparams;
+        while (argi < argend)
+            setnilvalue(argi++); // complete missing arguments
+        L->top = p->is_vararg ? argi : ci->top;
+
+        ci->savedpc = p->code;
+
+#if VM_HAS_NATIVE
+        if (p->execdata)
+            ci->flags = LUA_CALLINFO_NATIVE;
+#endif
+
+        return PCRLUA;
+    }
+    else
+    {
+        lua_CFunction func = ccl->c.f;
+        int n = func(L);
+
+        // yield
+        if (n < 0)
+            return PCRYIELD;
+
+        // ci is our callinfo, cip is our parent
+        CallInfo* ci = L->ci;
+        CallInfo* cip = ci - 1;
+
+        // copy return values into parent stack (but only up to nresults!), fill the rest with nil
+        // TODO: it might be worthwhile to handle the case when nresults==b explicitly?
+        StkId res = ci->func;
+        StkId vali = L->top - n;
+        StkId valend = L->top;
+
+        int i;
+        for (i = nresults; i != 0 && vali < valend; i--)
+            setobj2s(L, res++, vali++);
+        while (i-- > 0)
+            setnilvalue(res++);
+
+        // pop the stack frame
+        L->ci = cip;
+        L->base = cip->base;
+        L->top = res;
+
+        return PCRC;
+    }
+}
+
+void luau_poscall(lua_State* L, StkId first)
+{
+    // finish interrupted execution of `OP_CALL'
+    // ci is our callinfo, cip is our parent
+    CallInfo* ci = L->ci;
+    CallInfo* cip = ci - 1;
+
+    // copy return values into parent stack (but only up to nresults!), fill the rest with nil
+    // TODO: it might be worthwhile to handle the case when nresults==b explicitly?
+    StkId res = ci->func;
+    StkId vali = first;
+    StkId valend = L->top;
+
+    int i;
+    for (i = ci->nresults; i != 0 && vali < valend; i--)
+        setobj2s(L, res++, vali++);
+    while (i-- > 0)
+        setnilvalue(res++);
+
+    // pop the stack frame
+    L->ci = cip;
+    L->base = cip->base;
+    L->top = (ci->nresults == LUA_MULTRET) ? res : cip->top;
+}

--- a/lib/luau/VM/src/lvmload.cpp
+++ b/lib/luau/VM/src/lvmload.cpp
@@ -1,0 +1,424 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lvm.h"
+
+#include "lstate.h"
+#include "ltable.h"
+#include "lfunc.h"
+#include "lstring.h"
+#include "lgc.h"
+#include "lmem.h"
+#include "lbytecode.h"
+#include "lapi.h"
+
+#include <string.h>
+
+// TODO: RAII deallocation doesn't work for longjmp builds if a memory error happens
+template<typename T>
+struct TempBuffer
+{
+    lua_State* L;
+    T* data;
+    size_t count;
+
+    TempBuffer(lua_State* L, size_t count)
+        : L(L)
+        , data(luaM_newarray(L, count, T, 0))
+        , count(count)
+    {
+    }
+
+    ~TempBuffer()
+    {
+        luaM_freearray(L, data, count, T, 0);
+    }
+
+    T& operator[](size_t index)
+    {
+        LUAU_ASSERT(index < count);
+        return data[index];
+    }
+};
+
+void luaV_getimport(lua_State* L, Table* env, TValue* k, StkId res, uint32_t id, bool propagatenil)
+{
+    int count = id >> 30;
+    LUAU_ASSERT(count > 0);
+
+    int id0 = int(id >> 20) & 1023;
+    int id1 = int(id >> 10) & 1023;
+    int id2 = int(id) & 1023;
+
+    // after the first call to luaV_gettable, res may be invalid, and env may (sometimes) be garbage collected
+    // we take care to not use env again and to restore res before every consecutive use
+    ptrdiff_t resp = savestack(L, res);
+
+    // global lookup for id0
+    TValue g;
+    sethvalue(L, &g, env);
+    luaV_gettable(L, &g, &k[id0], res);
+
+    // table lookup for id1
+    if (count < 2)
+        return;
+
+    res = restorestack(L, resp);
+    if (!propagatenil || !ttisnil(res))
+        luaV_gettable(L, res, &k[id1], res);
+
+    // table lookup for id2
+    if (count < 3)
+        return;
+
+    res = restorestack(L, resp);
+    if (!propagatenil || !ttisnil(res))
+        luaV_gettable(L, res, &k[id2], res);
+}
+
+template<typename T>
+static T read(const char* data, size_t size, size_t& offset)
+{
+    T result;
+    memcpy(&result, data + offset, sizeof(T));
+    offset += sizeof(T);
+
+    return result;
+}
+
+static unsigned int readVarInt(const char* data, size_t size, size_t& offset)
+{
+    unsigned int result = 0;
+    unsigned int shift = 0;
+
+    uint8_t byte;
+
+    do
+    {
+        byte = read<uint8_t>(data, size, offset);
+        result |= (byte & 127) << shift;
+        shift += 7;
+    } while (byte & 128);
+
+    return result;
+}
+
+static TString* readString(TempBuffer<TString*>& strings, const char* data, size_t size, size_t& offset)
+{
+    unsigned int id = readVarInt(data, size, offset);
+
+    return id == 0 ? NULL : strings[id - 1];
+}
+
+static void resolveImportSafe(lua_State* L, Table* env, TValue* k, uint32_t id)
+{
+    struct ResolveImport
+    {
+        TValue* k;
+        uint32_t id;
+
+        static void run(lua_State* L, void* ud)
+        {
+            ResolveImport* self = static_cast<ResolveImport*>(ud);
+
+            // note: we call getimport with nil propagation which means that accesses to table chains like A.B.C will resolve in nil
+            // this is technically not necessary but it reduces the number of exceptions when loading scripts that rely on getfenv/setfenv for global
+            // injection
+            // allocate a stack slot so that we can do table lookups
+            luaD_checkstack(L, 1);
+            setnilvalue(L->top);
+            L->top++;
+
+            luaV_getimport(L, L->gt, self->k, L->top - 1, self->id, /* propagatenil= */ true);
+        }
+    };
+
+    ResolveImport ri = {k, id};
+    if (L->gt->safeenv)
+    {
+        // luaD_pcall will make sure that if any C/Lua calls during import resolution fail, the thread state is restored back
+        int oldTop = lua_gettop(L);
+        int status = luaD_pcall(L, &ResolveImport::run, &ri, savestack(L, L->top), 0);
+        LUAU_ASSERT(oldTop + 1 == lua_gettop(L)); // if an error occurred, luaD_pcall saves it on stack
+
+        if (status != 0)
+        {
+            // replace error object with nil
+            setnilvalue(L->top - 1);
+        }
+    }
+    else
+    {
+        setnilvalue(L->top);
+        L->top++;
+    }
+}
+
+int luau_load(lua_State* L, const char* chunkname, const char* data, size_t size, int env)
+{
+    size_t offset = 0;
+
+    uint8_t version = read<uint8_t>(data, size, offset);
+
+
+
+    // 0 means the rest of the bytecode is the error message
+    if (version == 0)
+    {
+        char chunkbuf[LUA_IDSIZE];
+        const char* chunkid = luaO_chunkid(chunkbuf, sizeof(chunkbuf), chunkname, strlen(chunkname));
+        lua_pushfstring(L, "%s%.*s", chunkid, int(size - offset), data + offset);
+        return 1;
+    }
+
+    if (version < LBC_VERSION_MIN || version > LBC_VERSION_MAX)
+    {
+        char chunkbuf[LUA_IDSIZE];
+        const char* chunkid = luaO_chunkid(chunkbuf, sizeof(chunkbuf), chunkname, strlen(chunkname));
+        lua_pushfstring(L, "%s: bytecode version mismatch (expected [%d..%d], got %d)", chunkid, LBC_VERSION_MIN, LBC_VERSION_MAX, version);
+        return 1;
+    }
+
+    // we will allocate a fair amount of memory so check GC before we do
+    luaC_checkGC(L);
+
+    // pause GC for the duration of deserialization - some objects we're creating aren't rooted
+    // TODO: if an allocation error happens mid-load, we do not unpause GC!
+    size_t GCthreshold = L->global->GCthreshold;
+    L->global->GCthreshold = SIZE_MAX;
+
+    // env is 0 for current environment and a stack index otherwise
+    Table* envt = (env == 0) ? L->gt : hvalue(luaA_toobject(L, env));
+
+    TString* source = luaS_new(L, chunkname);
+
+    uint8_t typesversion = 0;
+
+    if (version >= 4)
+    {
+        typesversion = read<uint8_t>(data, size, offset);
+    }
+
+    // string table
+    unsigned int stringCount = readVarInt(data, size, offset);
+    TempBuffer<TString*> strings(L, stringCount);
+
+    for (unsigned int i = 0; i < stringCount; ++i)
+    {
+        unsigned int length = readVarInt(data, size, offset);
+
+        strings[i] = luaS_newlstr(L, data + offset, length);
+        offset += length;
+    }
+
+    // proto table
+    unsigned int protoCount = readVarInt(data, size, offset);
+    TempBuffer<Proto*> protos(L, protoCount);
+
+    for (unsigned int i = 0; i < protoCount; ++i)
+    {
+        Proto* p = luaF_newproto(L);
+        p->source = source;
+        p->bytecodeid = int(i);
+
+        p->maxstacksize = read<uint8_t>(data, size, offset);
+        p->numparams = read<uint8_t>(data, size, offset);
+        p->nups = read<uint8_t>(data, size, offset);
+        p->is_vararg = read<uint8_t>(data, size, offset);
+
+        if (version >= 4)
+        {
+            p->flags = read<uint8_t>(data, size, offset);
+
+            uint32_t typesize = readVarInt(data, size, offset);
+
+            if (typesize && typesversion == LBC_TYPE_VERSION)
+            {
+                uint8_t* types = (uint8_t*)data + offset;
+
+                LUAU_ASSERT(typesize == unsigned(2 + p->numparams));
+                LUAU_ASSERT(types[0] == LBC_TYPE_FUNCTION);
+                LUAU_ASSERT(types[1] == p->numparams);
+
+                p->typeinfo = luaM_newarray(L, typesize, uint8_t, p->memcat);
+                memcpy(p->typeinfo, types, typesize);
+            }
+
+            offset += typesize;
+        }
+
+        p->sizecode = readVarInt(data, size, offset);
+        p->code = luaM_newarray(L, p->sizecode, Instruction, p->memcat);
+        for (int j = 0; j < p->sizecode; ++j)
+            p->code[j] = read<uint32_t>(data, size, offset);
+
+        p->codeentry = p->code;
+
+        p->sizek = readVarInt(data, size, offset);
+        p->k = luaM_newarray(L, p->sizek, TValue, p->memcat);
+
+#ifdef HARDMEMTESTS
+        // this is redundant during normal runs, but resolveImportSafe can trigger GC checks under HARDMEMTESTS
+        // because p->k isn't fully formed at this point, we pre-fill it with nil to make subsequent setup safe
+        for (int j = 0; j < p->sizek; ++j)
+        {
+            setnilvalue(&p->k[j]);
+        }
+#endif
+
+        for (int j = 0; j < p->sizek; ++j)
+        {
+            switch (read<uint8_t>(data, size, offset))
+            {
+            case LBC_CONSTANT_NIL:
+                setnilvalue(&p->k[j]);
+                break;
+
+            case LBC_CONSTANT_BOOLEAN:
+            {
+                uint8_t v = read<uint8_t>(data, size, offset);
+                setbvalue(&p->k[j], v);
+                break;
+            }
+
+            case LBC_CONSTANT_NUMBER:
+            {
+                double v = read<double>(data, size, offset);
+                setnvalue(&p->k[j], v);
+                break;
+            }
+
+            case LBC_CONSTANT_VECTOR:
+            {
+                float x = read<float>(data, size, offset);
+                float y = read<float>(data, size, offset);
+                float z = read<float>(data, size, offset);
+                float w = read<float>(data, size, offset);
+                (void)w;
+                setvvalue(&p->k[j], x, y, z, w);
+                break;
+            }
+
+            case LBC_CONSTANT_STRING:
+            {
+                TString* v = readString(strings, data, size, offset);
+                setsvalue(L, &p->k[j], v);
+                break;
+            }
+
+            case LBC_CONSTANT_IMPORT:
+            {
+                uint32_t iid = read<uint32_t>(data, size, offset);
+                resolveImportSafe(L, envt, p->k, iid);
+                setobj(L, &p->k[j], L->top - 1);
+                L->top--;
+                break;
+            }
+
+            case LBC_CONSTANT_TABLE:
+            {
+                int keys = readVarInt(data, size, offset);
+                Table* h = luaH_new(L, 0, keys);
+                for (int i = 0; i < keys; ++i)
+                {
+                    int key = readVarInt(data, size, offset);
+                    TValue* val = luaH_set(L, h, &p->k[key]);
+                    setnvalue(val, 0.0);
+                }
+                sethvalue(L, &p->k[j], h);
+                break;
+            }
+
+            case LBC_CONSTANT_CLOSURE:
+            {
+                uint32_t fid = readVarInt(data, size, offset);
+                Closure* cl = luaF_newLclosure(L, protos[fid]->nups, envt, protos[fid]);
+                cl->preload = (cl->nupvalues > 0);
+                setclvalue(L, &p->k[j], cl);
+                break;
+            }
+
+            default:
+                LUAU_ASSERT(!"Unexpected constant kind");
+            }
+        }
+
+        p->sizep = readVarInt(data, size, offset);
+        p->p = luaM_newarray(L, p->sizep, Proto*, p->memcat);
+        for (int j = 0; j < p->sizep; ++j)
+        {
+            uint32_t fid = readVarInt(data, size, offset);
+            p->p[j] = protos[fid];
+        }
+
+        p->linedefined = readVarInt(data, size, offset);
+        p->debugname = readString(strings, data, size, offset);
+
+        uint8_t lineinfo = read<uint8_t>(data, size, offset);
+
+        if (lineinfo)
+        {
+            p->linegaplog2 = read<uint8_t>(data, size, offset);
+
+            int intervals = ((p->sizecode - 1) >> p->linegaplog2) + 1;
+            int absoffset = (p->sizecode + 3) & ~3;
+
+            p->sizelineinfo = absoffset + intervals * sizeof(int);
+            p->lineinfo = luaM_newarray(L, p->sizelineinfo, uint8_t, p->memcat);
+            p->abslineinfo = (int*)(p->lineinfo + absoffset);
+
+            uint8_t lastoffset = 0;
+            for (int j = 0; j < p->sizecode; ++j)
+            {
+                lastoffset += read<uint8_t>(data, size, offset);
+                p->lineinfo[j] = lastoffset;
+            }
+
+            int lastline = 0;
+            for (int j = 0; j < intervals; ++j)
+            {
+                lastline += read<int32_t>(data, size, offset);
+                p->abslineinfo[j] = lastline;
+            }
+        }
+
+        uint8_t debuginfo = read<uint8_t>(data, size, offset);
+
+        if (debuginfo)
+        {
+            p->sizelocvars = readVarInt(data, size, offset);
+            p->locvars = luaM_newarray(L, p->sizelocvars, LocVar, p->memcat);
+
+            for (int j = 0; j < p->sizelocvars; ++j)
+            {
+                p->locvars[j].varname = readString(strings, data, size, offset);
+                p->locvars[j].startpc = readVarInt(data, size, offset);
+                p->locvars[j].endpc = readVarInt(data, size, offset);
+                p->locvars[j].reg = read<uint8_t>(data, size, offset);
+            }
+
+            p->sizeupvalues = readVarInt(data, size, offset);
+            p->upvalues = luaM_newarray(L, p->sizeupvalues, TString*, p->memcat);
+
+            for (int j = 0; j < p->sizeupvalues; ++j)
+            {
+                p->upvalues[j] = readString(strings, data, size, offset);
+            }
+        }
+
+        protos[i] = p;
+    }
+
+    // "main" proto is pushed to Lua stack
+    uint32_t mainid = readVarInt(data, size, offset);
+    Proto* main = protos[mainid];
+
+    luaC_threadbarrier(L);
+
+    Closure* cl = luaF_newLclosure(L, 0, envt, main);
+    setclvalue(L, L->top, cl);
+    incr_top(L);
+
+    L->global->GCthreshold = GCthreshold;
+
+    return 0;
+}

--- a/lib/luau/VM/src/lvmutils.cpp
+++ b/lib/luau/VM/src/lvmutils.cpp
@@ -1,0 +1,619 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+// This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
+#include "lvm.h"
+
+#include "lstate.h"
+#include "lstring.h"
+#include "ltable.h"
+#include "lgc.h"
+#include "ldo.h"
+#include "lnumutils.h"
+
+#include <string.h>
+
+// limit for table tag-method chains (to avoid loops)
+#define MAXTAGLOOP 100
+
+const TValue* luaV_tonumber(const TValue* obj, TValue* n)
+{
+    double num;
+    if (ttisnumber(obj))
+        return obj;
+    if (ttisstring(obj) && luaO_str2d(svalue(obj), &num))
+    {
+        setnvalue(n, num);
+        return n;
+    }
+    else
+        return NULL;
+}
+
+int luaV_tostring(lua_State* L, StkId obj)
+{
+    if (!ttisnumber(obj))
+        return 0;
+    else
+    {
+        char s[LUAI_MAXNUM2STR];
+        double n = nvalue(obj);
+        char* e = luai_num2str(s, n);
+        LUAU_ASSERT(e < s + sizeof(s));
+        setsvalue(L, obj, luaS_newlstr(L, s, e - s));
+        return 1;
+    }
+}
+
+const float* luaV_tovector(const TValue* obj)
+{
+    if (ttisvector(obj))
+        return vvalue(obj);
+
+    return nullptr;
+}
+
+static StkId callTMres(lua_State* L, StkId res, const TValue* f, const TValue* p1, const TValue* p2)
+{
+    ptrdiff_t result = savestack(L, res);
+    // using stack room beyond top is technically safe here, but for very complicated reasons:
+    // * The stack guarantees EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
+    // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
+    // stack and checkstack may invalidate those pointers
+    // * we cannot use savestack/restorestack because the arguments are sometimes on the C++ stack
+    // * during stack reallocation all of the allocated stack is copied (even beyond stack_last) so these
+    // values will be preserved even if they go past stack_last
+    LUAU_ASSERT((L->top + 3) < (L->stack + L->stacksize));
+    setobj2s(L, L->top, f);      // push function
+    setobj2s(L, L->top + 1, p1); // 1st argument
+    setobj2s(L, L->top + 2, p2); // 2nd argument
+    luaD_checkstack(L, 3);
+    L->top += 3;
+    luaD_call(L, L->top - 3, 1);
+    res = restorestack(L, result);
+    L->top--;
+    setobj2s(L, res, L->top);
+    return res;
+}
+
+static void callTM(lua_State* L, const TValue* f, const TValue* p1, const TValue* p2, const TValue* p3)
+{
+    // using stack room beyond top is technically safe here, but for very complicated reasons:
+    // * The stack guarantees EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
+    // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
+    // stack and checkstack may invalidate those pointers
+    // * we cannot use savestack/restorestack because the arguments are sometimes on the C++ stack
+    // * during stack reallocation all of the allocated stack is copied (even beyond stack_last) so these
+    // values will be preserved even if they go past stack_last
+    LUAU_ASSERT((L->top + 4) < (L->stack + L->stacksize));
+    setobj2s(L, L->top, f);      // push function
+    setobj2s(L, L->top + 1, p1); // 1st argument
+    setobj2s(L, L->top + 2, p2); // 2nd argument
+    setobj2s(L, L->top + 3, p3); // 3th argument
+    luaD_checkstack(L, 4);
+    L->top += 4;
+    luaD_call(L, L->top - 4, 0);
+}
+
+void luaV_gettable(lua_State* L, const TValue* t, TValue* key, StkId val)
+{
+    int loop;
+    for (loop = 0; loop < MAXTAGLOOP; loop++)
+    {
+        const TValue* tm;
+        if (ttistable(t))
+        { // `t' is a table?
+            Table* h = hvalue(t);
+
+            const TValue* res = luaH_get(h, key); // do a primitive get
+
+            if (res != luaO_nilobject)
+                L->cachedslot = gval2slot(h, res); // remember slot to accelerate future lookups
+
+            if (!ttisnil(res) // result is no nil?
+                || (tm = fasttm(L, h->metatable, TM_INDEX)) == NULL)
+            { // or no TM?
+                setobj2s(L, val, res);
+                return;
+            }
+            // t isn't a table, so see if it has an INDEX meta-method to look up the key with
+        }
+        else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_INDEX)))
+            luaG_indexerror(L, t, key);
+        if (ttisfunction(tm))
+        {
+            callTMres(L, val, tm, t, key);
+            return;
+        }
+        t = tm; // else repeat with `tm'
+    }
+    luaG_runerror(L, "'__index' chain too long; possible loop");
+}
+
+void luaV_settable(lua_State* L, const TValue* t, TValue* key, StkId val)
+{
+    int loop;
+    TValue temp;
+    for (loop = 0; loop < MAXTAGLOOP; loop++)
+    {
+        const TValue* tm;
+        if (ttistable(t))
+        { // `t' is a table?
+            Table* h = hvalue(t);
+
+            const TValue* oldval = luaH_get(h, key);
+
+            // should we assign the key? (if key is valid or __newindex is not set)
+            if (!ttisnil(oldval) || (tm = fasttm(L, h->metatable, TM_NEWINDEX)) == NULL)
+            {
+                if (h->readonly)
+                    luaG_readonlyerror(L);
+
+                // luaH_set would work but would repeat the lookup so we use luaH_setslot that can reuse oldval if it's safe
+                TValue* newval = luaH_setslot(L, h, oldval, key);
+
+                L->cachedslot = gval2slot(h, newval); // remember slot to accelerate future lookups
+
+                setobj2t(L, newval, val);
+                luaC_barriert(L, h, val);
+                return;
+            }
+
+            // fallthrough to metamethod
+        }
+        else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_NEWINDEX)))
+            luaG_indexerror(L, t, key);
+
+        if (ttisfunction(tm))
+        {
+            callTM(L, tm, t, key, val);
+            return;
+        }
+        // else repeat with `tm'
+        setobj(L, &temp, tm); // avoid pointing inside table (may rehash)
+        t = &temp;
+    }
+    luaG_runerror(L, "'__newindex' chain too long; possible loop");
+}
+
+static int call_binTM(lua_State* L, const TValue* p1, const TValue* p2, StkId res, TMS event)
+{
+    const TValue* tm = luaT_gettmbyobj(L, p1, event); // try first operand
+    if (ttisnil(tm))
+        tm = luaT_gettmbyobj(L, p2, event); // try second operand
+    if (ttisnil(tm))
+        return 0;
+    callTMres(L, res, tm, p1, p2);
+    return 1;
+}
+
+static const TValue* get_compTM(lua_State* L, Table* mt1, Table* mt2, TMS event)
+{
+    const TValue* tm1 = fasttm(L, mt1, event);
+    const TValue* tm2;
+    if (tm1 == NULL)
+        return NULL; // no metamethod
+    if (mt1 == mt2)
+        return tm1; // same metatables => same metamethods
+    tm2 = fasttm(L, mt2, event);
+    if (tm2 == NULL)
+        return NULL;                // no metamethod
+    if (luaO_rawequalObj(tm1, tm2)) // same metamethods?
+        return tm1;
+    return NULL;
+}
+
+static int call_orderTM(lua_State* L, const TValue* p1, const TValue* p2, TMS event, bool error = false)
+{
+    const TValue* tm1 = luaT_gettmbyobj(L, p1, event);
+    const TValue* tm2;
+    if (ttisnil(tm1))
+    {
+        if (error)
+            luaG_ordererror(L, p1, p2, event);
+        return -1; // no metamethod?
+    }
+    tm2 = luaT_gettmbyobj(L, p2, event);
+    if (!luaO_rawequalObj(tm1, tm2)) // different metamethods?
+    {
+        if (error)
+            luaG_ordererror(L, p1, p2, event);
+        return -1;
+    }
+    callTMres(L, L->top, tm1, p1, p2);
+    return !l_isfalse(L->top);
+}
+
+int luaV_strcmp(const TString* ls, const TString* rs)
+{
+    if (ls == rs)
+        return 0;
+
+    const char* l = getstr(ls);
+    const char* r = getstr(rs);
+
+    // always safe to read one character because even empty strings are nul terminated
+    if (*l != *r)
+        return uint8_t(*l) - uint8_t(*r);
+
+    size_t ll = ls->len;
+    size_t lr = rs->len;
+    size_t lmin = ll < lr ? ll : lr;
+
+    int res = memcmp(l, r, lmin);
+    if (res != 0)
+        return res;
+
+    return ll == lr ? 0 : ll < lr ? -1 : 1;
+}
+
+int luaV_lessthan(lua_State* L, const TValue* l, const TValue* r)
+{
+    if (LUAU_UNLIKELY(ttype(l) != ttype(r)))
+        luaG_ordererror(L, l, r, TM_LT);
+    else if (LUAU_LIKELY(ttisnumber(l)))
+        return luai_numlt(nvalue(l), nvalue(r));
+    else if (ttisstring(l))
+        return luaV_strcmp(tsvalue(l), tsvalue(r)) < 0;
+    else
+        return call_orderTM(L, l, r, TM_LT, /* error= */ true);
+}
+
+int luaV_lessequal(lua_State* L, const TValue* l, const TValue* r)
+{
+    int res;
+    if (ttype(l) != ttype(r))
+        luaG_ordererror(L, l, r, TM_LE);
+    else if (ttisnumber(l))
+        return luai_numle(nvalue(l), nvalue(r));
+    else if (ttisstring(l))
+        return luaV_strcmp(tsvalue(l), tsvalue(r)) <= 0;
+    else if ((res = call_orderTM(L, l, r, TM_LE)) != -1) // first try `le'
+        return res;
+    else if ((res = call_orderTM(L, r, l, TM_LT)) == -1) // error if not `lt'
+        luaG_ordererror(L, l, r, TM_LE);
+    return !res;
+}
+
+int luaV_equalval(lua_State* L, const TValue* t1, const TValue* t2)
+{
+    const TValue* tm;
+    LUAU_ASSERT(ttype(t1) == ttype(t2));
+    switch (ttype(t1))
+    {
+    case LUA_TNIL:
+        return 1;
+    case LUA_TNUMBER:
+        return luai_numeq(nvalue(t1), nvalue(t2));
+    case LUA_TVECTOR:
+        return luai_veceq(vvalue(t1), vvalue(t2));
+    case LUA_TBOOLEAN:
+        return bvalue(t1) == bvalue(t2); // true must be 1 !!
+    case LUA_TLIGHTUSERDATA:
+        return pvalue(t1) == pvalue(t2) && (!FFlag::TaggedLuData || lightuserdatatag(t1) == lightuserdatatag(t2));
+    case LUA_TUSERDATA:
+    {
+        tm = get_compTM(L, uvalue(t1)->metatable, uvalue(t2)->metatable, TM_EQ);
+        if (!tm)
+            return uvalue(t1) == uvalue(t2);
+        break; // will try TM
+    }
+    case LUA_TTABLE:
+    {
+        tm = get_compTM(L, hvalue(t1)->metatable, hvalue(t2)->metatable, TM_EQ);
+        if (!tm)
+            return hvalue(t1) == hvalue(t2);
+        break; // will try TM
+    }
+    default:
+        return gcvalue(t1) == gcvalue(t2);
+    }
+    callTMres(L, L->top, tm, t1, t2); // call TM
+    return !l_isfalse(L->top);
+}
+
+void luaV_concat(lua_State* L, int total, int last)
+{
+    do
+    {
+        StkId top = L->base + last + 1;
+        int n = 2; // number of elements handled in this pass (at least 2)
+        if (!(ttisstring(top - 2) || ttisnumber(top - 2)) || !tostring(L, top - 1))
+        {
+            if (!call_binTM(L, top - 2, top - 1, top - 2, TM_CONCAT))
+                luaG_concaterror(L, top - 2, top - 1);
+        }
+        else if (tsvalue(top - 1)->len == 0) // second op is empty?
+            (void)tostring(L, top - 2);      // result is first op (as string)
+        else
+        {
+            // at least two string values; get as many as possible
+            size_t tl = tsvalue(top - 1)->len;
+            char* buffer;
+            int i;
+            // collect total length
+            for (n = 1; n < total && tostring(L, top - n - 1); n++)
+            {
+                size_t l = tsvalue(top - n - 1)->len;
+                if (l > MAXSSIZE - tl)
+                    luaG_runerror(L, "string length overflow");
+                tl += l;
+            }
+
+            char buf[LUA_BUFFERSIZE];
+            TString* ts = nullptr;
+
+            if (tl < LUA_BUFFERSIZE)
+            {
+                buffer = buf;
+            }
+            else
+            {
+                ts = luaS_bufstart(L, tl);
+                buffer = ts->data;
+            }
+
+            tl = 0;
+            for (i = n; i > 0; i--)
+            { // concat all strings
+                size_t l = tsvalue(top - i)->len;
+                memcpy(buffer + tl, svalue(top - i), l);
+                tl += l;
+            }
+
+            if (tl < LUA_BUFFERSIZE)
+            {
+                setsvalue(L, top - n, luaS_newlstr(L, buffer, tl));
+            }
+            else
+            {
+                setsvalue(L, top - n, luaS_buffinish(L, ts));
+            }
+        }
+        total -= n - 1; // got `n' strings to create 1 new
+        last -= n - 1;
+    } while (total > 1); // repeat until only 1 result left
+}
+
+void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TMS op)
+{
+    TValue tempb, tempc;
+    const TValue *b, *c;
+    if ((b = luaV_tonumber(rb, &tempb)) != NULL && (c = luaV_tonumber(rc, &tempc)) != NULL)
+    {
+        double nb = nvalue(b), nc = nvalue(c);
+        switch (op)
+        {
+        case TM_ADD:
+            setnvalue(ra, luai_numadd(nb, nc));
+            break;
+        case TM_SUB:
+            setnvalue(ra, luai_numsub(nb, nc));
+            break;
+        case TM_MUL:
+            setnvalue(ra, luai_nummul(nb, nc));
+            break;
+        case TM_DIV:
+            setnvalue(ra, luai_numdiv(nb, nc));
+            break;
+        case TM_IDIV:
+            setnvalue(ra, luai_numidiv(nb, nc));
+            break;
+        case TM_MOD:
+            setnvalue(ra, luai_nummod(nb, nc));
+            break;
+        case TM_POW:
+            setnvalue(ra, luai_numpow(nb, nc));
+            break;
+        case TM_UNM:
+            setnvalue(ra, luai_numunm(nb));
+            break;
+        default:
+            LUAU_ASSERT(0);
+            break;
+        }
+    }
+    else
+    {
+        // vector operations that we support:
+        // v+v  v-v  -v    (add/sub/neg)
+        // v*v  s*v  v*s   (mul)
+        // v/v  s/v  v/s   (div)
+        // v//v s//v v//s  (floor div)
+
+        const float* vb = luaV_tovector(rb);
+        const float* vc = luaV_tovector(rc);
+
+        if (vb && vc)
+        {
+            switch (op)
+            {
+            case TM_ADD:
+                setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
+                return;
+            case TM_SUB:
+                setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
+                return;
+            case TM_MUL:
+                setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
+                return;
+            case TM_DIV:
+                setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
+                return;
+            case TM_IDIV:
+                setvvalue(ra, float(luai_numidiv(vb[0], vc[0])), float(luai_numidiv(vb[1], vc[1])), float(luai_numidiv(vb[2], vc[2])),
+                    float(luai_numidiv(vb[3], vc[3])));
+                return;
+            case TM_UNM:
+                setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
+                return;
+            default:
+                break;
+            }
+        }
+        else if (vb)
+        {
+            c = luaV_tonumber(rc, &tempc);
+
+            if (c)
+            {
+                float nc = cast_to(float, nvalue(c));
+
+                switch (op)
+                {
+                case TM_MUL:
+                    setvvalue(ra, vb[0] * nc, vb[1] * nc, vb[2] * nc, vb[3] * nc);
+                    return;
+                case TM_DIV:
+                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc, vb[3] / nc);
+                    return;
+                case TM_IDIV:
+                    setvvalue(ra, float(luai_numidiv(vb[0], nc)), float(luai_numidiv(vb[1], nc)), float(luai_numidiv(vb[2], nc)),
+                        float(luai_numidiv(vb[3], nc)));
+                    return;
+                default:
+                    break;
+                }
+            }
+        }
+        else if (vc)
+        {
+            b = luaV_tonumber(rb, &tempb);
+
+            if (b)
+            {
+                float nb = cast_to(float, nvalue(b));
+
+                switch (op)
+                {
+                case TM_MUL:
+                    setvvalue(ra, nb * vc[0], nb * vc[1], nb * vc[2], nb * vc[3]);
+                    return;
+                case TM_DIV:
+                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2], nb / vc[3]);
+                    return;
+                case TM_IDIV:
+                    setvvalue(ra, float(luai_numidiv(nb, vc[0])), float(luai_numidiv(nb, vc[1])), float(luai_numidiv(nb, vc[2])),
+                        float(luai_numidiv(nb, vc[3])));
+                    return;
+                default:
+                    break;
+                }
+            }
+        }
+
+        if (!call_binTM(L, rb, rc, ra, op))
+        {
+            luaG_aritherror(L, rb, rc, op);
+        }
+    }
+}
+
+void luaV_dolen(lua_State* L, StkId ra, const TValue* rb)
+{
+    const TValue* tm = NULL;
+    switch (ttype(rb))
+    {
+    case LUA_TTABLE:
+    {
+        Table* h = hvalue(rb);
+        if ((tm = fasttm(L, h->metatable, TM_LEN)) == NULL)
+        {
+            setnvalue(ra, cast_num(luaH_getn(h)));
+            return;
+        }
+        break;
+    }
+    case LUA_TSTRING:
+    {
+        TString* ts = tsvalue(rb);
+        setnvalue(ra, cast_num(ts->len));
+        return;
+    }
+    default:
+        tm = luaT_gettmbyobj(L, rb, TM_LEN);
+    }
+
+    if (ttisnil(tm))
+        luaG_typeerror(L, rb, "get length of");
+
+    StkId res = callTMres(L, ra, tm, rb, luaO_nilobject);
+    if (!ttisnumber(res))
+        luaG_runerror(L, "'__len' must return a number"); // note, we can't access rb since stack may have been reallocated
+}
+
+LUAU_NOINLINE void luaV_prepareFORN(lua_State* L, StkId plimit, StkId pstep, StkId pinit)
+{
+    if (!ttisnumber(pinit) && !luaV_tonumber(pinit, pinit))
+        luaG_forerror(L, pinit, "initial value");
+    if (!ttisnumber(plimit) && !luaV_tonumber(plimit, plimit))
+        luaG_forerror(L, plimit, "limit");
+    if (!ttisnumber(pstep) && !luaV_tonumber(pstep, pstep))
+        luaG_forerror(L, pstep, "step");
+}
+
+// calls a C function f with no yielding support; optionally save one resulting value to the res register
+// the function and arguments have to already be pushed to L->top
+LUAU_NOINLINE void luaV_callTM(lua_State* L, int nparams, int res)
+{
+    ++L->nCcalls;
+
+    if (L->nCcalls >= LUAI_MAXCCALLS)
+        luaD_checkCstack(L);
+
+    luaD_checkstack(L, LUA_MINSTACK);
+
+    StkId top = L->top;
+    StkId fun = top - nparams - 1;
+
+    CallInfo* ci = incr_ci(L);
+    ci->func = fun;
+    ci->base = fun + 1;
+    ci->top = top + LUA_MINSTACK;
+    ci->savedpc = NULL;
+    ci->flags = 0;
+    ci->nresults = (res >= 0);
+    LUAU_ASSERT(ci->top <= L->stack_last);
+
+    LUAU_ASSERT(ttisfunction(ci->func));
+    LUAU_ASSERT(clvalue(ci->func)->isC);
+
+    L->base = fun + 1;
+    LUAU_ASSERT(L->top == L->base + nparams);
+
+    lua_CFunction func = clvalue(fun)->c.f;
+    int n = func(L);
+    LUAU_ASSERT(n >= 0); // yields should have been blocked by nCcalls
+
+    // ci is our callinfo, cip is our parent
+    // note that we read L->ci again since it may have been reallocated by the call
+    CallInfo* cip = L->ci - 1;
+
+    // copy return value into parent stack
+    if (res >= 0)
+    {
+        if (n > 0)
+        {
+            setobj2s(L, &cip->base[res], L->top - n);
+        }
+        else
+        {
+            setnilvalue(&cip->base[res]);
+        }
+    }
+
+    L->ci = cip;
+    L->base = cip->base;
+    L->top = cip->top;
+
+    --L->nCcalls;
+}
+
+LUAU_NOINLINE void luaV_tryfuncTM(lua_State* L, StkId func)
+{
+    const TValue* tm = luaT_gettmbyobj(L, func, TM_CALL);
+    if (!ttisfunction(tm))
+        luaG_typeerror(L, func, "call");
+    for (StkId p = L->top; p > func; p--) // open space for metamethod
+        setobj2s(L, p, p - 1);
+    L->top++;              // stack space pre-allocated by the caller
+    setobj2s(L, func, tm); // tag method is the new function to be called
+}

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ test:
 	zig build test --summary failures -Dversion=lua_52
 	zig build test --summary failures -Dversion=lua_53
 	zig build test --summary failures -Dversion=lua_54
+	zig build test --summary failures -Dversion=luau
 
 	zig build install-example-interpreter
 	zig build install-example-zig-function

--- a/src/zigluau/assert.cpp
+++ b/src/zigluau/assert.cpp
@@ -1,0 +1,13 @@
+#include "Luau/Common.h"
+
+#include <cstdio>
+
+static int assertionHandler(const char* expr, const char* file, int line, const char* function)
+{
+    printf("%s(%d): ASSERTION FAILED: %s\n", file, line, expr);
+    return 1;
+}
+
+extern "C" void zig_registerAssertionHandler() {
+    Luau::assertHandler() = assertionHandler;
+}

--- a/src/zigluau/lib.zig
+++ b/src/zigluau/lib.zig
@@ -384,6 +384,18 @@ pub const Lua = struct {
         return c.lua_gc(lua.state, c.LUA_GCSETSTEPMUL, multiplier);
     }
 
+    pub fn gcIsRunning(lua: *Lua) bool {
+        return c.lua_gc(lua.state, c.LUA_GCISRUNNING, 0) == 1;
+    }
+
+    pub fn gcSetGoal(lua: *Lua, goal: i32) i32 {
+        return c.lua_gc(lua.state, c.LUA_GCSETGOAL, goal);
+    }
+
+    pub fn gcSetStepSize(lua: *Lua, size: i32) i32 {
+        return c.lua_gc(lua.state, c.LUA_GCSETSTEPSIZE, size);
+    }
+
     /// Returns the memory allocation function of a given state
     /// If data is not null, it is set to the opaque pointer given when the allocator function was set
     /// See https://www.lua.org/manual/5.1/manual.html#lua_getallocf

--- a/src/zigluau/lib.zig
+++ b/src/zigluau/lib.zig
@@ -1,0 +1,1430 @@
+//! complete bindings around the Lua C API version 5.1.5
+//! exposes all Lua functionality, with additional Zig helper functions
+
+const std = @import("std");
+
+const c = @cImport({
+    @cInclude("lua/lua.h");
+    @cInclude("lua/lualib.h");
+});
+
+/// This function is defined in assert.cpp and must be called to define the assertion printer
+extern "c" fn zig_registerAssertionHandler() void;
+
+const Allocator = std.mem.Allocator;
+
+// Types
+//
+// Lua constants and types are declared below in alphabetical order
+// For constants that have a logical grouping (like Operators), Zig enums are used for type safety
+
+/// The type of function that Lua uses for all internal allocations and frees
+/// `data` is an opaque pointer to any data (the allocator), `ptr` is a pointer to the block being alloced/realloced/freed
+/// `osize` is the original size or a code, and `nsize` is the new size
+///
+/// See https://www.lua.org/manual/5.1/manual.html#lua_Alloc for more details
+pub const AllocFn = *const fn (data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.C) ?*anyopaque;
+
+/// Type for C functions
+/// See https://www.lua.org/manual/5.1/manual.html#lua_CFunction for the protocol
+pub const CFn = *const fn (state: ?*LuaState) callconv(.C) c_int;
+
+/// The internal Lua debug structure
+/// See https://www.lua.org/manual/5.1/manual.html#lua_Debug
+const Debug = c.lua_Debug;
+
+/// The Lua debug interface structure
+pub const DebugInfo = struct {
+    source: [:0]const u8 = undefined,
+    src_len: usize = 0,
+    short_src: [c.LUA_IDSIZE:0]u8 = undefined,
+
+    name: ?[:0]const u8 = undefined,
+    what: FnType = undefined,
+
+    current_line: ?i32 = null,
+    first_line_defined: ?i32 = null,
+    last_line_defined: ?i32 = null,
+
+    is_vararg: bool = false,
+
+    pub const NameType = enum { global, local, method, field, upvalue, other };
+
+    pub const FnType = enum { lua, c, main, tail };
+
+    pub const Options = packed struct {
+        @">": bool = false,
+        f: bool = false,
+        l: bool = false,
+        n: bool = false,
+        S: bool = false,
+        u: bool = false,
+        L: bool = false,
+
+        fn toString(options: Options) [10:0]u8 {
+            var str = [_:0]u8{0} ** 10;
+            var index: u8 = 0;
+
+            inline for (std.meta.fields(Options)) |field| {
+                if (@field(options, field.name)) {
+                    str[index] = field.name[0];
+                    index += 1;
+                }
+            }
+            while (index < str.len) : (index += 1) str[index] = 0;
+
+            return str;
+        }
+    };
+};
+
+/// The superset of all errors returned from ziglua
+pub const Error = error{
+    /// A generic failure (used when a function can only fail in one way)
+    Fail,
+    /// A runtime error
+    Runtime,
+    /// A syntax error during precompilation
+    Syntax,
+    /// A memory allocation error
+    Memory,
+    /// An error while running the message handler
+    MsgHandler,
+    /// A file-releated error
+    File,
+};
+
+/// Type for arrays of functions to be registered
+pub const FnReg = struct {
+    name: [:0]const u8,
+    func: CFn,
+};
+
+/// The index of the global environment table
+pub const globals_index = c.LUA_GLOBALSINDEX;
+
+/// Type for debugging hook functions
+/// See https://www.lua.org/manual/5.1/manual.html#lua_Hook
+pub const CHookFn = *const fn (state: ?*LuaState, ar: ?*Debug) callconv(.C) void;
+
+/// Hook event codes
+pub const hook_call = c.LUA_HOOKCALL;
+pub const hook_count = c.LUA_HOOKCOUNT;
+pub const hook_line = c.LUA_HOOKLINE;
+pub const hook_ret = c.LUA_HOOKRET;
+pub const hook_tail_call = c.LUA_HOOKTAILCALL;
+
+/// Type of integers in Lua (typically a ptrdiff_t)
+pub const Integer = c.lua_Integer;
+
+/// Bitflag for the Lua standard libraries
+pub const Libs = packed struct {
+    base: bool = false,
+    package: bool = false,
+    string: bool = false,
+    utf8: bool = false,
+    table: bool = false,
+    math: bool = false,
+    io: bool = false,
+    os: bool = false,
+    debug: bool = false,
+};
+
+/// The type of the opaque structure that points to a thread and the state of a Lua interpreter
+pub const LuaState = c.lua_State;
+
+/// Lua types
+/// Must be a signed integer because LuaType.none is -1
+pub const LuaType = enum(i5) {
+    none = c.LUA_TNONE,
+    nil = c.LUA_TNIL,
+    boolean = c.LUA_TBOOLEAN,
+    light_userdata = c.LUA_TLIGHTUSERDATA,
+    number = c.LUA_TNUMBER,
+    string = c.LUA_TSTRING,
+    table = c.LUA_TTABLE,
+    function = c.LUA_TFUNCTION,
+    userdata = c.LUA_TUSERDATA,
+    thread = c.LUA_TTHREAD,
+};
+
+/// The maximum integer value that `Integer` can store
+pub const max_integer = c.LUA_MAXINTEGER;
+
+/// The minimum Lua stack available to a function
+pub const min_stack = c.LUA_MINSTACK;
+
+/// Option for multiple returns in `Lua.protectedCall()` and `Lua.call()`
+pub const mult_return = c.LUA_MULTRET;
+
+/// Type of floats in Lua (typically an f64)
+pub const Number = c.lua_Number;
+
+/// The type of the reader function used by `Lua.load()`
+pub const CReaderFn = *const fn (state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.C) [*c]const u8;
+
+/// The possible status of a call to `Lua.resumeThread`
+pub const ResumeStatus = enum(u1) {
+    ok = StatusCode.ok,
+    yield = StatusCode.yield,
+};
+
+/// Reference constants
+pub const ref_nil = c.LUA_REFNIL;
+pub const ref_no = c.LUA_NOREF;
+
+/// Index of the regsitry in the stack (pseudo-index)
+pub const registry_index = c.LUA_REGISTRYINDEX;
+
+/// Index of the main thread in the registry
+pub const ridx_mainthread = c.LUA_RIDX_MAINTHREAD;
+
+/// Status that a thread can be in
+/// Usually errors are reported by a Zig error rather than a status enum value
+pub const Status = enum(u3) {
+    ok = StatusCode.ok,
+    yield = StatusCode.yield,
+    err_runtime = StatusCode.err_runtime,
+    err_syntax = StatusCode.err_syntax,
+    err_memory = StatusCode.err_memory,
+    err_error = StatusCode.err_error,
+};
+
+/// Status codes
+/// Not public, because typically Status.ok is returned from a function implicitly;
+/// Any function that returns an error usually returns a Zig error, and a void return
+/// is an implicit Status.ok.
+/// In the rare case that the status code is required from a function, an enum is
+/// used for that specific function's return type
+const StatusCode = struct {
+    // Lua 5.1 doesn't have an explicit variable, but 0 represents OK
+    pub const ok = 0;
+    pub const yield = c.LUA_YIELD;
+    pub const err_runtime = c.LUA_ERRRUN;
+    pub const err_syntax = c.LUA_ERRSYNTAX;
+    pub const err_memory = c.LUA_ERRMEM;
+    pub const err_error = c.LUA_ERRERR;
+};
+
+// Only used in loadFileX, so no need to group with Status
+pub const err_file = c.LUA_ERRFILE;
+
+/// The standard representation for file handles used by the standard IO library
+pub const Stream = c.luaL_Stream;
+
+/// The type of the writer function used by `Lua.dump()`
+pub const CWriterFn = *const fn (state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int;
+
+/// A Zig wrapper around the Lua C API
+/// Represents a Lua state or thread and contains the entire state of the Lua interpreter
+pub const Lua = struct {
+    allocator: ?*Allocator = null,
+    state: *LuaState,
+
+    const alignment = @alignOf(std.c.max_align_t);
+
+    /// Allows Lua to allocate memory using a Zig allocator passed in via data.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_Alloc for more details
+    fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.C) ?*align(alignment) anyopaque {
+        // just like malloc() returns a pointer "which is suitably aligned for any built-in type",
+        // the memory allocated by this function should also be aligned for any type that Lua may
+        // desire to allocate. use the largest alignment for the target
+        const allocator = opaqueCast(Allocator, data.?);
+
+        if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
+            const prev_slice = prev_ptr[0..osize];
+
+            // when nsize is zero the allocator must behave like free and return null
+            if (nsize == 0) {
+                allocator.free(prev_slice);
+                return null;
+            }
+
+            // when nsize is not zero the allocator must behave like realloc
+            const new_ptr = allocator.realloc(prev_slice, nsize) catch return null;
+            return new_ptr.ptr;
+        } else if (nsize == 0) {
+            return null;
+        } else {
+            // ptr is null, allocate a new block of memory
+            const new_ptr = allocator.alignedAlloc(u8, alignment, nsize) catch return null;
+            return new_ptr.ptr;
+        }
+    }
+
+    /// Initialize a Lua state with the given allocator
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newstate
+    pub fn init(allocator: Allocator) !Lua {
+        zig_registerAssertionHandler();
+
+        // the userdata passed to alloc needs to be a pointer with a consistent address
+        // so we allocate an Allocator struct to hold a copy of the allocator's data
+        const allocator_ptr = allocator.create(Allocator) catch return error.Memory;
+        allocator_ptr.* = allocator;
+
+        const state = c.lua_newstate(alloc, allocator_ptr) orelse return error.Memory;
+        return Lua{
+            .allocator = allocator_ptr,
+            .state = state,
+        };
+    }
+
+    /// Deinitialize a Lua state and free all memory
+    pub fn deinit(lua: *Lua) void {
+        lua.close();
+        if (lua.allocator) |a| {
+            const allocator = a;
+            allocator.destroy(a);
+            lua.allocator = null;
+        }
+    }
+
+    // Library functions
+    //
+    // Library functions are included in alphabetical order.
+    // Each is kept similar to the original C API function while also making it easy to use from Zig
+
+    /// Calls a function (or any callable value)
+    /// First push the function to be called onto the stack. Then push any arguments onto the stack.
+    /// Then call this function. All arguments and the function value are popped, and any results
+    /// are pushed onto the stack.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_call
+    pub fn call(lua: *Lua, num_args: i32, num_results: i32) void {
+        c.lua_call(lua.state, num_args, num_results);
+    }
+
+    /// Ensures that the stack has space for at least n extra arguments
+    /// Returns an error if more stack space cannot be allocated
+    /// Never shrinks the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_checkstack
+    pub fn checkStack(lua: *Lua, n: i32) !void {
+        if (c.lua_checkstack(lua.state, n) == 0) return error.Fail;
+    }
+
+    /// Release all Lua objects in the state and free all dynamic memory
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_close
+    pub fn close(lua: *Lua) void {
+        c.lua_close(lua.state);
+    }
+
+    /// Concatenates the n values at the top of the stack, pops them, and leaves the result at the top
+    /// If the number of values is 1, the result is a single value on the stack (nothing changes)
+    /// If the number of values is 0, the result is the empty string
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_concat
+    pub fn concat(lua: *Lua, n: i32) void {
+        c.lua_concat(lua.state, n);
+    }
+
+    /// Creates a new empty table and pushes onto the stack
+    /// num_arr is a hint for how many elements the table will have as a sequence
+    /// num_rec is a hint for how many other elements the table will have
+    /// Lua may preallocate memory for the table based on the hints
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_createtable
+    pub fn createTable(lua: *Lua, num_arr: i32, num_rec: i32) void {
+        c.lua_createtable(lua.state, num_arr, num_rec);
+    }
+
+    /// Returns true if the two values at the indexes are equal following the semantics of the
+    /// Lua == operator.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_equal
+    pub fn equal(lua: *Lua, index1: i32, index2: i32) bool {
+        return c.lua_equal(lua.state, index1, index2) == 1;
+    }
+
+    /// Raises a Lua error using the value at the top of the stack as the error object
+    /// Does a longjump and therefore never returns
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_error
+    pub fn raiseError(lua: *Lua) noreturn {
+        _ = c.lua_error(lua.state);
+        unreachable;
+    }
+
+    /// Perform a full garbage-collection cycle
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcCollect(lua: *Lua) void {
+        _ = c.lua_gc(lua.state, c.LUA_GCCOLLECT, 0);
+    }
+
+    /// Stops the garbage collector
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcStop(lua: *Lua) void {
+        _ = c.lua_gc(lua.state, c.LUA_GCSTOP, 0);
+    }
+
+    /// Restarts the garbage collector
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcRestart(lua: *Lua) void {
+        _ = c.lua_gc(lua.state, c.LUA_GCRESTART, 0);
+    }
+
+    /// Performs an incremental step of garbage collection corresponding to the allocation of step_size Kbytes
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcStep(lua: *Lua) void {
+        _ = c.lua_gc(lua.state, c.LUA_GCSTEP, 0);
+    }
+
+    /// Returns the current amount of memory (in Kbytes) in use by Lua
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcCount(lua: *Lua) i32 {
+        return c.lua_gc(lua.state, c.LUA_GCCOUNT, 0);
+    }
+
+    /// Returns the remainder of dividing the current amount of bytes of memory in use by Lua by 1024
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcCountB(lua: *Lua) i32 {
+        return c.lua_gc(lua.state, c.LUA_GCCOUNTB, 0);
+    }
+
+    /// Sets `multiplier` as the new value for the step multiplier of the collector
+    /// Returns the previous value of the step multiplier
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gc
+    pub fn gcSetStepMul(lua: *Lua, multiplier: i32) i32 {
+        return c.lua_gc(lua.state, c.LUA_GCSETSTEPMUL, multiplier);
+    }
+
+    /// Returns the memory allocation function of a given state
+    /// If data is not null, it is set to the opaque pointer given when the allocator function was set
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getallocf
+    pub fn getAllocFn(lua: *Lua, data: ?**anyopaque) AllocFn {
+        // Assert cannot be null because it is impossible (and not useful) to pass null
+        // to the functions that set the allocator (setallocf and newstate)
+        return c.lua_getallocf(lua.state, @ptrCast(data)).?;
+    }
+
+    /// Pushes onto the stack the environment table of the value at the given index.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getfenv
+    pub fn getFnEnvironment(lua: *Lua, index: i32) void {
+        c.lua_getfenv(lua.state, index);
+    }
+
+    /// Pushes onto the stack the value t[key] where t is the value at the given index
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getfield
+    pub fn getField(lua: *Lua, index: i32, key: [:0]const u8) LuaType {
+        return @enumFromInt(c.lua_getfield(lua.state, index, key.ptr));
+    }
+
+    /// Pushes onto the stack the value of the global name
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getglobal
+    pub fn getGlobal(lua: *Lua, name: [:0]const u8) LuaType {
+        return @enumFromInt(c.lua_getglobal(lua.state, name.ptr));
+    }
+
+    /// If the value at the given index has a metatable, the function pushes that metatable onto the stack
+    /// Otherwise an error is returned
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getmetatable
+    pub fn getMetatable(lua: *Lua, index: i32) !void {
+        if (c.lua_getmetatable(lua.state, index) == 0) return error.Fail;
+    }
+
+    /// Pushes onto the stack the value t[k] where t is the value at the given index and k is the value on the top of the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gettable
+    pub fn getTable(lua: *Lua, index: i32) LuaType {
+        return @enumFromInt(c.lua_gettable(lua.state, index));
+    }
+
+    /// Returns the index of the top element in the stack
+    /// Because indices start at 1, the result is also equal to the number of elements in the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_gettop
+    pub fn getTop(lua: *Lua) i32 {
+        return c.lua_gettop(lua.state);
+    }
+
+    /// Moves the top element into the given valid `index` shifting up any elements to make room
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_insert
+    pub fn insert(lua: *Lua, index: i32) void {
+        // translate-c cannot translate this macro correctly
+        c.lua_insert(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a boolean
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isboolean
+    pub fn isBoolean(lua: *Lua, index: i32) bool {
+        return c.lua_isboolean(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a CFn
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_iscfunction
+    pub fn isCFunction(lua: *Lua, index: i32) bool {
+        return c.lua_iscfunction(lua.state, index) != 0;
+    }
+
+    /// Returns true if the value at the given index is a function (C or Lua)
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isfunction
+    pub fn isFunction(lua: *Lua, index: i32) bool {
+        return c.lua_isfunction(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a light userdata
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_islightuserdata
+    pub fn isLightUserdata(lua: *Lua, index: i32) bool {
+        return c.lua_islightuserdata(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is nil
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isnil
+    pub fn isNil(lua: *Lua, index: i32) bool {
+        return c.lua_isnil(lua.state, index);
+    }
+
+    /// Returns true if the given index is not valid
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isnone
+    pub fn isNone(lua: *Lua, index: i32) bool {
+        return c.lua_isnone(lua.state, index);
+    }
+
+    /// Returns true if the given index is not valid or if the value at the index is nil
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isnoneornil
+    pub fn isNoneOrNil(lua: *Lua, index: i32) bool {
+        return c.lua_isnoneornil(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a number
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isnumber
+    pub fn isNumber(lua: *Lua, index: i32) bool {
+        return c.lua_isnumber(lua.state, index) != 0;
+    }
+
+    /// Returns true if the value at the given index is a string
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isstring
+    pub fn isString(lua: *Lua, index: i32) bool {
+        return c.lua_isstring(lua.state, index) != 0;
+    }
+
+    /// Returns true if the value at the given index is a table
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_istable
+    pub fn isTable(lua: *Lua, index: i32) bool {
+        return c.lua_istable(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a thread
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isthread
+    pub fn isThread(lua: *Lua, index: i32) bool {
+        return c.lua_isthread(lua.state, index);
+    }
+
+    /// Returns true if the value at the given index is a userdata (full or light)
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_isuserdata
+    pub fn isUserdata(lua: *Lua, index: i32) bool {
+        return c.lua_isuserdata(lua.state, index) != 0;
+    }
+
+    /// Returns true if the value at index1 is smaller than the value at index2, following the
+    /// semantics of the Lua < operator.
+    /// See https://www.lua.org/manual/5.4/manual.html#lua_lessthan
+    pub fn lessThan(lua: *Lua, index1: i32, index2: i32) bool {
+        return c.lua_lessthan(lua.state, index1, index2) == 1;
+    }
+
+    /// Creates a new independent state and returns its main thread
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newstate
+    pub fn newState(alloc_fn: AllocFn, data: ?*anyopaque) !Lua {
+        zig_registerAssertionHandler();
+        const state = c.lua_newstate(alloc_fn, data) orelse return error.Memory;
+        return Lua{ .state = state };
+    }
+
+    /// Creates a new empty table and pushes it onto the stack
+    /// Equivalent to createTable(0, 0)
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newtable
+    pub fn newTable(lua: *Lua) void {
+        c.lua_newtable(lua.state);
+    }
+
+    /// Creates a new thread, pushes it on the stack, and returns a Lua state that represents the new thread
+    /// The new thread shares the global environment but has a separate execution stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newthread
+    pub fn newThread(lua: *Lua) Lua {
+        const state = c.lua_newthread(lua.state).?;
+        return .{ .state = state };
+    }
+
+    /// This function allocates a new userdata of the given type.
+    /// Returns a pointer to the Lua-owned data
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newuserdata
+    pub fn newUserdata(lua: *Lua, comptime T: type) *T {
+        // safe to .? because this function throws a Lua error on out of memory
+        // so the returned pointer should never be null
+        const ptr = c.lua_newuserdata(lua.state, @sizeOf(T)).?;
+        return opaqueCast(T, ptr);
+    }
+
+    /// This function creates and pushes a slice of full userdata onto the stack.
+    /// Returns a slice to the Lua-owned data.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_newuserdata
+    pub fn newUserdataSlice(lua: *Lua, comptime T: type, size: usize) []T {
+        // safe to .? because this function throws a Lua error on out of memory
+        const ptr = c.lua_newuserdata(lua.state, @sizeOf(T) * size).?;
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
+    }
+
+    /// Pops a key from the stack, and pushes a key-value pair from the table at the given index.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_next
+    pub fn next(lua: *Lua, index: i32) bool {
+        return c.lua_next(lua.state, index) != 0;
+    }
+
+    /// Returns the length of the value at the given index
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_objlen
+    pub fn objectLen(lua: *Lua, index: i32) i32 {
+        return c.lua_objlen(lua.state, index);
+    }
+
+    /// Calls a function (or callable object) in protected mode
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pcall
+    pub fn protectedCall(lua: *Lua, num_args: i32, num_results: i32, err_func: i32) !void {
+        // The translate-c version of lua_pcall does not type-check so we must rewrite it
+        // (macros don't always translate well with translate-c)
+        const ret = c.lua_pcall(lua.state, num_args, num_results, err_func);
+        switch (ret) {
+            StatusCode.ok => return,
+            StatusCode.err_runtime => return error.Runtime,
+            StatusCode.err_memory => return error.Memory,
+            StatusCode.err_error => return error.MsgHandler,
+            else => unreachable,
+        }
+    }
+
+    /// Pops `n` elements from the top of the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pop
+    pub fn pop(lua: *Lua, n: i32) void {
+        lua.setTop(-n - 1);
+    }
+
+    /// Pushes a boolean value with value `b` onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushboolean
+    pub fn pushBoolean(lua: *Lua, b: bool) void {
+        c.lua_pushboolean(lua.state, @intFromBool(b));
+    }
+
+    /// Pushes a new Closure onto the stack
+    /// `n` tells how many upvalues this function will have
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushcclosure
+    pub fn pushClosure(lua: *Lua, c_fn: CFn, name: [:0]const u8, n: i32) void {
+        c.lua_pushcclosurek(lua.state, c_fn, name, n, null);
+    }
+
+    /// Pushes a function onto the stack.
+    /// Equivalent to pushClosure with no upvalues
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushfunction
+    pub fn pushFunction(lua: *Lua, c_fn: CFn, name: [:0]const u8) void {
+        lua.pushClosure(c_fn, name, 0);
+    }
+
+    /// Push a formatted string onto the stack and return a pointer to the string
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushfstring
+    pub fn pushFString(lua: *Lua, fmt: [:0]const u8, args: anytype) [*:0]const u8 {
+        return @call(.auto, c.lua_pushfstringL, .{ lua.state, fmt.ptr } ++ args);
+    }
+
+    /// Pushes an integer with value `n` onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushinteger
+    pub fn pushInteger(lua: *Lua, n: Integer) void {
+        c.lua_pushinteger(lua.state, n);
+    }
+
+    /// Pushes a light userdata onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushlightuserdata
+    pub fn pushLightUserdata(lua: *Lua, ptr: *anyopaque) void {
+        c.lua_pushlightuserdata(lua.state, ptr);
+    }
+
+    /// Pushes the bytes onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushlstring
+    pub fn pushBytes(lua: *Lua, bytes: []const u8) void {
+        c.lua_pushlstring(lua.state, bytes.ptr, bytes.len);
+    }
+
+    /// Pushes a nil value onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushnil
+    pub fn pushNil(lua: *Lua) void {
+        c.lua_pushnil(lua.state);
+    }
+
+    /// Pushes a float with value `n` onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushnumber
+    pub fn pushNumber(lua: *Lua, n: Number) void {
+        c.lua_pushnumber(lua.state, n);
+    }
+
+    /// Pushes a zero-terminated string onto the stack
+    /// Lua makes a copy of the string so `str` may be freed immediately after return
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushstring
+    pub fn pushString(lua: *Lua, str: [:0]const u8) void {
+        c.lua_pushstring(lua.state, str.ptr);
+    }
+
+    /// Pushes this thread onto the stack
+    /// Returns true if this thread is the main thread of its state
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushthread
+    pub fn pushThread(lua: *Lua) bool {
+        return c.lua_pushthread(lua.state) != 0;
+    }
+
+    /// Pushes a copy of the element at the given index onto the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_pushvalue
+    pub fn pushValue(lua: *Lua, index: i32) void {
+        c.lua_pushvalue(lua.state, index);
+    }
+
+    /// Returns true if the two values in indices `index1` and `index2` are primitively equal
+    /// Bypasses __eq metamethods
+    /// Returns false if not equal, or if any index is invalid
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_rawequal
+    pub fn rawEqual(lua: *Lua, index1: i32, index2: i32) bool {
+        return c.lua_rawequal(lua.state, index1, index2) != 0;
+    }
+
+    /// Similar to `Lua.getTable()` but does a raw access (without metamethods)
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_rawget
+    pub fn rawGetTable(lua: *Lua, index: i32) LuaType {
+        return @enumFromInt(c.lua_rawget(lua.state, index));
+    }
+
+    /// Pushes onto the stack the value t[n], where `t` is the table at the given `index`
+    /// Returns the `LuaType` of the pushed value
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_rawgeti
+    pub fn rawGetIndex(lua: *Lua, index: i32, n: i32) LuaType {
+        return @enumFromInt(c.lua_rawgeti(lua.state, index, n));
+    }
+
+    /// Similar to `Lua.setTable()` but does a raw assignment (without metamethods)
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_rawset
+    pub fn rawSetTable(lua: *Lua, index: i32) void {
+        c.lua_rawset(lua.state, index);
+    }
+
+    /// Does the equivalent of t[`i`] = v where t is the table at the given `index`
+    /// and v is the value at the top of the stack
+    /// Pops the value from the stack. Does not use __newindex metavalue
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_rawseti
+    pub fn rawSetIndex(lua: *Lua, index: i32, i: i32) void {
+        c.lua_rawseti(lua.state, index, i);
+    }
+
+    // /// Sets the C function f as the new value of global name
+    // /// See https://www.lua.org/manual/5.1/manual.html#lua_register
+    // pub fn register(lua: *Lua, name: [:0]const u8, c_fn: CFn) void {
+    //     // translate-c failure
+    //     // c.lua_register(lua.state, name, c_fn);
+    //     lua.pushFunction(c_fn);
+    //     lua.setGlobal(name);
+    // }
+
+    /// Removes the element at the given valid `index` shifting down elements to fill the gap
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_remove
+    pub fn remove(lua: *Lua, index: i32) void {
+        c.lua_remove(lua.state, index);
+    }
+
+    /// Moves the top element into the given valid `index` without shifting any elements,
+    /// then pops the top element
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_replace
+    pub fn replace(lua: *Lua, index: i32) void {
+        c.lua_replace(lua.state, index);
+    }
+
+    /// Starts and resumes a coroutine in the thread
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_resume
+    pub fn resumeThread(lua: *Lua, from: ?Lua, num_args: i32) !ResumeStatus {
+        const from_state = if (from) |from_val| from_val.state else null;
+        const thread_status = c.lua_resume(lua.state, from_state, num_args);
+        switch (thread_status) {
+            StatusCode.err_runtime => return error.Runtime,
+            StatusCode.err_memory => return error.Memory,
+            StatusCode.err_error => return error.MsgHandler,
+            else => return @enumFromInt(thread_status),
+        }
+    }
+
+    /// Pops a table from the stack and sets it as the new environment for the value at the
+    /// given index. Returns an error if the value at that index is not a function or thread or userdata.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setfenv
+    pub fn setFnEnvironment(lua: *Lua, index: i32) !void {
+        if (c.lua_setfenv(lua.state, index) == 0) return error.Fail;
+    }
+
+    /// Does the equivalent to t[`k`] = v where t is the value at the given `index`
+    /// and v is the value on the top of the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setfield
+    pub fn setField(lua: *Lua, index: i32, k: [:0]const u8) void {
+        c.lua_setfield(lua.state, index, k.ptr);
+    }
+
+    /// Pops a value from the stack and sets it as the new value of global `name`
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setglobal
+    pub fn setGlobal(lua: *Lua, name: [:0]const u8) void {
+        c.lua_setglobal(lua.state, name.ptr);
+    }
+
+    /// Pops a table or nil from the stack and sets that value as the new metatable for the
+    /// value at the given `index`
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setmetatable
+    pub fn setMetatable(lua: *Lua, index: i32) void {
+        // lua_setmetatable always returns 1 so is safe to ignore
+        _ = c.lua_setmetatable(lua.state, index);
+    }
+
+    /// Does the equivalent to t[k] = v, where t is the value at the given `index`
+    /// v is the value on the top of the stack, and k is the value just below the top
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_settable
+    pub fn setTable(lua: *Lua, index: i32) void {
+        c.lua_settable(lua.state, index);
+    }
+
+    /// Sets the top of the stack to `index`
+    /// If the new top is greater than the old, new elements are filled with nil
+    /// If `index` is 0 all stack elements are removed
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_settop
+    pub fn setTop(lua: *Lua, index: i32) void {
+        c.lua_settop(lua.state, index);
+    }
+
+    /// Returns the status of this thread
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_status
+    pub fn status(lua: *Lua) Status {
+        return @enumFromInt(c.lua_status(lua.state));
+    }
+
+    /// Converts the Lua value at the given `index` into a boolean
+    /// The Lua value at the index will be considered true unless it is false or nil
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_toboolean
+    pub fn toBoolean(lua: *Lua, index: i32) bool {
+        return c.lua_toboolean(lua.state, index) != 0;
+    }
+
+    /// Converts a value at the given `index` into a CFn
+    /// Returns an error if the value is not a CFn
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tocfunction
+    pub fn toCFunction(lua: *Lua, index: i32) !CFn {
+        return c.lua_tocfunction(lua.state, index) orelse return error.Fail;
+    }
+
+    /// Converts the Lua value at the given `index` to a signed integer
+    /// The Lua value must be an integer, or a number, or a string convertible to an integer otherwise toInteger returns 0
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tointeger
+    pub fn toInteger(lua: *Lua, index: i32) !Integer {
+        var success: c_int = undefined;
+        const result = c.lua_tointegerx(lua.state, index, &success);
+        if (success == 0) return error.Fail;
+        return result;
+    }
+
+    /// Returns a slice of bytes at the given index
+    /// If the value is not a string or number, returns an error
+    /// If the value was a number the actual value in the stack will be changed to a string
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tolstring
+    pub fn toBytes(lua: *Lua, index: i32) ![:0]const u8 {
+        var length: usize = undefined;
+        if (c.lua_tolstring(lua.state, index, &length)) |ptr| return ptr[0..length :0];
+        return error.Fail;
+    }
+
+    /// Converts the Lua value at the given `index` to a float
+    /// The Lua value must be a number or a string convertible to a number otherwise toNumber returns 0
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tonumber
+    pub fn toNumber(lua: *Lua, index: i32) !Number {
+        var success: c_int = undefined;
+        const result = c.lua_tonumberx(lua.state, index, &success);
+        if (success == 0) return error.Fail;
+        return result;
+    }
+
+    /// Converts the value at the given `index` to an opaque pointer
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_topointer
+    pub fn toPointer(lua: *Lua, index: i32) !*const anyopaque {
+        if (c.lua_topointer(lua.state, index)) |ptr| return ptr;
+        return error.Fail;
+    }
+
+    /// Converts the Lua value at the given `index` to a zero-terminated many-itemed-pointer (string)
+    /// Returns an error if the conversion failed
+    /// If the value was a number the actual value in the stack will be changed to a string
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tolstring
+    pub fn toString(lua: *Lua, index: i32) ![*:0]const u8 {
+        var length: usize = undefined;
+        if (c.lua_tolstring(lua.state, index, &length)) |str| return str;
+        return error.Fail;
+    }
+
+    /// Converts the value at the given `index` to a Lua thread (wrapped with a `Lua` struct)
+    /// The thread does _not_ contain an allocator because it is not the main thread and should therefore not be used with `deinit()`
+    /// Returns an error if the value is not a thread
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_tothread
+    pub fn toThread(lua: *Lua, index: i32) !Lua {
+        const thread = c.lua_tothread(lua.state, index);
+        if (thread) |thread_ptr| return Lua{ .state = thread_ptr };
+        return error.Fail;
+    }
+
+    /// Returns a Lua-owned userdata pointer of the given type at the given index.
+    /// Works for both light and full userdata.
+    /// Returns an error if the value is not a userdata.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_touserdata
+    pub fn toUserdata(lua: *Lua, comptime T: type, index: i32) !*T {
+        if (c.lua_touserdata(lua.state, index)) |ptr| return opaqueCast(T, ptr);
+        return error.Fail;
+    }
+
+    /// Returns a Lua-owned userdata slice of the given type at the given index.
+    /// Returns an error if the value is not a userdata.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_touserdata
+    pub fn toUserdataSlice(lua: *Lua, comptime T: type, index: i32) ![]T {
+        if (c.lua_touserdata(lua.state, index)) |ptr| {
+            const size = @as(u32, @intCast(lua.objectLen(index))) / @sizeOf(T);
+            return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
+        }
+        return error.Fail;
+    }
+
+    /// Returns the `LuaType` of the value at the given index
+    /// Note that this is equivalent to lua_type but because type is a Zig primitive it is renamed to `typeOf`
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_type
+    pub fn typeOf(lua: *Lua, index: i32) LuaType {
+        return @enumFromInt(c.lua_type(lua.state, index));
+    }
+
+    /// Returns the name of the given `LuaType` as a null-terminated slice
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_typename
+    pub fn typeName(lua: *Lua, t: LuaType) [:0]const u8 {
+        return std.mem.span(c.lua_typename(lua.state, @intFromEnum(t)));
+    }
+
+    /// Returns the pseudo-index that represents the `i`th upvalue of the running function
+    pub fn upvalueIndex(i: i32) i32 {
+        return c.lua_upvalueindex(i);
+    }
+
+    /// Pops `num` values from the current stack and pushes onto the stack of `to`
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_xmove
+    pub fn xMove(lua: *Lua, to: Lua, num: i32) void {
+        c.lua_xmove(lua.state, to.state, num);
+    }
+
+    /// Yields a coroutine
+    /// This function must be used as the return expression of a function
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_yield
+    pub fn yield(lua: *Lua, num_results: i32) i32 {
+        return c.lua_yield(lua.state, num_results);
+    }
+
+    // Debug library functions
+    //
+    // The debug interface functions are included in alphabetical order
+    // Each is kept similar to the original C API function while also making it easy to use from Zig
+
+    /// Gets information about a specific function or function invocation.
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getinfo
+    pub fn getInfo(lua: *Lua, level: i32, options: DebugInfo.Options, info: *DebugInfo) void {
+        const str = options.toString();
+
+        var ar: Debug = undefined;
+
+        // should never fail because we are controlling options with the struct param
+        _ = c.lua_getinfo(lua.state, level, &str, &ar);
+        // std.debug.assert( != 0);
+
+        // copy data into a struct
+        if (options.l) info.current_line = if (ar.currentline == -1) null else ar.currentline;
+        if (options.n) {
+            info.name = if (ar.name != null) std.mem.span(ar.name) else null;
+        }
+        if (options.S) {
+            info.source = std.mem.span(ar.source);
+            // TODO: short_src figureit out
+            // @memcpy(&info.short_src, ar.short_src);
+            info.first_line_defined = ar.linedefined;
+            info.what = blk: {
+                const what = std.mem.span(ar.what);
+                if (std.mem.eql(u8, "Lua", what)) break :blk .lua;
+                if (std.mem.eql(u8, "C", what)) break :blk .c;
+                if (std.mem.eql(u8, "main", what)) break :blk .main;
+                if (std.mem.eql(u8, "tail", what)) break :blk .tail;
+                unreachable;
+            };
+        }
+    }
+
+    /// Gets information about a local variable
+    /// Returns the name of the local variable
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getlocal
+    pub fn getLocal(lua: *Lua, level: i32, n: i32) ![:0]const u8 {
+        if (c.lua_getlocal(lua.state, level, n)) |name| {
+            return std.mem.span(name);
+        }
+        return error.Fail;
+    }
+
+    /// Gets information about the `n`th upvalue of the closure at index `func_index`
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_getupvaule
+    pub fn getUpvalue(lua: *Lua, func_index: i32, n: i32) ![:0]const u8 {
+        if (c.lua_getupvalue(lua.state, func_index, n)) |name| {
+            return std.mem.span(name);
+        }
+        return error.Fail;
+    }
+
+    /// Sets the value of a local variable
+    /// Returns an error when the index is greater than the number of active locals
+    /// Returns the name of the local variable
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setlocal
+    pub fn setLocal(lua: *Lua, level: i32, n: i32) ![:0]const u8 {
+        if (c.lua_setlocal(lua.state, level, n)) |name| {
+            return std.mem.span(name);
+        }
+        return error.Fail;
+    }
+
+    /// Sets the value of a closure's upvalue
+    /// Returns the name of the upvalue or an error if the upvalue does not exist
+    /// See https://www.lua.org/manual/5.1/manual.html#lua_setupvalue
+    pub fn setUpvalue(lua: *Lua, func_index: i32, n: i32) ![:0]const u8 {
+        if (c.lua_setupvalue(lua.state, func_index, n)) |name| {
+            return std.mem.span(name);
+        }
+        return error.Fail;
+    }
+
+    // Auxiliary library functions
+    //
+    // Auxiliary library functions are included in alphabetical order.
+    // Each is kept similar to the original C API function while also making it easy to use from Zig
+
+    /// Checks whether `cond` is true. Raises an error using `Lua.argError()` if not
+    /// Possibly never returns
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_argcheck
+    pub fn argCheck(lua: *Lua, cond: bool, arg: i32, extra_msg: [:0]const u8) void {
+        // translate-c failed
+        if (!cond) lua.argError(arg, extra_msg);
+    }
+
+    /// Raises an error reporting a problem with argument `arg` of the C function that called it
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_argerror
+    pub fn argError(lua: *Lua, arg: i32, extra_msg: [*:0]const u8) noreturn {
+        _ = c.luaL_argerror(lua.state, arg, extra_msg);
+        unreachable;
+    }
+
+    /// Calls a metamethod
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_callmeta
+    pub fn callMeta(lua: *Lua, obj: i32, field: [:0]const u8) !void {
+        if (c.luaL_callmeta(lua.state, obj, field.ptr) == 0) return error.Fail;
+    }
+
+    /// Checks whether the function has an argument of any type at position `arg`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkany
+    pub fn checkAny(lua: *Lua, arg: i32) void {
+        c.luaL_checkany(lua.state, arg);
+    }
+
+    /// Checks whether the function argument `arg` is a number and returns the number cast to an Integer
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkinteger
+    pub fn checkInteger(lua: *Lua, arg: i32) Integer {
+        return c.luaL_checkinteger(lua.state, arg);
+    }
+
+    /// Checks whether the function argument `arg` is a slice of bytes and returns the slice
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checklstring
+    pub fn checkBytes(lua: *Lua, arg: i32) [:0]const u8 {
+        var length: usize = 0;
+        const str = c.luaL_checklstring(lua.state, arg, &length);
+        // luaL_checklstring never returns null (throws lua error)
+        return str[0..length :0];
+    }
+
+    /// Checks whether the function argument `arg` is a number and returns the number
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checknumber
+    pub fn checkNumber(lua: *Lua, arg: i32) Number {
+        return c.luaL_checknumber(lua.state, arg);
+    }
+
+    /// Checks whether the function argument `arg` is a string and searches for the enum value with the same name in `T`.
+    /// `default` is used as a default value when not null
+    /// Returns the enum value found
+    /// Useful for mapping Lua strings to Zig enums
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkoption
+    pub fn checkOption(lua: *Lua, comptime T: type, arg: i32, default: ?T) T {
+        const name = blk: {
+            if (default) |defaultName| {
+                break :blk lua.optBytes(arg, @tagName(defaultName));
+            } else {
+                break :blk lua.checkBytes(arg);
+            }
+        };
+
+        inline for (std.meta.fields(T)) |field| {
+            if (std.mem.eql(u8, field.name, name)) {
+                return @enumFromInt(field.value);
+            }
+        }
+
+        return lua.argError(arg, lua.pushFString("invalid option '%s'", .{name.ptr}));
+    }
+
+    /// Grows the stack size to top + `size` elements, raising an error if the stack cannot grow to that size
+    /// `msg` is an additional text to go into the error message
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkstack
+    pub fn checkStackErr(lua: *Lua, size: i32, msg: ?[*:0]const u8) void {
+        c.luaL_checkstack(lua.state, size, msg);
+    }
+
+    /// Checks whether the function argument `arg` is a string and returns the string
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkstring
+    pub fn checkString(lua: *Lua, arg: i32) [*:0]const u8 {
+        return c.luaL_checklstring(lua.state, arg, null);
+    }
+
+    /// Checks whether the function argument `arg` has type `t`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checktype
+    pub fn checkType(lua: *Lua, arg: i32, t: LuaType) void {
+        c.luaL_checktype(lua.state, arg, @intFromEnum(t));
+    }
+
+    /// Checks whether the function argument `arg` is a userdata of the type `name`
+    /// Returns the userdata's memory-block address
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkudata
+    pub fn checkUserdata(lua: *Lua, comptime T: type, arg: i32, name: [:0]const u8) *T {
+        // the returned pointer will not be null
+        return opaqueCast(T, c.luaL_checkudata(lua.state, arg, name.ptr).?);
+    }
+
+    /// Checks whether the function argument `arg` is a userdata of the type `name`
+    /// Returns a Lua-owned userdata slice
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_checkudata
+    pub fn checkUserdataSlice(lua: *Lua, comptime T: type, arg: i32, name: [:0]const u8) []T {
+        // the returned pointer will not be null
+        const ptr = c.luaL_checkudata(lua.state, arg, name.ptr).?;
+        const size = @as(u32, @intCast(lua.objectLen(arg))) / @sizeOf(T);
+        return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
+    }
+
+    /// Raises an error
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_error
+    pub fn raiseErrorStr(lua: *Lua, fmt: [:0]const u8, args: anytype) noreturn {
+        _ = @call(.auto, c.luaL_errorL, .{ lua.state, fmt.ptr } ++ args);
+        unreachable;
+    }
+
+    /// Pushes onto the stack the field `e` from the metatable of the object at index `obj`
+    /// and returns the type of the pushed value
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_getmetafield
+    pub fn getMetaField(lua: *Lua, obj: i32, field: [:0]const u8) !LuaType {
+        const val_type: LuaType = @enumFromInt(c.luaL_getmetafield(lua.state, obj, field.ptr));
+        if (val_type == .nil) return error.Fail;
+        return val_type;
+    }
+
+    /// Pushes onto the stack the metatable associated with the name `type_name` in the registry
+    /// or nil if there is no metatable associated with that name. Returns the type of the pushed value
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_getmetatable
+    pub fn getMetatableRegistry(lua: *Lua, table_name: [:0]const u8) LuaType {
+        return @enumFromInt(c.luaL_getmetatable(lua.state, table_name));
+    }
+
+    /// If the registry already has the key `key`, returns an error
+    /// Otherwise, creates a new table to be used as a metatable for userdata
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_newmetatable
+    pub fn newMetatable(lua: *Lua, key: [:0]const u8) !void {
+        if (c.luaL_newmetatable(lua.state, key.ptr) == 0) return error.Fail;
+    }
+
+    /// Creates a new Lua state with an allocator using the default libc allocator
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_newstate
+    pub fn newStateLibc() !Lua {
+        zig_registerAssertionHandler();
+        const state = c.luaL_newstate() orelse return error.Memory;
+        return Lua{ .state = state };
+    }
+
+    // luaL_opt (a macro) really isn't that useful, so not going to implement for now
+
+    /// If the function argument `arg` is an integer, returns the integer
+    /// If the argument is absent or nil returns `default`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_optinteger
+    pub fn optInteger(lua: *Lua, arg: i32, default: Integer) Integer {
+        return c.luaL_optinteger(lua.state, arg, default);
+    }
+
+    /// If the function argument `arg` is a slice of bytes, returns the slice
+    /// If the argument is absent or nil returns `default`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_optlstring
+    pub fn optBytes(lua: *Lua, arg: i32, default: [:0]const u8) [:0]const u8 {
+        var length: usize = 0;
+        // will never return null because default cannot be null
+        const ret: [*]const u8 = c.luaL_optlstring(lua.state, arg, default.ptr, &length);
+        if (ret == default.ptr) return default;
+        return ret[0..length :0];
+    }
+
+    /// If the function argument `arg` is a number, returns the number
+    /// If the argument is absent or nil returns `default`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_optnumber
+    pub fn optNumber(lua: *Lua, arg: i32, default: Number) Number {
+        return c.luaL_optnumber(lua.state, arg, default);
+    }
+
+    /// If the function argument `arg` is a string, returns the string
+    /// If the argment is absent or nil returns `default`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_optstring
+    pub fn optString(lua: *Lua, arg: i32, default: [:0]const u8) [*:0]const u8 {
+        // translate-c error
+        return c.luaL_optlstring(lua.state, arg, default.ptr, null);
+    }
+
+    /// Creates and returns a reference in the table at index `index` for the object on the top of the stack
+    /// Pops the object
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_ref
+    pub fn ref(lua: *Lua, index: i32) !i32 {
+        const ret = c.lua_ref(lua.state, index);
+        return if (ret == ref_nil) error.Fail else ret;
+    }
+
+    /// Opens a library
+    pub fn registerFns(lua: *Lua, libname: ?[:0]const u8, funcs: []const FnReg) void {
+        // translated from the implementation of luaI_openlib so we can use a slice of
+        // FnReg without requiring a sentinel end value
+        if (libname) |name| {
+            _ = c.luaL_findtable(lua.state, registry_index, "_LOADED", 1);
+            _ = lua.getField(-1, name);
+            if (!lua.isTable(-1)) {
+                lua.pop(1);
+                if (c.luaL_findtable(lua.state, globals_index, name, @intCast(funcs.len))) |_| {
+                    lua.raiseErrorStr("name conflict for module '%s'", .{name.ptr});
+                }
+                lua.pushValue(-1);
+                lua.setField(-3, name);
+            }
+            lua.remove(-2);
+            lua.insert(-1);
+        }
+        for (funcs) |f| {
+            lua.pushFunction(f.func, f.name);
+            lua.setField(-2, f.name);
+        }
+    }
+
+    /// Returns the name of the type of the value at the given `index`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_typename
+    pub fn typeNameIndex(lua: *Lua, index: i32) [:0]const u8 {
+        return std.mem.span(c.luaL_typename(lua.state, index));
+    }
+
+    /// Releases the reference `r` from the table at index `index`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_unref
+    pub fn unref(lua: *Lua, r: i32) void {
+        c.lua_unref(lua.state, r);
+    }
+
+    /// Pushes onto the stack a string identifying the current position of the control
+    /// at the call stack `level`
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_where
+    pub fn where(lua: *Lua, level: i32) void {
+        c.luaL_where(lua.state, level);
+    }
+
+    // Standard library loading functions
+
+    /// Opens the specified standard library functions
+    /// Behaves like openLibs, but allows specifying which libraries
+    /// to expose to the global table rather than all of them
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_openlibs
+    pub fn open(lua: *Lua, libs: Libs) void {
+        if (libs.base) lua.requireF("", c.luaopen_base);
+        if (libs.string) lua.requireF(c.LUA_STRLIBNAME, c.luaopen_string);
+        if (libs.table) lua.requireF(c.LUA_TABLIBNAME, c.luaopen_table);
+        if (libs.math) lua.requireF(c.LUA_MATHLIBNAME, c.luaopen_math);
+        if (libs.os) lua.requireF(c.LUA_OSLIBNAME, c.luaopen_os);
+        if (libs.debug) lua.requireF(c.LUA_DBLIBNAME, c.luaopen_debug);
+    }
+
+    fn requireF(lua: *Lua, name: [:0]const u8, func: CFn) void {
+        lua.pushFunction(func, name);
+        lua.pushString(name);
+        lua.call(1, 0);
+    }
+
+    /// Open all standard libraries
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_openlibs
+    pub fn openLibs(lua: *Lua) void {
+        c.luaL_openlibs(lua.state);
+    }
+
+    /// Open the basic standard library
+    pub fn openBase(lua: *Lua) void {
+        _ = c.luaopen_base(lua.state);
+    }
+
+    /// Open the string standard library
+    pub fn openString(lua: *Lua) void {
+        _ = c.luaopen_string(lua.state);
+    }
+
+    /// Open the table standard library
+    pub fn openTable(lua: *Lua) void {
+        _ = c.luaopen_table(lua.state);
+    }
+
+    /// Open the math standard library
+    pub fn openMath(lua: *Lua) void {
+        _ = c.luaopen_math(lua.state);
+    }
+
+    /// Open the os standard library
+    pub fn openOS(lua: *Lua) void {
+        _ = c.luaopen_os(lua.state);
+    }
+
+    /// Open the debug standard library
+    pub fn openDebug(lua: *Lua) void {
+        _ = c.luaopen_debug(lua.state);
+    }
+};
+
+/// A string buffer allowing for Zig code to build Lua strings piecemeal
+/// All LuaBuffer functions are wrapped in this struct to make the API more convenient to use
+/// See https://www.lua.org/manual/5.1/manual.html#luaL_Buffer
+pub const Buffer = struct {
+    b: LuaBuffer = undefined,
+
+    /// Initialize a Lua string buffer
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_buffinit
+    pub fn init(buf: *Buffer, lua: Lua) void {
+        c.luaL_buffinit(lua.state, &buf.b);
+    }
+
+    /// TODO: buffinitsize
+
+    /// Internal Lua type for a string buffer
+    pub const LuaBuffer = c.luaL_Strbuf;
+
+    // pub const buffer_size = c.LUAL_BUFFERSIZE;
+    pub const buffer_size = 10;
+
+    // TODO: addchar (defined as a macro)
+
+    /// Adds the string to the buffer
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_addlstring
+    pub fn addBytes(buf: *Buffer, str: []const u8) void {
+        c.luaL_addlstring(&buf.b, str.ptr, str.len);
+    }
+
+    /// Adds to the buffer a string of `length` previously copied to the buffer area
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_addsize
+    pub fn addSize(buf: *Buffer, length: usize) void {
+        // another function translate-c couldn't handle
+        // c.luaL_addsize(&buf.b, length);
+        var lua_buf = &buf.b;
+        lua_buf.p += length;
+    }
+
+    /// Adds the value on the top of the stack to the buffer and pops the value
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_addvalue
+    pub fn addValue(buf: *Buffer) void {
+        c.luaL_addvalue(&buf.b);
+    }
+
+    /// TODO: addvalueany
+
+    /// Equivalent to prepSize with a buffer size of Buffer.buffer_size
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_prepbuffer
+    // pub fn prep(buf: *Buffer) []u8 {
+    //     return c.luaL_prepbuffsize(&buf.b, buffer_size);
+    // }
+
+    /// TODO: prepbuffsize
+
+    /// Finishes the use of the buffer leaving the final string on the top of the stack
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_pushresult
+    pub fn pushResult(buf: *Buffer) void {
+        c.luaL_pushresult(&buf.b);
+    }
+
+    // TODO: pushresultsize
+};
+
+// Helper functions to make the ziglua API easier to use
+
+/// Casts the opaque pointer to a pointer of the given type with the proper alignment
+/// Useful for casting pointers from the Lua API like userdata or other data
+pub inline fn opaqueCast(comptime T: type, ptr: *anyopaque) *T {
+    return @ptrCast(@alignCast(ptr));
+}
+
+pub const ZigFn = fn (lua: *Lua) i32;
+// pub const ZigHookFn = fn (lua: *Lua, event: Event, info: *DebugInfo) void;
+pub const ZigContFn = fn (lua: *Lua, status: Status, ctx: i32) i32;
+pub const ZigReaderFn = fn (lua: *Lua, data: *anyopaque) ?[]const u8;
+pub const ZigWriterFn = fn (lua: *Lua, buf: []const u8, data: *anyopaque) bool;
+
+fn TypeOfWrap(comptime T: type) type {
+    return switch (T) {
+        LuaState => Lua,
+        ZigFn => CFn,
+        // ZigHookFn => CHookFn,
+        ZigReaderFn => CReaderFn,
+        ZigWriterFn => CWriterFn,
+        else => @compileError("unsupported type given to wrap: '" ++ @typeName(T) ++ "'"),
+    };
+}
+
+/// Wraps the given value for use in the Lua API
+/// Supports the following:
+/// * `LuaState` => `Lua`
+pub fn wrap(comptime value: anytype) TypeOfWrap(@TypeOf(value)) {
+    const T = @TypeOf(value);
+    return switch (T) {
+        LuaState => Lua{ .state = value },
+        ZigFn => wrapZigFn(value),
+        // ZigHookFn => wrapZigHookFn(value),
+        ZigReaderFn => wrapZigReaderFn(value),
+        ZigWriterFn => wrapZigWriterFn(value),
+        else => @compileError("unsupported type given to wrap: '" ++ @typeName(T) ++ "'"),
+    };
+}
+
+/// Wrap a ZigFn in a CFn for passing to the API
+fn wrapZigFn(comptime f: ZigFn) CFn {
+    return struct {
+        fn inner(state: ?*LuaState) callconv(.C) c_int {
+            // this is called by Lua, state should never be null
+            var lua: Lua = .{ .state = state.? };
+            return @call(.always_inline, f, .{&lua});
+        }
+    }.inner;
+}
+
+/// Wrap a ZigReaderFn in a CReaderFn for passing to the API
+fn wrapZigReaderFn(comptime f: ZigReaderFn) CReaderFn {
+    return struct {
+        fn inner(state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.C) [*c]const u8 {
+            var lua: Lua = .{ .state = state.? };
+            if (@call(.always_inline, f, .{ &lua, data.? })) |buffer| {
+                size.* = buffer.len;
+                return buffer.ptr;
+            } else {
+                size.* = 0;
+                return null;
+            }
+        }
+    }.inner;
+}
+
+/// Wrap a ZigWriterFn in a CWriterFn for passing to the API
+fn wrapZigWriterFn(comptime f: ZigWriterFn) CWriterFn {
+    return struct {
+        fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
+            // this is called by Lua, state should never be null
+            var lua: Lua = .{ .state = state.? };
+            const buffer = @as([*]const u8, @ptrCast(buf))[0..size];
+            const result = @call(.always_inline, f, .{ &lua, buffer, data.? });
+            // it makes more sense for the inner writer function to return false for failure,
+            // so negate the result here
+            return @intFromBool(!result);
+        }
+    }.inner;
+}
+
+/// Export a Zig function to be used as a Zig (C) Module
+pub fn exportFn(comptime name: []const u8, comptime func: ZigFn) void {
+    const declaration = wrap(func);
+    @export(declaration, .{ .name = "luaopen_" ++ name, .linkage = .Strong });
+}

--- a/src/zigluau/lib.zig
+++ b/src/zigluau/lib.zig
@@ -1099,6 +1099,14 @@ pub const Lua = struct {
         return @as([*]T, @ptrCast(@alignCast(ptr)))[0..size];
     }
 
+    /// Loads and runs the given string
+    /// See https://www.lua.org/manual/5.1/manual.html#luaL_dostring
+    /// TODO: does it make sense to have this in Luau?
+    pub fn doString(lua: *Lua, str: [:0]const u8) !void {
+        try lua.loadString(str);
+        try lua.protectedCall(0, mult_return, 0);
+    }
+
     /// Raises an error
     /// See https://www.lua.org/manual/5.1/manual.html#luaL_error
     pub fn raiseErrorStr(lua: *Lua, fmt: [:0]const u8, args: anytype) noreturn {
@@ -1124,6 +1132,7 @@ pub const Lua = struct {
 
     /// Loads a string as a Lua chunk
     /// See https://www.lua.org/manual/5.1/manual.html#luaL_loadstring
+    /// TODO: does it make sense to have this in Luau?
     pub fn loadString(lua: *Lua, str: [:0]const u8) !void {
         var size: usize = 0;
         const bytecode = c.luau_compile(str.ptr, str.len, null, &size);
@@ -1134,7 +1143,7 @@ pub const Lua = struct {
         // luau_compile uses libc malloc to allocate the bytecode on the heap
         defer std.heap.c_allocator.free(bytecode[0..size]);
 
-        if (c.luau_load(lua.state, "a", bytecode, size, 0) != 0) return error.Fail;
+        if (c.luau_load(lua.state, "...", bytecode, size, 0) != 0) return error.Fail;
     }
 
     /// If the registry already has the key `key`, returns an error

--- a/src/zigluau/luau.cpp
+++ b/src/zigluau/luau.cpp
@@ -1,6 +1,7 @@
 #include "Luau/Common.h"
 
 #include <cstdio>
+#include <cstdlib>
 
 static int assertionHandler(const char* expr, const char* file, int line, const char* function)
 {
@@ -10,4 +11,8 @@ static int assertionHandler(const char* expr, const char* file, int line, const 
 
 extern "C" void zig_registerAssertionHandler() {
     Luau::assertHandler() = assertionHandler;
+}
+
+extern "C" void zig_luau_free(void *ptr) {
+    free(ptr);
 }

--- a/src/zigluau/tests.zig
+++ b/src/zigluau/tests.zig
@@ -1,0 +1,1210 @@
+const std = @import("std");
+const testing = std.testing;
+const ziglua = @import("lib.zig");
+
+const AllocFn = ziglua.AllocFn;
+const Buffer = ziglua.Buffer;
+const DebugInfo = ziglua.DebugInfo;
+const Error = ziglua.Error;
+const Event = ziglua.Event;
+const Integer = ziglua.Integer;
+const Lua = ziglua.Lua;
+const LuaType = ziglua.LuaType;
+const Number = ziglua.Number;
+
+const expect = testing.expect;
+const expectEqual = testing.expectEqual;
+const expectEqualStrings = testing.expectEqualStrings;
+const expectError = testing.expectError;
+const panic = std.debug.panic;
+
+fn expectEqualStringsSentinel(expected: []const u8, actual: [*:0]const u8) !void {
+    return expectEqualStrings(expected, std.mem.span(actual));
+}
+
+// until issue #1717 we need to use the struct workaround
+const add = struct {
+    fn addInner(l: *Lua) i32 {
+        const a = l.toInteger(1) catch unreachable;
+        const b = l.toInteger(2) catch unreachable;
+        l.pushInteger(a + b);
+        return 1;
+    }
+}.addInner;
+
+const sub = struct {
+    fn subInner(l: *Lua) i32 {
+        const a = l.toInteger(1) catch unreachable;
+        const b = l.toInteger(2) catch unreachable;
+        l.pushInteger(a - b);
+        return 1;
+    }
+}.subInner;
+
+fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.C) ?*anyopaque {
+    _ = data;
+
+    const alignment = @alignOf(std.c.max_align_t);
+    if (@as(?[*]align(alignment) u8, @ptrCast(@alignCast(ptr)))) |prev_ptr| {
+        const prev_slice = prev_ptr[0..osize];
+        if (nsize == 0) {
+            testing.allocator.free(prev_slice);
+            return null;
+        }
+        const new_ptr = testing.allocator.realloc(prev_slice, nsize) catch return null;
+        return new_ptr.ptr;
+    } else if (nsize == 0) {
+        return null;
+    } else {
+        const new_ptr = testing.allocator.alignedAlloc(u8, alignment, nsize) catch return null;
+        return new_ptr.ptr;
+    }
+}
+
+fn failing_alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.C) ?*anyopaque {
+    _ = data;
+    _ = ptr;
+    _ = osize;
+    _ = nsize;
+    return null;
+}
+
+test "initialization" {
+    // initialize the Zig wrapper
+    var lua = try Lua.init(testing.allocator);
+    try expectEqual(ziglua.Status.ok, lua.status());
+    lua.deinit();
+
+    // attempt to initialize the Zig wrapper with no memory
+    try expectError(error.Memory, Lua.init(testing.failing_allocator));
+
+    // use the library directly
+    lua = try Lua.newState(alloc, null);
+    lua.close();
+
+    // use the library with a bad AllocFn
+    try expectError(error.Memory, Lua.newState(failing_alloc, null));
+
+    // use the auxiliary library (uses libc realloc and cannot be checked for leaks!)
+    lua = try Lua.newStateLibc();
+    lua.close();
+}
+
+test "alloc functions" {
+    var lua = try Lua.newState(alloc, null);
+    defer lua.deinit();
+
+    // get default allocator
+    var data: *anyopaque = undefined;
+    try expectEqual(@as(AllocFn, alloc), lua.getAllocFn(&data));
+}
+
+test "standard library loading" {
+    // open a subset of standard libraries with Zig wrapper
+    {
+        var lua = try Lua.init(testing.allocator);
+        defer lua.deinit();
+        lua.open(.{
+            .base = true,
+            .package = true,
+            .string = true,
+            .table = true,
+            .math = true,
+            .io = true,
+            .os = true,
+            .debug = true,
+        });
+    }
+
+    // open all standard libraries
+    {
+        var lua = try Lua.init(testing.allocator);
+        defer lua.deinit();
+        // lua.openLibs();
+    }
+
+    // open all standard libraries with individual functions
+    // these functions are only useful if you want to load the standard
+    // packages into a non-standard table
+    {
+        var lua = try Lua.init(testing.allocator);
+        defer lua.deinit();
+        // lua.openBase();
+        // lua.openPackage();
+        // lua.openString();
+        // lua.openTable();
+        // lua.openMath();
+        // lua.openIO();
+        // lua.openOS();
+        // lua.openDebug();
+    }
+}
+
+test "type of and getting values" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    var value: i32 = 0;
+
+    lua.pushNil();
+    try expect(lua.isNil(1));
+    try expect(lua.isNoneOrNil(1));
+    try expect(lua.isNoneOrNil(2));
+    try expect(lua.isNone(2));
+    lua.pop(1);
+
+    lua.pushBoolean(true);
+    lua.newTable();
+    lua.pushInteger(1);
+    lua.pushLightUserdata(&value);
+    lua.pushNil();
+    lua.pushNumber(0.1);
+    _ = lua.pushThread();
+    lua.pushString("all your codebase are belong to us");
+    lua.pushFunction(ziglua.wrap(add), "add");
+    lua.pushBytes("hello world");
+    _ = lua.pushFString("%s %s %d", .{ "hello", "world", @as(i32, 10) });
+    lua.pushValue(1);
+
+    // test both typeof and is functions
+    try expectEqual(LuaType.boolean, lua.typeOf(1));
+    try expectEqual(LuaType.table, lua.typeOf(2));
+    try expectEqual(LuaType.number, lua.typeOf(3));
+    try expectEqual(LuaType.light_userdata, lua.typeOf(4));
+    try expectEqual(LuaType.nil, lua.typeOf(5));
+    try expectEqual(LuaType.number, lua.typeOf(6));
+    try expectEqual(LuaType.thread, lua.typeOf(7));
+    try expectEqual(LuaType.string, lua.typeOf(8));
+    try expectEqual(LuaType.function, lua.typeOf(9));
+    try expectEqual(LuaType.string, lua.typeOf(10));
+    try expectEqual(LuaType.string, lua.typeOf(11));
+    try expectEqual(LuaType.boolean, lua.typeOf(12));
+
+    try expect(lua.isBoolean(1));
+    try expect(lua.isTable(2));
+    try expect(lua.isNumber(3));
+    try expect(lua.isLightUserdata(4));
+    try expect(lua.isUserdata(4));
+    try expect(lua.isNil(5));
+    try expect(lua.isNumber(6));
+    try expect(lua.isThread(7));
+    try expect(lua.isString(8));
+    try expect(lua.isCFunction(9));
+    try expect(lua.isFunction(9));
+    try expect(lua.isString(10));
+    try expect(lua.isString(11));
+    try expect(lua.isBoolean(12));
+
+    try expectEqualStrings("hello world 10", std.mem.span(try lua.toString(11)));
+
+    // the created thread should equal the main thread (but created thread has no allocator ref)
+    try expectEqual(lua.state, (try lua.toThread(7)).state);
+    try expectEqual(@as(ziglua.CFn, ziglua.wrap(add)), try lua.toCFunction(9));
+
+    try expectEqual(@as(Number, 0.1), try lua.toNumber(6));
+    try expectEqual(@as(Integer, 1), try lua.toInteger(3));
+
+    try expectEqualStrings("number", lua.typeNameIndex(3));
+}
+
+test "typenames" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    try expectEqualStrings("no value", lua.typeName(.none));
+    try expectEqualStrings("nil", lua.typeName(.nil));
+    try expectEqualStrings("boolean", lua.typeName(.boolean));
+    try expectEqualStrings("userdata", lua.typeName(.light_userdata));
+    try expectEqualStrings("number", lua.typeName(.number));
+    try expectEqualStrings("string", lua.typeName(.string));
+    try expectEqualStrings("table", lua.typeName(.table));
+    try expectEqualStrings("function", lua.typeName(.function));
+    try expectEqualStrings("userdata", lua.typeName(.userdata));
+    try expectEqualStrings("thread", lua.typeName(.thread));
+}
+
+// test "executing string contents" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+//     lua.openLibs();
+
+//     try lua.loadString("f = function(x) return x + 10 end");
+//     try lua.protectedCall(0, 0, 0);
+//     try lua.loadString("a = f(2)");
+//     try lua.protectedCall(0, 0, 0);
+
+//     lua.getGlobal("f");
+//     try expectEqual(LuaType.function, lua.typeOf(-1));
+//     lua.pop(1);
+//     lua.getGlobal("a");
+//     try expectEqual(LuaType.number, lua.typeOf(-1));
+//     try expectEqual(@as(i64, 12), lua.toInteger(1));
+
+//     try expectError(error.Syntax, lua.loadString("bad syntax"));
+//     try lua.loadString("a = g()");
+//     try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
+// }
+
+test "filling and checking the stack" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    try expectEqual(@as(i32, 0), lua.getTop());
+
+    // We want to push 30 values onto the stack
+    // this should work without fail
+    try lua.checkStack(30);
+
+    var count: i32 = 0;
+    while (count < 30) : (count += 1) {
+        lua.pushNil();
+    }
+
+    try expectEqual(@as(i32, 30), lua.getTop());
+
+    // this should fail (beyond max stack size)
+    try expectError(error.Fail, lua.checkStack(1_000_000));
+
+    // this is small enough it won't fail (would raise an error if it did)
+    lua.checkStackErr(40, null);
+    while (count < 40) : (count += 1) {
+        lua.pushNil();
+    }
+
+    try expectEqual(@as(i32, 40), lua.getTop());
+}
+
+test "comparisions" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    lua.pushInteger(1);
+    lua.pushInteger(2);
+
+    try testing.expect(!lua.equal(1, 2));
+    try testing.expect(lua.lessThan(1, 2));
+
+    lua.pushInteger(2);
+
+    try testing.expect(lua.equal(2, 3));
+}
+
+test "stack manipulation" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    // add some numbers to manipulate
+    var num: i32 = 1;
+    while (num <= 10) : (num += 1) {
+        lua.pushInteger(num);
+    }
+    try expectEqual(@as(i32, 10), lua.getTop());
+
+    lua.setTop(12);
+    try expectEqual(@as(i32, 12), lua.getTop());
+    try expect(lua.isNil(-1));
+
+    lua.remove(1);
+    try expect(lua.isNil(-1));
+
+    lua.insert(1);
+    try expect(lua.isNil(1));
+
+    lua.setTop(0);
+    try expectEqual(@as(i32, 0), lua.getTop());
+}
+
+// test "calling a function" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     lua.register("zigadd", ziglua.wrap(add));
+//     lua.getGlobal("zigadd");
+//     lua.pushInteger(10);
+//     lua.pushInteger(32);
+
+//     // protectedCall is safer, but we might as well exercise call when
+//     // we know it should be safe
+//     lua.call(2, 1);
+
+//     try expectEqual(@as(i64, 42), try lua.toInteger(1));
+// }
+
+// test "string buffers" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     var buffer: Buffer = undefined;
+//     buffer.init(lua);
+
+//     buffer.addChar('z');
+//     buffer.addChar('i');
+//     buffer.addChar('g');
+//     buffer.addString("l");
+
+//     var str = buffer.prep();
+//     str[0] = 'u';
+//     str[1] = 'a';
+//     buffer.addSize(2);
+
+//     buffer.addBytes(" api ");
+//     lua.pushNumber(5.1);
+//     buffer.addValue();
+//     buffer.pushResult();
+//     try expectEqualStrings("ziglua api 5.1", try lua.toBytes(-1));
+
+//     // now test a small buffer
+//     buffer = undefined;
+//     buffer.init(lua);
+//     var b = buffer.prep();
+//     b[0] = 'a';
+//     b[1] = 'b';
+//     b[2] = 'c';
+//     buffer.addSize(3);
+//     b = buffer.prep();
+//     @memcpy(b, "defghijklmnopqrstuvwxyz");
+//     buffer.addSize(23);
+//     buffer.pushResult();
+//     try expectEqualStrings("abcdefghijklmnopqrstuvwxyz", try lua.toBytes(-1));
+//     lua.pop(1);
+// }
+
+test "function registration" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    // register all functions as part of a table
+    const funcs = [_]ziglua.FnReg{
+        .{ .name = "add", .func = ziglua.wrap(add) },
+    };
+    lua.newTable();
+    lua.registerFns(null, &funcs);
+
+    try expectEqual(LuaType.function, lua.getField(-1, "add"));
+    lua.pushInteger(1);
+    lua.pushInteger(2);
+    try lua.protectedCall(2, 1, 0);
+    try expectEqual(@as(Integer, 3), try lua.toInteger(-1));
+    lua.setTop(0);
+
+    // register functions as globals in a library table
+    lua.registerFns("testlib", &funcs);
+
+    // testlib.add(1, 2)
+    _ = lua.getGlobal("testlib");
+    try expectEqual(LuaType.function, lua.getField(-1, "add"));
+    lua.pushInteger(1);
+    lua.pushInteger(2);
+    try lua.protectedCall(2, 1, 0);
+    try expectEqual(@as(Integer, 3), try lua.toInteger(-1));
+}
+
+test "concat" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    lua.pushString("hello ");
+    lua.pushNumber(10);
+    lua.pushString(" wow!");
+    lua.concat(3);
+
+    try expectEqualStrings("hello 10 wow!", try lua.toBytes(-1));
+}
+
+test "garbage collector" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    // because the garbage collector is an opaque, unmanaged
+    // thing, it is hard to test, so just run each function
+    lua.gcStop();
+    lua.gcCollect();
+    lua.gcRestart();
+    lua.gcStep();
+    _ = lua.gcCount();
+    _ = lua.gcCountB();
+    _ = lua.gcSetStepMul(2);
+}
+
+// test "table access" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString("a = { [1] = 'first', key = 'value', ['other one'] = 1234 }");
+//     lua.getGlobal("a");
+
+//     lua.rawGetIndex(1, 1);
+//     try expectEqual(LuaType.string, lua.typeOf(-1));
+//     try expectEqualStrings("first", try lua.toBytes(-1));
+
+//     lua.rawGetIndex(1, 1);
+//     try expectEqual(LuaType.string, lua.typeOf(-1));
+//     try expectEqualStrings("first", try lua.toBytes(-1));
+
+//     lua.pushString("key");
+//     lua.getTable(1);
+//     try expectEqual(LuaType.string, lua.typeOf(-1));
+//     try expectEqualStrings("value", try lua.toBytes(-1));
+
+//     lua.pushString("other one");
+//     lua.rawGetTable(1);
+//     try expectEqual(LuaType.number, lua.typeOf(-1));
+//     try expectEqual(@as(Integer, 1234), lua.toInteger(-1));
+
+//     // a.name = "ziglua"
+//     lua.pushString("name");
+//     lua.pushString("ziglua");
+//     lua.setTable(1);
+
+//     // a.lang = "zig"
+//     lua.pushString("lang");
+//     lua.pushString("zig");
+//     lua.rawSetTable(1);
+
+//     try expectError(error.Fail, lua.getMetatable(1));
+
+//     // create a metatable (it isn't a useful one)
+//     lua.newTable();
+//     lua.pushFunction(ziglua.wrap(add));
+//     lua.setField(-2, "__len");
+//     lua.setMetatable(1);
+
+//     try lua.getMetatable(1);
+//     _ = try lua.getMetaField(1, "__len");
+//     try expectError(error.Fail, lua.getMetaField(1, "__index"));
+
+//     lua.pushBoolean(true);
+//     lua.setField(1, "bool");
+
+//     try lua.doString("b = a.bool");
+//     lua.getGlobal("b");
+//     try expectEqual(LuaType.boolean, lua.typeOf(-1));
+//     try expect(lua.toBoolean(-1));
+
+//     // create array [1, 2, 3, 4, 5]
+//     lua.createTable(0, 0);
+//     var index: i32 = 1;
+//     while (index <= 5) : (index += 1) {
+//         lua.pushInteger(index);
+//         lua.rawSetIndex(-2, index);
+//     }
+
+//     // add a few more
+//     while (index <= 10) : (index += 1) {
+//         lua.pushInteger(index);
+//         lua.rawSetIndex(-2, index);
+//     }
+// }
+
+// test "dump and load" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     // store a function in a global
+//     try lua.doString("f = function(x) return function(n) return n + x end end");
+//     // put the function on the stack
+//     lua.getGlobal("f");
+
+//     const writer = struct {
+//         fn inner(l: *Lua, buf: []const u8, data: *anyopaque) bool {
+//             _ = l;
+//             var arr = ziglua.opaqueCast(std.ArrayList(u8), data);
+//             arr.appendSlice(buf) catch return false;
+//             return true;
+//         }
+//     }.inner;
+
+//     var buffer = std.ArrayList(u8).init(testing.allocator);
+//     defer buffer.deinit();
+
+//     // save the function as a binary chunk in the buffer
+//     try lua.dump(ziglua.wrap(writer), &buffer);
+
+//     // clear the stack
+//     lua.setTop(0);
+
+//     const reader = struct {
+//         fn inner(l: *Lua, data: *anyopaque) ?[]const u8 {
+//             _ = l;
+//             const arr = ziglua.opaqueCast(std.ArrayList(u8), data);
+//             return arr.items;
+//         }
+//     }.inner;
+
+//     // now load the function back onto the stack
+//     try lua.load(ziglua.wrap(reader), &buffer, "function");
+//     try expectEqual(LuaType.function, lua.typeOf(-1));
+
+//     // run the function (creating a new function)
+//     lua.pushInteger(5);
+//     try lua.protectedCall(1, 1, 0);
+
+//     // now call the new function (which should return the value + 5)
+//     lua.pushInteger(6);
+//     try lua.protectedCall(1, 1, 0);
+//     try expectEqual(@as(Integer, 11), lua.toInteger(-1));
+// }
+
+test "threads" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    var new_thread = lua.newThread();
+    try expectEqual(@as(i32, 1), lua.getTop());
+    try expectEqual(@as(i32, 0), new_thread.getTop());
+
+    lua.pushInteger(10);
+    lua.pushNil();
+
+    lua.xMove(new_thread, 2);
+    try expectEqual(@as(i32, 2), new_thread.getTop());
+}
+
+test "userdata and uservalues" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const Data = struct {
+        val: i32,
+        code: [4]u8,
+    };
+
+    // create a Lua-owned pointer to a Data
+    var data = lua.newUserdata(Data);
+    data.val = 1;
+    @memcpy(&data.code, "abcd");
+
+    try expectEqual(data, try lua.toUserdata(Data, 1));
+    try expectEqual(@as(*const anyopaque, @ptrCast(data)), try lua.toPointer(1));
+}
+
+test "upvalues" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    // counter from PIL
+    const counter = struct {
+        fn inner(l: *Lua) i32 {
+            var counter = l.toInteger(Lua.upvalueIndex(1)) catch unreachable;
+            counter += 1;
+            l.pushInteger(counter);
+            l.pushInteger(counter);
+            l.replace(Lua.upvalueIndex(1));
+            return 1;
+        }
+    }.inner;
+
+    // Initialize the counter at 0
+    lua.pushInteger(0);
+    lua.pushClosure(ziglua.wrap(counter), "counter", 1);
+    lua.setGlobal("counter");
+
+    // call the function repeatedly, each time ensuring the result increases by one
+    var expected: Integer = 1;
+    while (expected <= 10) : (expected += 1) {
+        _ = lua.getGlobal("counter");
+        lua.call(0, 1);
+        try expectEqual(expected, try lua.toInteger(-1));
+        lua.pop(1);
+    }
+}
+
+// test "table traversal" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString("t = { key = 'value', second = true, third = 1 }");
+//     lua.getGlobal("t");
+
+//     lua.pushNil();
+
+//     while (lua.next(1)) {
+//         switch (lua.typeOf(-1)) {
+//             .string => {
+//                 try expectEqualStrings("key", try lua.toBytes(-2));
+//                 try expectEqualStrings("value", try lua.toBytes(-1));
+//             },
+//             .boolean => {
+//                 try expectEqualStrings("second", try lua.toBytes(-2));
+//                 try expectEqual(true, lua.toBoolean(-1));
+//             },
+//             .number => {
+//                 try expectEqualStrings("third", try lua.toBytes(-2));
+//                 try expectEqual(@as(Integer, 1), lua.toInteger(-1));
+//             },
+//             else => unreachable,
+//         }
+//         lua.pop(1);
+//     }
+// }
+
+test "raise error" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const makeError = struct {
+        fn inner(l: *Lua) i32 {
+            l.pushString("makeError made an error");
+            l.raiseError();
+            return 0;
+        }
+    }.inner;
+
+    lua.pushFunction(ziglua.wrap(makeError), "makeError");
+    try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
+    try expectEqualStrings("makeError made an error", try lua.toBytes(-1));
+}
+
+test "yielding" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    var thread = lua.newThread();
+    thread.pushFunction(ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            l.pushInteger(1);
+            return l.yield(1);
+        }
+    }.inner), "yieldfn");
+
+    _ = try thread.resumeThread(null, 0);
+    try expectEqual(@as(Integer, 1), try thread.toInteger(-1));
+}
+
+// test "resuming" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     // here we create a Lua function that will run 5 times, continutally
+//     // yielding a count until it finally returns the string "done"
+//     var thread = lua.newThread();
+//     thread.openLibs();
+//     try thread.doString(
+//         \\counter = function()
+//         \\  coroutine.yield(1)
+//         \\  coroutine.yield(2)
+//         \\  coroutine.yield(3)
+//         \\  coroutine.yield(4)
+//         \\  coroutine.yield(5)
+//         \\  return "done"
+//         \\end
+//     );
+//     thread.getGlobal("counter");
+
+//     var i: i32 = 1;
+//     while (i <= 5) : (i += 1) {
+//         try expectEqual(ziglua.ResumeStatus.yield, try thread.resumeThread(0));
+//         try expectEqual(@as(Integer, i), thread.toInteger(-1));
+//         lua.pop(lua.getTop());
+//     }
+//     try expectEqual(ziglua.ResumeStatus.ok, try thread.resumeThread(0));
+//     try expectEqualStrings("done", try thread.toBytes(-1));
+// }
+
+// test "debug interface" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString(
+//         \\f = function(x)
+//         \\  local y = x * 2
+//         \\  y = y + 2
+//         \\  return x + y
+//         \\end
+//     );
+//     lua.getGlobal("f");
+
+//     var info: DebugInfo = undefined;
+//     lua.getInfo(.{
+//         .@">" = true,
+//         .l = true,
+//         .S = true,
+//         .n = true,
+//         .u = true,
+//     }, &info);
+
+//     // get information about the function
+//     try expectEqual(DebugInfo.FnType.lua, info.what);
+//     try expectEqual(DebugInfo.NameType.other, info.name_what);
+//     const len = std.mem.len(@as([*:0]u8, @ptrCast(&info.short_src)));
+//     try expectEqualStrings("[string \"f = function(x)...\"]", info.short_src[0..len]);
+//     try expectEqual(@as(?i32, 1), info.first_line_defined);
+//     try expectEqual(@as(?i32, 5), info.last_line_defined);
+//     try expectEqual(@as(?i32, null), info.current_line);
+
+//     // create a hook
+//     const hook = struct {
+//         fn inner(l: *Lua, event: Event, i: *DebugInfo) void {
+//             switch (event) {
+//                 .call => {
+//                     l.getInfo(.{ .l = true }, i);
+//                     if (i.current_line.? != 2) panic("Expected line to be 2", .{});
+//                     _ = l.getLocal(i, 1) catch unreachable;
+//                     if ((l.toNumber(-1)) != 3) panic("Expected x to equal 3", .{});
+//                 },
+//                 .line => if (i.current_line.? == 4) {
+//                     // modify the value of y to be 0 right before returning
+//                     l.pushNumber(0);
+//                     _ = l.setLocal(i, 2) catch unreachable;
+//                 },
+//                 .ret => {
+//                     l.getInfo(.{ .l = true }, i);
+//                     if (i.current_line.? != 4) panic("Expected line to be 4", .{});
+//                     _ = l.getLocal(i, 1) catch unreachable;
+//                     if ((l.toNumber(-1)) != 3) panic("Expected result to equal 3", .{});
+//                 },
+//                 else => unreachable,
+//             }
+//         }
+//     }.inner;
+
+//     // run the hook when a function is called
+//     try expectEqual(@as(?ziglua.CHookFn, null), lua.getHook());
+//     try expectEqual(ziglua.HookMask{}, lua.getHookMask());
+//     try expectEqual(@as(i32, 0), lua.getHookCount());
+
+//     lua.setHook(ziglua.wrap(hook), .{ .call = true, .line = true, .ret = true }, 0);
+//     try expectEqual(@as(?ziglua.CHookFn, ziglua.wrap(hook)), lua.getHook());
+//     try expectEqual(ziglua.HookMask{ .call = true, .line = true, .ret = true }, lua.getHookMask());
+
+//     lua.getGlobal("f");
+//     lua.pushNumber(3);
+//     try lua.protectedCall(1, 1, 0);
+// }
+
+// test "debug upvalues" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString(
+//         \\f = function(x)
+//         \\  return function(y)
+//         \\    return x + y
+//         \\  end
+//         \\end
+//         \\addone = f(1)
+//     );
+//     lua.getGlobal("addone");
+
+//     // index doesn't exist
+//     try expectError(error.Fail, lua.getUpvalue(1, 2));
+
+//     // inspect the upvalue (should be x)
+//     try expectEqualStrings("x", try lua.getUpvalue(-1, 1));
+//     try expectEqual(@as(Number, 1), lua.toNumber(-1));
+//     lua.pop(1);
+
+//     // now make the function an "add five" function
+//     lua.pushNumber(5);
+//     _ = try lua.setUpvalue(-2, 1);
+
+//     // call the new function (should return 7)
+//     lua.pushNumber(2);
+//     try lua.protectedCall(1, 1, 0);
+//     try expectEqual(@as(Number, 7), lua.toNumber(-1));
+// }
+
+// test "getstack" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try expectError(error.Fail, lua.getStack(1));
+
+//     const function = struct {
+//         fn inner(l: *Lua) i32 {
+//             // get info about calling lua function
+//             var info = l.getStack(1) catch unreachable;
+//             l.getInfo(.{ .n = true }, &info);
+//             expectEqualStrings("g", info.name.?) catch unreachable;
+//             return 0;
+//         }
+//     }.inner;
+
+//     lua.pushFunction(ziglua.wrap(function));
+//     lua.setGlobal("f");
+
+//     try lua.doString(
+//         \\g = function()
+//         \\  f()
+//         \\end
+//         \\g()
+//     );
+// }
+
+test "aux check functions" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const function = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            l.checkAny(1);
+            _ = l.checkInteger(2);
+            _ = l.checkBytes(3);
+            _ = l.checkNumber(4);
+            _ = l.checkString(5);
+            l.checkType(6, .boolean);
+            return 0;
+        }
+    }.inner);
+
+    lua.pushFunction(function, "function");
+    lua.protectedCall(0, 0, 0) catch {
+        try expectEqualStrings("missing argument #1", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.protectedCall(1, 0, 0) catch {
+        try expectEqualStrings("missing argument #2 to 'function' (number expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.protectedCall(2, 0, 0) catch {
+        try expectEqualStrings("missing argument #3 to 'function' (string expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.pushBytes("hello world");
+    lua.protectedCall(3, 0, 0) catch {
+        try expectEqualStrings("missing argument #4 to 'function' (number expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.pushBytes("hello world");
+    lua.pushNumber(4);
+    lua.protectedCall(4, 0, 0) catch {
+        try expectEqualStrings("missing argument #5 to 'function' (string expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.pushBytes("hello world");
+    lua.pushNumber(4);
+    lua.pushString("hello world");
+    lua.protectedCall(5, 0, 0) catch {
+        try expectEqualStrings("missing argument #6 to 'function' (boolean expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.pushBytes("hello world");
+    lua.pushNumber(4);
+    lua.pushString("hello world");
+    lua.pushBoolean(true);
+    lua.protectedCall(6, 0, 0) catch {
+        try expectEqualStrings("missing argument #7 to 'function' (number expected)", try lua.toBytes(-1));
+        lua.pop(-1);
+    };
+
+    lua.pushFunction(function, "function");
+    lua.pushNil();
+    lua.pushInteger(3);
+    lua.pushBytes("hello world");
+    lua.pushNumber(4);
+    lua.pushString("hello world");
+    lua.pushBoolean(true);
+    try lua.protectedCall(6, 0, 0);
+}
+
+test "get global nil" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    _ = lua.getGlobal("foo");
+    try expectEqual(LuaType.nil, lua.typeOf(-1));
+}
+
+// test "metatables" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString("f = function() return 10 end");
+
+//     try lua.newMetatable("mt");
+
+//     // set the len metamethod to the function f
+//     lua.getGlobal("f");
+//     lua.setField(1, "__len");
+
+//     lua.newTable();
+//     lua.getField(ziglua.registry_index, "mt");
+//     lua.setMetatable(-2);
+
+//     try lua.callMeta(-1, "__len");
+//     try expectEqual(@as(Number, 10), lua.toNumber(-1));
+// }
+
+test "aux opt functions" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const function = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            expectEqual(@as(Integer, 10), l.optInteger(1, 10)) catch unreachable;
+            expectEqualStrings("zig", l.optBytes(2, "zig")) catch unreachable;
+            expectEqual(@as(Number, 1.23), l.optNumber(3, 1.23)) catch unreachable;
+            expectEqualStringsSentinel("lang", l.optString(4, "lang")) catch unreachable;
+            return 0;
+        }
+    }.inner);
+
+    lua.pushFunction(function, "function");
+    try lua.protectedCall(0, 0, 0);
+
+    lua.pushFunction(function, "function");
+    lua.pushInteger(10);
+    lua.pushBytes("zig");
+    lua.pushNumber(1.23);
+    lua.pushString("lang");
+    try lua.protectedCall(4, 0, 0);
+}
+
+test "checkOption" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const Variant = enum {
+        one,
+        two,
+        three,
+    };
+
+    const function = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            const option = l.checkOption(Variant, 1, .one);
+            l.pushInteger(switch (option) {
+                .one => 1,
+                .two => 2,
+                .three => 3,
+            });
+            return 1;
+        }
+    }.inner);
+
+    lua.pushFunction(function, "function");
+    lua.pushString("one");
+    try lua.protectedCall(1, 1, 0);
+    try expectEqual(@as(Integer, 1), try lua.toInteger(-1));
+    lua.pop(1);
+
+    lua.pushFunction(function, "function");
+    lua.pushString("two");
+    try lua.protectedCall(1, 1, 0);
+    try expectEqual(@as(Integer, 2), try lua.toInteger(-1));
+    lua.pop(1);
+
+    lua.pushFunction(function, "function");
+    lua.pushString("three");
+    try lua.protectedCall(1, 1, 0);
+    try expectEqual(@as(Integer, 3), try lua.toInteger(-1));
+    lua.pop(1);
+
+    // try the default now
+    lua.pushFunction(function, "function");
+    try lua.protectedCall(0, 1, 0);
+    try expectEqual(@as(Integer, 1), try lua.toInteger(-1));
+    lua.pop(1);
+
+    // check the raised error
+    lua.pushFunction(function, "function");
+    lua.pushString("unknown");
+    try expectError(error.Runtime, lua.protectedCall(1, 1, 0));
+    try expectEqualStrings("invalid argument #1 to 'function' (invalid option 'unknown')", try lua.toBytes(-1));
+}
+
+// test "where" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     const whereFn = ziglua.wrap(struct {
+//         fn inner(l: *Lua) i32 {
+//             l.where(1);
+//             return 1;
+//         }
+//     }.inner);
+
+//     lua.pushFunction(whereFn);
+//     lua.setGlobal("whereFn");
+
+//     try lua.doString(
+//         \\
+//         \\ret = whereFn()
+//     );
+
+//     lua.getGlobal("ret");
+//     try expectEqualStrings("[string \"...\"]:2: ", try lua.toBytes(-1));
+// }
+
+test "ref" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    lua.pushNil();
+    try expectError(error.Fail, lua.ref(1));
+    try expectEqual(@as(Integer, 1), lua.getTop());
+
+    // In luau lua.ref does not pop the item from the stack
+    // and the data is stored in the registry_index by default
+    lua.pushBytes("Hello there");
+    const ref = try lua.ref(2);
+
+    _ = lua.rawGetIndex(ziglua.registry_index, ref);
+    try expectEqualStrings("Hello there", try lua.toBytes(-1));
+
+    lua.unref(ref);
+}
+
+test "args and errors" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const argCheck = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            l.argCheck(false, 1, "error!");
+            return 0;
+        }
+    }.inner);
+
+    lua.pushFunction(argCheck, "argCheck");
+    try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
+
+    const raisesError = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            l.raiseErrorStr("some error %s!", .{"zig"});
+            unreachable;
+        }
+    }.inner);
+
+    lua.pushFunction(raisesError, "raisesError");
+    try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
+    try expectEqualStrings("some error zig!", try lua.toBytes(-1));
+}
+
+test "userdata" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const Type = struct { a: i32, b: f32 };
+    try lua.newMetatable("Type");
+
+    const checkUdata = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            const ptr = l.checkUserdata(Type, 1, "Type");
+            if (ptr.a != 1234) {
+                l.pushBytes("error!");
+                l.raiseError();
+            }
+            if (ptr.b != 3.14) {
+                l.pushBytes("error!");
+                l.raiseError();
+            }
+            return 1;
+        }
+    }.inner);
+
+    lua.pushFunction(checkUdata, "checkUdata");
+
+    {
+        var t = lua.newUserdata(Type);
+        try expectEqual(LuaType.table, lua.getField(ziglua.registry_index, "Type"));
+        lua.setMetatable(-2);
+        t.a = 1234;
+        t.b = 3.14;
+
+        // call checkUdata asserting that the udata passed in with the
+        // correct metatable and values
+        try lua.protectedCall(1, 1, 0);
+    }
+}
+
+test "userdata slices" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    try lua.newMetatable("FixedArray");
+
+    // create an array of 10
+    const slice = lua.newUserdataSlice(Integer, 10);
+    try expectEqual(LuaType.table, lua.getField(ziglua.registry_index, "FixedArray"));
+    lua.setMetatable(-2);
+
+    for (slice, 1..) |*item, index| {
+        item.* = @intCast(index);
+    }
+
+    const udataFn = struct {
+        fn inner(l: *Lua) i32 {
+            _ = l.checkUserdataSlice(Integer, 1, "FixedArray");
+            const arr = l.toUserdataSlice(Integer, 1) catch unreachable;
+            for (arr, 1..) |item, index| {
+                if (item != index) l.raiseErrorStr("something broke!", .{});
+            }
+
+            return 0;
+        }
+    }.inner;
+
+    lua.pushFunction(ziglua.wrap(udataFn), "udataFn");
+    lua.pushValue(2);
+
+    try lua.protectedCall(1, 0, 0);
+}
+
+// test "function environments" {
+//     var lua = try Lua.init(testing.allocator);
+//     defer lua.deinit();
+
+//     try lua.doString("function test() return x end");
+
+//     // set the global _G.x to be 10
+//     lua.pushInteger(10);
+//     lua.setGlobal("x");
+
+//     lua.getGlobal("test");
+//     try lua.protectedCall(0, 1, 0);
+//     try testing.expectEqual(@as(Integer, 10), lua.toInteger(1));
+//     lua.pop(1);
+
+//     // now set the functions table to have a different value of x
+//     lua.getGlobal("test");
+//     lua.newTable();
+//     lua.pushInteger(20);
+//     lua.setField(2, "x");
+//     try lua.setFnEnvironment(1);
+
+//     try lua.protectedCall(0, 1, 0);
+//     try testing.expectEqual(@as(Integer, 20), lua.toInteger(1));
+//     lua.pop(1);
+
+//     lua.getGlobal("test");
+//     lua.getFnEnvironment(1);
+//     lua.getField(2, "x");
+//     try testing.expectEqual(@as(Integer, 20), lua.toInteger(3));
+// }
+
+test "objectLen" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    lua.pushString("lua");
+    try testing.expectEqual(@as(i32, 3), lua.objectLen(-1));
+}
+
+test {
+    testing.refAllDecls(Lua);
+    testing.refAllDecls(Buffer);
+}

--- a/src/zigluau/tests.zig
+++ b/src/zigluau/tests.zig
@@ -129,14 +129,12 @@ test "standard library loading" {
     {
         var lua = try Lua.init(testing.allocator);
         defer lua.deinit();
-        // lua.openBase();
-        // lua.openPackage();
-        // lua.openString();
-        // lua.openTable();
-        // lua.openMath();
-        // lua.openIO();
-        // lua.openOS();
-        // lua.openDebug();
+        lua.openBase();
+        lua.openString();
+        lua.openTable();
+        lua.openMath();
+        lua.openOS();
+        lua.openDebug();
     }
 }
 
@@ -223,27 +221,27 @@ test "typenames" {
     try expectEqualStrings("thread", lua.typeName(.thread));
 }
 
-// test "executing string contents" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
-//     lua.openLibs();
+test "executing string contents" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+    lua.openLibs();
 
-//     try lua.loadString("f = function(x) return x + 10 end");
-//     try lua.protectedCall(0, 0, 0);
-//     try lua.loadString("a = f(2)");
-//     try lua.protectedCall(0, 0, 0);
+    try lua.loadString("f = function(x) return x + 10 end");
+    try lua.protectedCall(0, 0, 0);
+    try lua.loadString("a = f(2)");
+    try lua.protectedCall(0, 0, 0);
 
-//     lua.getGlobal("f");
-//     try expectEqual(LuaType.function, lua.typeOf(-1));
-//     lua.pop(1);
-//     lua.getGlobal("a");
-//     try expectEqual(LuaType.number, lua.typeOf(-1));
-//     try expectEqual(@as(i64, 12), lua.toInteger(1));
+    try expectEqual(LuaType.function, lua.getGlobal("f"));
+    try expectEqual(LuaType.function, lua.typeOf(-1));
+    lua.pop(1);
+    try expectEqual(LuaType.number, lua.getGlobal("a"));
+    try expectEqual(LuaType.number, lua.typeOf(-1));
+    try expectEqual(@as(i64, 12), try lua.toInteger(1));
 
-//     try expectError(error.Syntax, lua.loadString("bad syntax"));
-//     try lua.loadString("a = g()");
-//     try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
-// }
+    try expectError(error.Fail, lua.loadString("bad syntax"));
+    try lua.loadString("a = g()");
+    try expectError(error.Runtime, lua.protectedCall(0, 0, 0));
+}
 
 test "filling and checking the stack" {
     var lua = try Lua.init(testing.allocator);

--- a/src/zigluau/tests.zig
+++ b/src/zigluau/tests.zig
@@ -120,7 +120,7 @@ test "standard library loading" {
     {
         var lua = try Lua.init(testing.allocator);
         defer lua.deinit();
-        // lua.openLibs();
+        lua.openLibs();
     }
 
     // open all standard libraries with individual functions
@@ -424,75 +424,75 @@ test "garbage collector" {
     _ = lua.gcSetStepMul(2);
 }
 
-// test "table access" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "table access" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     try lua.doString("a = { [1] = 'first', key = 'value', ['other one'] = 1234 }");
-//     lua.getGlobal("a");
+    try lua.doString("a = { [1] = 'first', key = 'value', ['other one'] = 1234 }");
+    _ = lua.getGlobal("a");
 
-//     lua.rawGetIndex(1, 1);
-//     try expectEqual(LuaType.string, lua.typeOf(-1));
-//     try expectEqualStrings("first", try lua.toBytes(-1));
+    _ = lua.rawGetIndex(1, 1);
+    try expectEqual(LuaType.string, lua.typeOf(-1));
+    try expectEqualStrings("first", try lua.toBytes(-1));
 
-//     lua.rawGetIndex(1, 1);
-//     try expectEqual(LuaType.string, lua.typeOf(-1));
-//     try expectEqualStrings("first", try lua.toBytes(-1));
+    _ = lua.rawGetIndex(1, 1);
+    try expectEqual(LuaType.string, lua.typeOf(-1));
+    try expectEqualStrings("first", try lua.toBytes(-1));
 
-//     lua.pushString("key");
-//     lua.getTable(1);
-//     try expectEqual(LuaType.string, lua.typeOf(-1));
-//     try expectEqualStrings("value", try lua.toBytes(-1));
+    lua.pushString("key");
+    _ = lua.getTable(1);
+    try expectEqual(LuaType.string, lua.typeOf(-1));
+    try expectEqualStrings("value", try lua.toBytes(-1));
 
-//     lua.pushString("other one");
-//     lua.rawGetTable(1);
-//     try expectEqual(LuaType.number, lua.typeOf(-1));
-//     try expectEqual(@as(Integer, 1234), lua.toInteger(-1));
+    lua.pushString("other one");
+    _ = lua.rawGetTable(1);
+    try expectEqual(LuaType.number, lua.typeOf(-1));
+    try expectEqual(@as(Integer, 1234), try lua.toInteger(-1));
 
-//     // a.name = "ziglua"
-//     lua.pushString("name");
-//     lua.pushString("ziglua");
-//     lua.setTable(1);
+    // a.name = "ziglua"
+    lua.pushString("name");
+    lua.pushString("ziglua");
+    lua.setTable(1);
 
-//     // a.lang = "zig"
-//     lua.pushString("lang");
-//     lua.pushString("zig");
-//     lua.rawSetTable(1);
+    // a.lang = "zig"
+    lua.pushString("lang");
+    lua.pushString("zig");
+    lua.rawSetTable(1);
 
-//     try expectError(error.Fail, lua.getMetatable(1));
+    try expectError(error.Fail, lua.getMetatable(1));
 
-//     // create a metatable (it isn't a useful one)
-//     lua.newTable();
-//     lua.pushFunction(ziglua.wrap(add));
-//     lua.setField(-2, "__len");
-//     lua.setMetatable(1);
+    // create a metatable (it isn't a useful one)
+    lua.newTable();
+    lua.pushFunction(ziglua.wrap(add), "add");
+    lua.setField(-2, "__len");
+    lua.setMetatable(1);
 
-//     try lua.getMetatable(1);
-//     _ = try lua.getMetaField(1, "__len");
-//     try expectError(error.Fail, lua.getMetaField(1, "__index"));
+    try lua.getMetatable(1);
+    _ = try lua.getMetaField(1, "__len");
+    try expectError(error.Fail, lua.getMetaField(1, "__index"));
 
-//     lua.pushBoolean(true);
-//     lua.setField(1, "bool");
+    lua.pushBoolean(true);
+    lua.setField(1, "bool");
 
-//     try lua.doString("b = a.bool");
-//     lua.getGlobal("b");
-//     try expectEqual(LuaType.boolean, lua.typeOf(-1));
-//     try expect(lua.toBoolean(-1));
+    try lua.doString("b = a.bool");
+    _ = lua.getGlobal("b");
+    try expectEqual(LuaType.boolean, lua.typeOf(-1));
+    try expect(lua.toBoolean(-1));
 
-//     // create array [1, 2, 3, 4, 5]
-//     lua.createTable(0, 0);
-//     var index: i32 = 1;
-//     while (index <= 5) : (index += 1) {
-//         lua.pushInteger(index);
-//         lua.rawSetIndex(-2, index);
-//     }
+    // create array [1, 2, 3, 4, 5]
+    lua.createTable(0, 0);
+    var index: i32 = 1;
+    while (index <= 5) : (index += 1) {
+        lua.pushInteger(index);
+        lua.rawSetIndex(-2, index);
+    }
 
-//     // add a few more
-//     while (index <= 10) : (index += 1) {
-//         lua.pushInteger(index);
-//         lua.rawSetIndex(-2, index);
-//     }
-// }
+    // add a few more
+    while (index <= 10) : (index += 1) {
+        lua.pushInteger(index);
+        lua.rawSetIndex(-2, index);
+    }
+}
 
 // test "dump and load" {
 //     var lua = try Lua.init(testing.allocator);
@@ -607,34 +607,34 @@ test "upvalues" {
     }
 }
 
-// test "table traversal" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "table traversal" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     try lua.doString("t = { key = 'value', second = true, third = 1 }");
-//     lua.getGlobal("t");
+    try lua.doString("t = { key = 'value', second = true, third = 1 }");
+    _ = lua.getGlobal("t");
 
-//     lua.pushNil();
+    lua.pushNil();
 
-//     while (lua.next(1)) {
-//         switch (lua.typeOf(-1)) {
-//             .string => {
-//                 try expectEqualStrings("key", try lua.toBytes(-2));
-//                 try expectEqualStrings("value", try lua.toBytes(-1));
-//             },
-//             .boolean => {
-//                 try expectEqualStrings("second", try lua.toBytes(-2));
-//                 try expectEqual(true, lua.toBoolean(-1));
-//             },
-//             .number => {
-//                 try expectEqualStrings("third", try lua.toBytes(-2));
-//                 try expectEqual(@as(Integer, 1), lua.toInteger(-1));
-//             },
-//             else => unreachable,
-//         }
-//         lua.pop(1);
-//     }
-// }
+    while (lua.next(1)) {
+        switch (lua.typeOf(-1)) {
+            .string => {
+                try expectEqualStrings("key", try lua.toBytes(-2));
+                try expectEqualStrings("value", try lua.toBytes(-1));
+            },
+            .boolean => {
+                try expectEqualStrings("second", try lua.toBytes(-2));
+                try expectEqual(true, lua.toBoolean(-1));
+            },
+            .number => {
+                try expectEqualStrings("third", try lua.toBytes(-2));
+                try expectEqual(@as(Integer, 1), try lua.toInteger(-1));
+            },
+            else => unreachable,
+        }
+        lua.pop(1);
+    }
+}
 
 test "raise error" {
     var lua = try Lua.init(testing.allocator);
@@ -926,25 +926,25 @@ test "get global nil" {
     try expectEqual(LuaType.nil, lua.typeOf(-1));
 }
 
-// test "metatables" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "metatables" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     try lua.doString("f = function() return 10 end");
+    try lua.doString("f = function() return 10 end");
 
-//     try lua.newMetatable("mt");
+    try lua.newMetatable("mt");
 
-//     // set the len metamethod to the function f
-//     lua.getGlobal("f");
-//     lua.setField(1, "__len");
+    // set the len metamethod to the function f
+    _ = lua.getGlobal("f");
+    lua.setField(1, "__len");
 
-//     lua.newTable();
-//     lua.getField(ziglua.registry_index, "mt");
-//     lua.setMetatable(-2);
+    lua.newTable();
+    _ = lua.getField(ziglua.registry_index, "mt");
+    lua.setMetatable(-2);
 
-//     try lua.callMeta(-1, "__len");
-//     try expectEqual(@as(Number, 10), lua.toNumber(-1));
-// }
+    try lua.callMeta(-1, "__len");
+    try expectEqual(@as(Number, 10), try lua.toNumber(-1));
+}
 
 test "aux opt functions" {
     var lua = try Lua.init(testing.allocator);
@@ -1024,28 +1024,28 @@ test "checkOption" {
     try expectEqualStrings("invalid argument #1 to 'function' (invalid option 'unknown')", try lua.toBytes(-1));
 }
 
-// test "where" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "where" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     const whereFn = ziglua.wrap(struct {
-//         fn inner(l: *Lua) i32 {
-//             l.where(1);
-//             return 1;
-//         }
-//     }.inner);
+    const whereFn = ziglua.wrap(struct {
+        fn inner(l: *Lua) i32 {
+            l.where(1);
+            return 1;
+        }
+    }.inner);
 
-//     lua.pushFunction(whereFn);
-//     lua.setGlobal("whereFn");
+    lua.pushFunction(whereFn, "where");
+    lua.setGlobal("whereFn");
 
-//     try lua.doString(
-//         \\
-//         \\ret = whereFn()
-//     );
+    try lua.doString(
+        \\
+        \\ret = whereFn()
+    );
 
-//     lua.getGlobal("ret");
-//     try expectEqualStrings("[string \"...\"]:2: ", try lua.toBytes(-1));
-// }
+    _ = lua.getGlobal("ret");
+    try expectEqualStrings("[string \"...\"]:2: ", try lua.toBytes(-1));
+}
 
 test "ref" {
     var lua = try Lua.init(testing.allocator);
@@ -1162,37 +1162,37 @@ test "userdata slices" {
     try lua.protectedCall(1, 0, 0);
 }
 
-// test "function environments" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "function environments" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     try lua.doString("function test() return x end");
+    try lua.doString("function test() return x end");
 
-//     // set the global _G.x to be 10
-//     lua.pushInteger(10);
-//     lua.setGlobal("x");
+    // set the global _G.x to be 10
+    lua.pushInteger(10);
+    lua.setGlobal("x");
 
-//     lua.getGlobal("test");
-//     try lua.protectedCall(0, 1, 0);
-//     try testing.expectEqual(@as(Integer, 10), lua.toInteger(1));
-//     lua.pop(1);
+    _ = lua.getGlobal("test");
+    try lua.protectedCall(0, 1, 0);
+    try testing.expectEqual(@as(Integer, 10), try lua.toInteger(1));
+    lua.pop(1);
 
-//     // now set the functions table to have a different value of x
-//     lua.getGlobal("test");
-//     lua.newTable();
-//     lua.pushInteger(20);
-//     lua.setField(2, "x");
-//     try lua.setFnEnvironment(1);
+    // now set the functions table to have a different value of x
+    _ = lua.getGlobal("test");
+    lua.newTable();
+    lua.pushInteger(20);
+    lua.setField(2, "x");
+    try lua.setFnEnvironment(1);
 
-//     try lua.protectedCall(0, 1, 0);
-//     try testing.expectEqual(@as(Integer, 20), lua.toInteger(1));
-//     lua.pop(1);
+    try lua.protectedCall(0, 1, 0);
+    try testing.expectEqual(@as(Integer, 20), try lua.toInteger(1));
+    lua.pop(1);
 
-//     lua.getGlobal("test");
-//     lua.getFnEnvironment(1);
-//     lua.getField(2, "x");
-//     try testing.expectEqual(@as(Integer, 20), lua.toInteger(3));
-// }
+    _ = lua.getGlobal("test");
+    lua.getFnEnvironment(1);
+    _ = lua.getField(2, "x");
+    try testing.expectEqual(@as(Integer, 20), try lua.toInteger(3));
+}
 
 test "objectLen" {
     var lua = try Lua.init(testing.allocator);

--- a/src/zigluau/tests.zig
+++ b/src/zigluau/tests.zig
@@ -421,9 +421,12 @@ test "garbage collector" {
     lua.gcCollect();
     lua.gcRestart();
     lua.gcStep();
+    _ = lua.gcIsRunning();
     _ = lua.gcCount();
     _ = lua.gcCountB();
+    _ = lua.gcSetGoal(10);
     _ = lua.gcSetStepMul(2);
+    _ = lua.gcSetStepSize(1);
 }
 
 test "table access" {

--- a/src/zigluau/tests.zig
+++ b/src/zigluau/tests.zig
@@ -312,60 +312,62 @@ test "stack manipulation" {
     try expectEqual(@as(i32, 0), lua.getTop());
 }
 
-// test "calling a function" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "calling a function" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     lua.register("zigadd", ziglua.wrap(add));
-//     lua.getGlobal("zigadd");
-//     lua.pushInteger(10);
-//     lua.pushInteger(32);
+    lua.register("zigadd", ziglua.wrap(add));
+    _ = lua.getGlobal("zigadd");
+    lua.pushInteger(10);
+    lua.pushInteger(32);
 
-//     // protectedCall is safer, but we might as well exercise call when
-//     // we know it should be safe
-//     lua.call(2, 1);
+    // protectedCall is safer, but we might as well exercise call when
+    // we know it should be safe
+    lua.call(2, 1);
 
-//     try expectEqual(@as(i64, 42), try lua.toInteger(1));
-// }
+    try expectEqual(@as(i64, 42), try lua.toInteger(1));
+}
 
-// test "string buffers" {
-//     var lua = try Lua.init(testing.allocator);
-//     defer lua.deinit();
+test "string buffers" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
 
-//     var buffer: Buffer = undefined;
-//     buffer.init(lua);
+    var buffer: Buffer = undefined;
+    buffer.init(lua);
 
-//     buffer.addChar('z');
-//     buffer.addChar('i');
-//     buffer.addChar('g');
-//     buffer.addString("l");
+    buffer.addChar('z');
+    buffer.addChar('i');
+    buffer.addChar('g');
+    buffer.addString("l");
 
-//     var str = buffer.prep();
-//     str[0] = 'u';
-//     str[1] = 'a';
-//     buffer.addSize(2);
+    var str = buffer.prep();
+    str[0] = 'u';
+    str[1] = 'a';
+    buffer.addSize(2);
 
-//     buffer.addBytes(" api ");
-//     lua.pushNumber(5.1);
-//     buffer.addValue();
-//     buffer.pushResult();
-//     try expectEqualStrings("ziglua api 5.1", try lua.toBytes(-1));
+    buffer.addBytes(" api ");
+    lua.pushNumber(5.1);
+    buffer.addValue();
 
-//     // now test a small buffer
-//     buffer = undefined;
-//     buffer.init(lua);
-//     var b = buffer.prep();
-//     b[0] = 'a';
-//     b[1] = 'b';
-//     b[2] = 'c';
-//     buffer.addSize(3);
-//     b = buffer.prep();
-//     @memcpy(b, "defghijklmnopqrstuvwxyz");
-//     buffer.addSize(23);
-//     buffer.pushResult();
-//     try expectEqualStrings("abcdefghijklmnopqrstuvwxyz", try lua.toBytes(-1));
-//     lua.pop(1);
-// }
+    lua.pushBytes(" luau");
+    buffer.addValueAny(-1);
+    buffer.pushResult();
+    try expectEqualStrings("ziglua api 5.1 luau", try lua.toBytes(-1));
+
+    // now test a small buffer
+    buffer = undefined;
+    buffer.init(lua);
+    var b = buffer.prep();
+    b[0] = 'a';
+    b[1] = 'b';
+    b[2] = 'c';
+    buffer.addSize(3);
+    b = buffer.prep();
+    @memcpy(b[0..23], "defghijklmnopqrstuvwxyz");
+    buffer.pushResultSize(23);
+    try expectEqualStrings("abcdefghijklmnopqrstuvwxyz", try lua.toBytes(-1));
+    lua.pop(1);
+}
 
 test "function registration" {
     var lua = try Lua.init(testing.allocator);


### PR DESCRIPTION
Adds preliminary Luau support to Ziglua. This was done by copying the lib and test file from Lua 5.1, so there may be some missing functions and behavior. Those can be added later.

Also restructures the build.zig file