### PR TITLE
Invert the argExpected condition to match Lua docs

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2382,7 +2382,7 @@ pub const Lua = opaque {
     /// See https://www.lua.org/manual/5.4/manual.html#luaL_argexpected
     pub fn argExpected(lua: *Lua, cond: bool, arg: i32, type_name: [:0]const u8) void {
         // translate-c failed
-        if (cond) lua.typeError(arg, type_name);
+        if (!cond) lua.typeError(arg, type_name);
     }
 
     /// Calls a metamethod

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1635,7 +1635,7 @@ test "args and errors" {
 
     const argExpected = ziglua.wrap(struct {
         fn inner(l: *Lua) i32 {
-            l.argExpected(true, 1, "string");
+            l.argExpected(false, 1, "string");
             return 0;
         }
     }.inner);


### PR DESCRIPTION
The new behavior matches my reading of the 5.4 docs (https://www.lua.org/manual/5.4/manual.html#luaL_argexpected) and the sense of argCheck, so I don't think the old behavior was intentional?