### PR TITLE
Update Luau to 0.653

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,8 +34,8 @@
         },
 
         .luau = .{
-            .url = "https://github.com/luau-lang/luau/archive/refs/tags/0.607.tar.gz",
-            .hash = "122003818ff2aa912db37d4bbda314ff9ff70d03d9243af4b639490be98e2bfa7cb6",
+            .url = "https://github.com/luau-lang/luau/archive/refs/tags/0.653.tar.gz",
+            .hash = "1220c76fb74b983b0ebfdd6b3a4aa8adf0c1ff69c9b6a9e9e05f9bc6a6c57a690e23",
         },
     },
 }

--- a/build/luau.zig
+++ b/build/luau.zig
@@ -8,7 +8,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
         .name = "luau",
         .target = target,
         .optimize = optimize,
-        .version = std.SemanticVersion{ .major = 0, .minor = 607, .patch = 0 },
+        .version = std.SemanticVersion{ .major = 0, .minor = 653, .patch = 0 },
     });
 
     lib.addIncludePath(upstream.path("Common/include"));
@@ -84,10 +84,12 @@ const luau_source_files = [_][]const u8{
     "VM/src/ltm.cpp",
     "VM/src/ludata.cpp",
     "VM/src/lutf8lib.cpp",
+    "VM/src/lveclib.cpp",
     "VM/src/lvmexecute.cpp",
     "VM/src/lvmload.cpp",
     "VM/src/lvmutils.cpp",
 
+    "Ast/src/Allocator.cpp",
     "Ast/src/Ast.cpp",
     "Ast/src/Confusables.cpp",
     "Ast/src/Lexer.cpp",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -4296,6 +4296,18 @@ pub const Lua = opaque {
         if (lang == .lua52 or lang == .lua53 or lang == .lua54) lua.pop(1);
     }
 
+    /// Open the vector standard library
+    ///
+    /// Only available in Luau
+    ///
+    /// * Pops:   `0`
+    /// * Pushes: `0`
+    /// * Errors: `other`
+    pub fn openVector(lua: *Lua) void {
+        lua.requireF(c.LUA_VECLIBNAME, c.luaopen_vector, true);
+        if (lang == .lua52 or lang == .lua53 or lang == .lua54) lua.pop(1);
+    }
+
     /// Returns if given typeinfo is a string type
     fn isTypeString(typeinfo: std.builtin.Type.Pointer) bool {
         const childinfo = @typeInfo(typeinfo.child);


### PR DESCRIPTION
This a pretty simple version bump, just needed to bring in a couple of new cpp files and add a luaopen_vector wrapper. Also the CompileOptions struct changed a bit. I took the time to copy over the doc comments about the CompileOptions struct because the ones that were there had changed and they're kind of confusing. At some point, enum coverage for the different option values would be good, but I thought I'd keep the changes as minimal as possible for the purposes of the PR.