### PR TITLE
Many changes to String and Bytes functions

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2876,8 +2876,9 @@ pub const Lua = struct {
     }
 
     /// Converts any Lua value at the given index into a string in a reasonable format
+    /// Uses the __tostring metamethod if available
     /// See https://www.lua.org/manual/5.4/manual.html#luaL_tolstring
-    pub fn toBytesFmt(lua: *Lua, index: i32) [:0]const u8 {
+    pub fn toStringEx(lua: *Lua, index: i32) [:0]const u8 {
         var length: usize = undefined;
         const ptr = c.luaL_tolstring(lua.state, index, &length);
         return ptr[0..length :0];

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1533,7 +1533,7 @@ pub const Lua = struct {
 
     /// Pushes the bytes onto the stack. Returns a slice pointing to Lua's internal copy of the string
     /// See https://www.lua.org/manual/5.4/manual.html#lua_pushlstring
-    pub fn pushBytes(lua: *Lua, bytes: []const u8) BytesResult {
+    pub fn pushString(lua: *Lua, bytes: []const u8) BytesResult {
         switch (lang) {
             .lua51, .luajit, .luau => {
                 c.lua_pushlstring(lua.state, bytes.ptr, bytes.len);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -3492,7 +3492,7 @@ pub const Buffer = struct {
 
     /// Adds the string to the buffer
     /// See https://www.lua.org/manual/5.4/manual.html#luaL_addlstring
-    pub fn addBytes(buf: *Buffer, str: []const u8) void {
+    pub fn addString(buf: *Buffer, str: []const u8) void {
         c.luaL_addlstring(&buf.b, str.ptr, str.len);
     }
 
@@ -3511,7 +3511,7 @@ pub const Buffer = struct {
 
     /// Adds the zero-terminated string pointed to by `str` to the buffer
     /// See https://www.lua.org/manual/5.4/manual.html#luaL_addstring
-    pub fn addString(buf: *Buffer, str: [:0]const u8) void {
+    pub fn addStringZ(buf: *Buffer, str: [:0]const u8) void {
         switch (lang) {
             .luau => c.luaL_addlstring(&buf.b, str.ptr, str.len),
             else => c.luaL_addstring(&buf.b, str.ptr),

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -320,7 +320,7 @@ test "type of and getting values" {
     try expect(lua.isThread(-1));
     try expectEqual(lua.state, (try lua.toThread(-1)).state);
 
-    _ = lua.pushString("all your codebase are belong to us");
+    _ = lua.pushStringZ("all your codebase are belong to us");
     try expectEqual(.string, lua.typeOf(-1));
     try expect(lua.isString(-1));
 
@@ -619,7 +619,7 @@ test "global table" {
     lua.pushGlobalTable();
 
     // find the print function
-    _ = lua.pushString("print");
+    _ = lua.pushStringZ("print");
     try expectEqual(.function, lua.getTable(-2));
 
     // index the global table in the global table
@@ -752,9 +752,9 @@ test "concat" {
     var lua = try Lua.init(&testing.allocator);
     defer lua.deinit();
 
-    _ = lua.pushString("hello ");
+    _ = lua.pushStringZ("hello ");
     lua.pushNumber(10);
-    _ = lua.pushString(" wow!");
+    _ = lua.pushStringZ(" wow!");
     lua.concat(3);
 
     if (ziglua.lang == .lua53 or ziglua.lang == .lua54) {
@@ -830,22 +830,22 @@ test "table access" {
     });
     try expectEqualStrings("first", try lua.toBytes(-1));
 
-    _ = lua.pushString("key");
+    _ = lua.pushStringZ("key");
     try expectEqual(.string, lua.getTable(1));
     try expectEqualStrings("value", try lua.toBytes(-1));
 
-    _ = lua.pushString("other one");
+    _ = lua.pushStringZ("other one");
     try expectEqual(.number, lua.rawGetTable(1));
     try expectEqual(1234, try toInteger(&lua, -1));
 
     // a.name = "ziglua"
-    _ = lua.pushString("name");
-    _ = lua.pushString("ziglua");
+    _ = lua.pushStringZ("name");
+    _ = lua.pushStringZ("ziglua");
     lua.setTable(1);
 
     // a.lang = "zig"
-    _ = lua.pushString("lang");
-    _ = lua.pushString("zig");
+    _ = lua.pushStringZ("lang");
+    _ = lua.pushStringZ("zig");
     lua.rawSetTable(1);
 
     try expectError(error.Fail, lua.getMetatable(1));
@@ -1031,7 +1031,7 @@ test "userdata and uservalues" {
         lua.pushNumber(1234.56);
         try lua.setUserValue(1, 1);
 
-        _ = lua.pushString("test string");
+        _ = lua.pushStringZ("test string");
         try lua.setUserValue(1, 2);
 
         try expectEqual(.number, try lua.getUserValue(1, 1));
@@ -1113,7 +1113,7 @@ test "registry" {
     const key = "mykey";
 
     // store a string in the registry
-    _ = lua.pushString("hello there");
+    _ = lua.pushStringZ("hello there");
     lua.rawSetPtr(ziglua.registry_index, key);
 
     // get key from the registry
@@ -1160,7 +1160,7 @@ test "raise error" {
 
     const makeError = struct {
         fn inner(l: *Lua) i32 {
-            _ = l.pushString("makeError made an error");
+            _ = l.pushStringZ("makeError made an error");
             l.raiseError();
             return 0;
         }
@@ -1175,7 +1175,7 @@ fn continuation(l: *Lua, status: ziglua.Status, ctx: isize) i32 {
     _ = status;
 
     if (ctx == 5) {
-        _ = l.pushString("done");
+        _ = l.pushStringZ("done");
         return 1;
     } else {
         // yield the current context value
@@ -1233,7 +1233,7 @@ fn continuation52(l: *Lua) i32 {
     const ctxOrNull = l.getContext() catch unreachable;
     const ctx = ctxOrNull orelse 0;
     if (ctx == 5) {
-        _ = l.pushString("done");
+        _ = l.pushStringZ("done");
         return 1;
     } else {
         // yield the current context value
@@ -1386,7 +1386,7 @@ test "aux check functions" {
     lua.pushInteger(3);
     _ = lua.pushBytes("hello world");
     lua.pushNumber(4);
-    _ = lua.pushString("hello world");
+    _ = lua.pushStringZ("hello world");
     lua.protectedCall(5, 0, 0) catch {
         try expectStringContains("boolean expected", try lua.toBytes(-1));
         lua.pop(-1);
@@ -1398,7 +1398,7 @@ test "aux check functions" {
         lua.pushInteger(3);
         _ = lua.pushBytes("hello world");
         lua.pushNumber(4);
-        _ = lua.pushString("hello world");
+        _ = lua.pushStringZ("hello world");
         lua.pushBoolean(true);
         lua.protectedCall(6, 0, 0) catch {
             try expectEqualStrings("bad argument #7 to '?' (number expected, got no value)", try lua.toBytes(-1));
@@ -1412,7 +1412,7 @@ test "aux check functions" {
     lua.pushInteger(3);
     _ = lua.pushBytes("hello world");
     lua.pushNumber(4);
-    _ = lua.pushString("hello world");
+    _ = lua.pushStringZ("hello world");
     lua.pushBoolean(true);
     if (ziglua.lang == .lua52) {
         lua.pushUnsigned(1);
@@ -1441,7 +1441,7 @@ test "aux opt functions" {
     lua.pushInteger(10);
     _ = lua.pushBytes("zig");
     lua.pushNumber(1.23);
-    _ = lua.pushString("lang");
+    _ = lua.pushStringZ("lang");
     try lua.protectedCall(4, 0, 0);
 }
 
@@ -1468,19 +1468,19 @@ test "checkOption" {
     }.inner);
 
     lua.pushFunction(function);
-    _ = lua.pushString("one");
+    _ = lua.pushStringZ("one");
     try lua.protectedCall(1, 1, 0);
     try expectEqual(1, try toInteger(&lua, -1));
     lua.pop(1);
 
     lua.pushFunction(function);
-    _ = lua.pushString("two");
+    _ = lua.pushStringZ("two");
     try lua.protectedCall(1, 1, 0);
     try expectEqual(2, try toInteger(&lua, -1));
     lua.pop(1);
 
     lua.pushFunction(function);
-    _ = lua.pushString("three");
+    _ = lua.pushStringZ("three");
     try lua.protectedCall(1, 1, 0);
     try expectEqual(3, try toInteger(&lua, -1));
     lua.pop(1);
@@ -1493,7 +1493,7 @@ test "checkOption" {
 
     // check the raised error
     lua.pushFunction(function);
-    _ = lua.pushString("unknown");
+    _ = lua.pushStringZ("unknown");
     try expectError(error.Runtime, lua.protectedCall(1, 1, 0));
     try expectStringContains("(invalid option 'unknown')", try lua.toBytes(-1));
 }
@@ -1860,7 +1860,7 @@ test "objectLen" {
     var lua = try Lua.init(&testing.allocator);
     defer lua.deinit();
 
-    lua.pushString("lua");
+    lua.pushStringZ("lua");
     try testing.expectEqual(3, lua.objectLen(-1));
 }
 
@@ -2292,9 +2292,9 @@ test "useratom" {
     defer lua.deinit();
     lua.setUserAtomCallbackFn(ziglua.wrap(useratomCb));
 
-    _ = lua.pushString("unknownatom");
-    _ = lua.pushString("method_one");
-    _ = lua.pushString("another_method");
+    _ = lua.pushStringZ("unknownatom");
+    _ = lua.pushStringZ("method_one");
+    _ = lua.pushStringZ("another_method");
 
     const atom_idx0, const str0 = try lua.toStringAtom(-2);
     const atom_idx1, const str1 = try lua.toStringAtom(-1);
@@ -2360,7 +2360,7 @@ test "namecall" {
     lua.pushVector(0, 0, 0);
 
     try lua.newMetatable("vector");
-    lua.pushString("__namecall");
+    lua.pushStringZ("__namecall");
     lua.pushFunctionNamed(ziglua.wrap(funcs.vectorNamecall), "vector_namecall");
     lua.setTable(-3);
 
@@ -2406,17 +2406,17 @@ test "toAny" {
     try testing.expect(my_float == 100.0);
 
     //[]const u8
-    _ = lua.pushString("hello world");
+    _ = lua.pushStringZ("hello world");
     const my_string_1 = try lua.toAny([]const u8, -1);
     try testing.expect(std.mem.eql(u8, my_string_1, "hello world"));
 
     //[:0]const u8
-    _ = lua.pushString("hello world");
+    _ = lua.pushStringZ("hello world");
     const my_string_2 = try lua.toAny([:0]const u8, -1);
     try testing.expect(std.mem.eql(u8, my_string_2, "hello world"));
 
     //[*:0]const u8
-    _ = lua.pushString("hello world");
+    _ = lua.pushStringZ("hello world");
     const my_string_3 = try lua.toAny([*:0]const u8, -1);
     const end = std.mem.indexOfSentinel(u8, 0, my_string_3);
     try testing.expect(std.mem.eql(u8, my_string_3[0..end], "hello world"));
@@ -2434,7 +2434,7 @@ test "toAny" {
 
     //enum
     const MyEnumType = enum { hello, goodbye };
-    _ = lua.pushString("hello");
+    _ = lua.pushStringZ("hello");
     const my_enum = try lua.toAny(MyEnumType, -1);
     try testing.expect(my_enum == MyEnumType.hello);
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -330,7 +330,7 @@ test "type of and getting values" {
     try expect(lua.isFunction(-1));
     try expectEqual(ziglua.wrap(add), try lua.toCFunction(-1));
 
-    _ = lua.pushBytes("hello world");
+    _ = lua.pushString("hello world");
     try expectEqual(.string, lua.typeOf(-1));
     try expect(lua.isString(-1));
 
@@ -373,7 +373,7 @@ test "unsigned" {
     lua.pushUnsigned(123456);
     try expectEqual(123456, try lua.toUnsigned(-1));
 
-    _ = lua.pushBytes("hello");
+    _ = lua.pushString("hello");
     try expectError(error.Fail, lua.toUnsigned(-1));
 }
 
@@ -1365,7 +1365,7 @@ test "aux check functions" {
     lua.pushFunction(function);
     lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushBytes("hello world");
+    _ = lua.pushString("hello world");
     lua.protectedCall(3, 0, 0) catch {
         try expectStringContains("number expected", try lua.toBytes(-1));
         lua.pop(-1);
@@ -1374,7 +1374,7 @@ test "aux check functions" {
     lua.pushFunction(function);
     lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushBytes("hello world");
+    _ = lua.pushString("hello world");
     lua.pushNumber(4);
     lua.protectedCall(4, 0, 0) catch {
         try expectStringContains("string expected", try lua.toBytes(-1));
@@ -1384,7 +1384,7 @@ test "aux check functions" {
     lua.pushFunction(function);
     lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushBytes("hello world");
+    _ = lua.pushString("hello world");
     lua.pushNumber(4);
     _ = lua.pushStringZ("hello world");
     lua.protectedCall(5, 0, 0) catch {
@@ -1396,7 +1396,7 @@ test "aux check functions" {
         lua.pushFunction(function);
         lua.pushNil();
         lua.pushInteger(3);
-        _ = lua.pushBytes("hello world");
+        _ = lua.pushString("hello world");
         lua.pushNumber(4);
         _ = lua.pushStringZ("hello world");
         lua.pushBoolean(true);
@@ -1410,7 +1410,7 @@ test "aux check functions" {
     // test pushFail here (currently acts the same as pushNil)
     if (ziglua.lang == .lua54) lua.pushFail() else lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushBytes("hello world");
+    _ = lua.pushString("hello world");
     lua.pushNumber(4);
     _ = lua.pushStringZ("hello world");
     lua.pushBoolean(true);
@@ -1439,7 +1439,7 @@ test "aux opt functions" {
 
     lua.pushFunction(function);
     lua.pushInteger(10);
-    _ = lua.pushBytes("zig");
+    _ = lua.pushString("zig");
     lua.pushNumber(1.23);
     _ = lua.pushStringZ("lang");
     try lua.protectedCall(4, 0, 0);
@@ -1565,7 +1565,7 @@ test "ref" {
     try expectError(error.Fail, lua.ref(ziglua.registry_index));
     try expectEqual(0, lua.getTop());
 
-    _ = lua.pushBytes("Hello there");
+    _ = lua.pushString("Hello there");
     const ref = try lua.ref(ziglua.registry_index);
 
     _ = lua.rawGetIndex(ziglua.registry_index, ref);
@@ -1586,7 +1586,7 @@ test "ref luau" {
 
     // In luau lua.ref does not pop the item from the stack
     // and the data is stored in the registry_index by default
-    lua.pushBytes("Hello there");
+    lua.pushString("Hello there");
     const ref = try lua.ref(2);
 
     _ = lua.rawGetIndex(ziglua.registry_index, ref);
@@ -1718,11 +1718,11 @@ test "userdata" {
         fn inner(l: *Lua) i32 {
             const ptr = l.checkUserdata(Type, 1, "Type");
             if (ptr.a != 1234) {
-                _ = l.pushBytes("error!");
+                _ = l.pushString("error!");
                 l.raiseError();
             }
             if (ptr.b != 3.14) {
-                _ = l.pushBytes("error!");
+                _ = l.pushString("error!");
                 l.raiseError();
             }
             return 1;
@@ -1751,15 +1751,15 @@ test "userdata" {
     const testUdata = ziglua.wrap(struct {
         fn inner(l: *Lua) i32 {
             const ptr = l.testUserdata(Type, 1, "Type") catch {
-                _ = l.pushBytes("error!");
+                _ = l.pushString("error!");
                 l.raiseError();
             };
             if (ptr.a != 1234) {
-                _ = l.pushBytes("error!");
+                _ = l.pushString("error!");
                 l.raiseError();
             }
             if (ptr.b != 3.14) {
-                _ = l.pushBytes("error!");
+                _ = l.pushString("error!");
                 l.raiseError();
             }
             return 0;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -553,14 +553,14 @@ test "string buffers" {
     buffer.init(lua);
 
     buffer.addChar('z');
-    buffer.addString("igl");
+    buffer.addStringZ("igl");
 
     var str = buffer.prep();
     str[0] = 'u';
     str[1] = 'a';
     buffer.addSize(2);
 
-    buffer.addBytes(" api ");
+    buffer.addString(" api ");
     lua.pushNumber(5.1);
     buffer.addValue();
     buffer.pushResult();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1332,11 +1332,10 @@ test "aux check functions" {
         fn inner(l: *Lua) i32 {
             l.checkAny(1);
             _ = l.checkInteger(2);
-            _ = l.checkBytes(3);
-            _ = l.checkNumber(4);
-            _ = l.checkString(5);
-            l.checkType(6, .boolean);
-            _ = if (ziglua.lang == .lua52) l.checkUnsigned(7);
+            _ = l.checkNumber(3);
+            _ = l.checkString(4);
+            l.checkType(5, .boolean);
+            _ = if (ziglua.lang == .lua52) l.checkUnsigned(6);
             return 0;
         }
     }.inner);
@@ -1365,18 +1364,8 @@ test "aux check functions" {
     lua.pushFunction(function);
     lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushString("hello world");
-    lua.protectedCall(3, 0, 0) catch {
-        try expectStringContains("number expected", try lua.toString(-1));
-        lua.pop(-1);
-    };
-
-    lua.pushFunction(function);
-    lua.pushNil();
-    lua.pushInteger(3);
-    _ = lua.pushString("hello world");
     lua.pushNumber(4);
-    lua.protectedCall(4, 0, 0) catch {
+    lua.protectedCall(3, 0, 0) catch {
         try expectStringContains("string expected", try lua.toString(-1));
         lua.pop(-1);
     };
@@ -1384,10 +1373,9 @@ test "aux check functions" {
     lua.pushFunction(function);
     lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushString("hello world");
     lua.pushNumber(4);
-    _ = lua.pushStringZ("hello world");
-    lua.protectedCall(5, 0, 0) catch {
+    _ = lua.pushString("hello world");
+    lua.protectedCall(4, 0, 0) catch {
         try expectStringContains("boolean expected", try lua.toString(-1));
         lua.pop(-1);
     };
@@ -1396,12 +1384,11 @@ test "aux check functions" {
         lua.pushFunction(function);
         lua.pushNil();
         lua.pushInteger(3);
-        _ = lua.pushString("hello world");
         lua.pushNumber(4);
-        _ = lua.pushStringZ("hello world");
+        _ = lua.pushString("hello world");
         lua.pushBoolean(true);
-        lua.protectedCall(6, 0, 0) catch {
-            try expectEqualStrings("bad argument #7 to '?' (number expected, got no value)", try lua.toString(-1));
+        lua.protectedCall(5, 0, 0) catch {
+            try expectEqualStrings("bad argument #6 to '?' (number expected, got no value)", try lua.toString(-1));
             lua.pop(-1);
         };
     }
@@ -1410,14 +1397,13 @@ test "aux check functions" {
     // test pushFail here (currently acts the same as pushNil)
     if (ziglua.lang == .lua54) lua.pushFail() else lua.pushNil();
     lua.pushInteger(3);
-    _ = lua.pushString("hello world");
     lua.pushNumber(4);
-    _ = lua.pushStringZ("hello world");
+    _ = lua.pushString("hello world");
     lua.pushBoolean(true);
     if (ziglua.lang == .lua52) {
         lua.pushUnsigned(1);
-        try lua.protectedCall(7, 0, 0);
-    } else try lua.protectedCall(6, 0, 0);
+        try lua.protectedCall(6, 0, 0);
+    } else try lua.protectedCall(5, 0, 0);
 }
 
 test "aux opt functions" {
@@ -1427,9 +1413,9 @@ test "aux opt functions" {
     const function = ziglua.wrap(struct {
         fn inner(l: *Lua) i32 {
             expectEqual(10, l.optInteger(1, 10)) catch unreachable;
-            expectEqualStrings("zig", l.optBytes(2, "zig")) catch unreachable;
+            expectEqualStrings("zig", l.optString(2, "zig")) catch unreachable;
             expectEqual(1.23, l.optNumber(3, 1.23)) catch unreachable;
-            expectEqualStrings("lang", std.mem.span(l.optString(4, "lang"))) catch unreachable;
+            expectEqualStrings("lang", l.optString(4, "lang")) catch unreachable;
             return 0;
         }
     }.inner);
@@ -2333,7 +2319,7 @@ test "namecall" {
 
         pub fn vectorNamecall(l: *Lua) i32 {
             const atom_idx, _ = l.namecallAtom() catch {
-                l.raiseErrorStr("%s is not a valid vector method", .{l.checkString(1)});
+                l.raiseErrorStr("%s is not a valid vector method", .{l.checkString(1).ptr});
             };
             switch (atom_idx) {
                 dot_idx => {


### PR DESCRIPTION
The commit messages should hopefully be clear. This renames functions that use "Bytes" in the name to "String" and any function that used "String" to refer to zero-terminated strings to be "StringZ".

Also cleans up a few places where `[*:0]` or `[:0]` were misplaced.

Part of https://github.com/natecraddock/ziglua/issues/37