### PR TITLE
Expose Luau bytecode loading API, add example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,10 +69,14 @@ pub fn build(b: *Build) void {
     test_step.dependOn(&run_tests.step);
 
     // Examples
-    const examples = [_]struct { []const u8, []const u8 }{
+    var common_examples = [_]struct { []const u8, []const u8 }{
         .{ "interpreter", "examples/interpreter.zig" },
         .{ "zig-function", "examples/zig-fn.zig" },
     };
+    const luau_examples = [_]struct { []const u8, []const u8 }{
+        .{ "luau-bytecode", "examples/luau-bytecode.zig" },
+    };
+    const examples = if (lang == .luau) &common_examples ++ luau_examples else &common_examples;
 
     for (examples) |example| {
         const exe = b.addExecutable(.{

--- a/examples/luau-bytecode.zig
+++ b/examples/luau-bytecode.zig
@@ -1,0 +1,33 @@
+//! Run Luau bytecode
+
+// How to recompile `test.luau.bin` bytecode binary:
+//
+//   luau-compile --binary test.luau  > test.bc
+//
+// This may be required if the Luau version gets upgraded.
+
+const std = @import("std");
+
+// The ziglua module is made available in build.zig
+const ziglua = @import("ziglua");
+
+pub fn main() anyerror!void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    defer _ = gpa.deinit();
+
+    // Initialize The Lua vm and get a reference to the main thread
+    var lua = try ziglua.Lua.init(allocator);
+    defer lua.deinit();
+
+    // Open all Lua standard libraries
+    lua.openLibs();
+
+    // Load bytecode
+    const src = @embedFile("./test.luau");
+    const bc = try ziglua.compile(allocator, src, ziglua.CompileOptions{});
+    defer allocator.free(bc);
+
+    try lua.loadBytecode("...", bc);
+    try lua.protectedCall(0, 0, 0);
+}

--- a/examples/test.luau
+++ b/examples/test.luau
@@ -1,0 +1,13 @@
+--!strict
+
+function ispositive(x : number) : string
+    if x > 0 then
+        return "yes"
+    else
+        return "no"
+    end
+end
+
+local result : string
+result = ispositive(1)
+print("result is positive:", result)


### PR DESCRIPTION
for #30

This exposes Luau API for loading precompiled Luau bytecode.  

I found some information from the Luau repository that indicates bytecode is not intended to be fully backwards/forwards compatible.  I think loading bytecode can be justified due to performance reasons (improves start up time) but anyone doing bytecode loading should be prepared to be able to recompile bytecode if they upgrade Luau.  

It feels like adding a zig-implementation of luau-compile into Ziglua.  It wouldn't be much code since the original luau-compile is pretty straightforward too.

Anyway, I'm working on a little blog post that explains how to use VSCode, Zig and Luau together so that VSCode can perform real-time static type checking of Luau code.  It may not be obvious from the docs of any of these components :)