### PR TITLE
expose `c` as build module and fix `exportFn`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -76,7 +76,15 @@ pub fn build(b: *Build) void {
     });
     c_headers.addIncludePath(lib.getEmittedIncludeTree());
     c_headers.step.dependOn(&install_lib.step);
-    ziglua.addImport("c", c_headers.createModule());
+
+    const ziglua_c = b.addModule("ziglua-c", .{
+        .root_source_file = c_headers.getOutput(),
+        .target = c_headers.target,
+        .optimize = c_headers.optimize,
+        .link_libc = c_headers.link_libc,
+    });
+
+    ziglua.addImport("c", ziglua_c);
 
     // Tests
     const tests = b.addTest(.{

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -5138,7 +5138,7 @@ pub fn exportFn(comptime name: []const u8, comptime func: anytype) CFn {
         }
 
         comptime {
-            @export(luaopen, .{ .name = "luaopen_" ++ name });
+            @export(&luaopen, .{ .name = "luaopen_" ++ name });
         }
     }.luaopen;
 }


### PR DESCRIPTION
use translate-c as a module for have direct access to lua C api.
![image](https://github.com/user-attachments/assets/71ce8a8e-50b6-495e-b4bb-e86f21c9863b)
![image](https://github.com/user-attachments/assets/da7dfaab-9bc0-4e55-a013-a0631d15242f)


use pointer in `@export`
![image](https://github.com/user-attachments/assets/571ff96a-5ba1-4083-abad-a764ea4be3da)

