### PR TITLE
Being chatty when no lazy dependency is found

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *Build) void {
     luadep: {
         const lua_tag = @tagName(lang);
         const upstream = b.lazyDependency(lua_tag, .{}) orelse {
-            std.debug.print("ziglua warning: could not find a dependency for {s}! Add one to your build.zig.zon.\n", .{lua_tag});
+            std.debug.print("ziglua warning: could not find a dependency for {s}! Do you need to run 'zig build --fetch'?.\n", .{lua_tag});
             break :luadep;
         };
 

--- a/build.zig
+++ b/build.zig
@@ -44,7 +44,11 @@ pub fn build(b: *Build) void {
     }
 
     luadep: {
-        const upstream = b.lazyDependency(@tagName(lang), .{}) orelse break :luadep;
+        const lua_tag = @tagName(lang);
+        const upstream = b.lazyDependency(lua_tag, .{}) orelse {
+            std.debug.print("ziglua warning: could not find a dependency for {s}! Add one to your build.zig.zon.\n", .{lua_tag});
+            break :luadep;
+        };
 
         const lib = switch (lang) {
             .luajit => buildLuaJIT(b, target, optimize, upstream, shared),


### PR DESCRIPTION
Silently breaking when no artifact is installed seems like a big footgun for people to step on. This makes needing to explicitly add a Lua dependency to a master project more explicit.