### PR TITLE
fix: replace `lua_yield` with what it expands to to avoid macro typecheck error

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2105,7 +2105,7 @@ pub const Lua = opaque {
         switch (lang) {
             .lua51, .luajit, .luau => return c.lua_yield(@ptrCast(lua), num_results),
             else => {
-                _ = c.lua_yield(@ptrCast(lua), num_results);
+                _ = c.lua_yieldk(@ptrCast(lua), num_results, 0, null);
                 unreachable;
             },
         }


### PR DESCRIPTION
because `lua_yield` is a macro, `translate-c` appears to be sad about types. since it just expands to `lua_yieldk` with extra arguments of `0` and `null`, this PR does that replacement.