### PR TITLE
fix: remove `Lua.equal` with compile error for lua 5.2, 5.3, 5.4

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -980,6 +980,10 @@ pub const Lua = opaque {
     ///
     /// See https://www.lua.org/manual/5.1/manual.html#lua_equal
     pub fn equal(lua: *Lua, index1: i32, index2: i32) bool {
+        switch (lang) {
+            .lua52, .lua53, .lua54 => @compileError("lua_equal is deprecated, use Lua.compare with .eq instead"),
+            else => {},
+        }
         return c.lua_equal(@ptrCast(lua), index1, index2) == 1;
     }
 
@@ -990,6 +994,8 @@ pub const Lua = opaque {
     /// * Pushes: `0`
     /// * Errors: `explained in text / on purpose`
     ///
+    /// Raises a Lua error using the value at the top of the stack as the error object
+    /// Does a longjump and therefore never returns
     /// See https://www.lua.org/manual/5.4/manual.html#lua_error
     pub fn raiseError(lua: *Lua) noreturn {
         _ = c.lua_error(@ptrCast(lua));


### PR DESCRIPTION
`lua_equal` is deprecated in Lua versions 5.2 and later; the same behavior can be achieved with `lua_compare` with the equality flag. this commit makes using `lua_equal` a compile error when `lang` is 5.2, 5.3 or 5.4. in fact, it is already a compile error (since the C header does not expose the function), but making it fail faster with a helpful replacement suggestion seems useful.

I chose to leave the declaration of `equal` untouched: I think this is helpful for ZLS, which I find has a tough time resolving `switch (lang)` in my seamstress project, but I'm happy to take a different route too.