### PR TITLE
add missing path

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = "ziglua",
     .version = "0.1.0",
-    .paths = .{ "build.zig", "build.zig.zon", "src", "license" },
+    .paths = .{ "build.zig", "build.zig.zon", "src", "license", "include" },
 
     .dependencies = .{
         // We do not use the lua.org version of Lua 5.1.5 because there is a known security issue


### PR DESCRIPTION
Because the `include` directory was not in the `paths` field of build.zig.zon, building ziglua master as a dependency fails because it fails to find the `include` directory. 

```zig
Robert@Roberts-MacBook-Pro-2 ~/z/dev (master)> zig build
install
└─ install dev
   └─ zig build-exe dev Debug native
      └─ translate-c failure
error: error: FileNotFound

error: the following command exited with error code 1:
/Users/Robert/zig/0.13.0/files/zig translate-c -lc --listen=- -I /Users/Robert/zig/dev/.zig-cache/i/a8616f6f48aaff0f313d6060ffcb2711/include /Users/Robert/.cache/zig/p/1220e799b85ed395896173008e6567a5614a4842d1e1485ee62e669926c2082bb93c/include/lua_all.h
Build Summary: 11/15 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install dev transitive failure
   └─ zig build-exe dev Debug native transitive failure
      └─ translate-c failure
error: the following build command failed with exit code 1:
/Users/Robert/zig/dev/.zig-cache/o/2d41ede4755489dfd1bd6b2e94bb5307/build /Users/Robert/zig/0.13.0/files/zig /Users/Robert/zig/dev /Users/Robert/zig/dev/.zig-cache /Users/Robert/.cache/zig --seed 0x8d01faf -Zd86f12b4e4c6389e
```