### PR TITLE
Fix example code in the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ pub fn main() anyerror!void {
     defer _ = gpa.deinit();
 
     // Initialize the Lua vm
-    var lua = try Lua.init(allocator);
+    var lua = try Lua.init(&allocator);
     defer lua.deinit();
 
     // Add an integer to the Lua stack and retrieve it


### PR DESCRIPTION
This is a follow-up to [commit #aca17d6b](https://github.com/natecraddock/ziglua/commit/aca17d6bc82436a1d824b0044c092662ae921a1d) and [Issue #40](https://github.com/natecraddock/ziglua/issues/40).

Looks like the example in the `README` did not get updated with the code change.