### PR TITLE
Add a method to set the Luau interrupt callback

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2555,6 +2555,15 @@ pub const Lua = opaque {
         unreachable;
     }
 
+    /// Raises an error from inside a Luau interrupt
+    /// See https://github.com/luau-lang/luau/blob/ce8495a69e7a4e774a5402f99e1fc282a92ced91/CLI/Repl.cpp#L59
+    pub fn raiseInterruptErrorStr(lua: *Lua, fmt: [:0]const u8, args: anytype) noreturn {
+        if (lang != .luau) return;
+        c.lua_rawcheckstack(@ptrCast(lua), 1);
+        lua.raiseErrorStr(fmt, args);
+        unreachable;
+    }
+
     /// This function produces the return values for process-related functions in the standard library
     /// See https://www.lua.org/manual/5.4/manual.html#luaL_execresult
     pub fn execResult(lua: *Lua, stat: i32) i32 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2895,6 +2895,7 @@ test "interrupt" {
         pub fn inner(l: *Lua, _: i32) void {
             times_called += 1;
             l.setInterruptCallbackFn(null);
+            l.raiseInterruptErrorStr("interrupted", .{});
         }
     };
 
@@ -2906,9 +2907,10 @@ test "interrupt" {
     );
     lua.setInterruptCallbackFn(ziglua.wrap(interrupt_handler.inner));
 
-    try lua.doString(
+    const expected_err = lua.doString(
         \\c = add(1, 2)
     );
+    try testing.expectError(ziglua.Error.Runtime, expected_err);
     try testing.expectEqual(1, interrupt_handler.times_called);
 
     // Handler should have removed itself


### PR DESCRIPTION
Added a method to set the interrupt callback - I tried to parallel how the useratom callback was set up.

Sorry for the spam; I'm just starting on a new project and some of these changes seem useful to push back upstream.