### PR TITLE
Fix build break for zig 0.14.0-dev.2596

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v2
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0-dev.1820+ea527f7a8
+          version: 0.14.0-dev.2596+e6879e99e
       - run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v2
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0-dev.2596+e6879e99e
+          version: 0.14.0-dev.2851+b074fb7dd
       - run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v1
       with:
-        version: 0.14.0-dev.1820+ea527f7a8
+        version: 0.14.0-dev.2596+e6879e99e
 
     - name: Run tests
       run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v1
       with:
-        version: 0.14.0-dev.2596+e6879e99e
+        version: 0.14.0-dev.2851+b074fb7dd
 
     - name: Run tests
       run: make test

--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -11,12 +11,14 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
             .name = "lua",
             .target = target,
             .optimize = optimize,
+            .unwind_tables = .sync,
         })
     else
         b.addStaticLibrary(.{
             .name = "lua",
             .target = target,
             .optimize = optimize,
+            .unwind_tables = .sync,
         });
 
     // Compile minilua interpreter used at build time to generate files
@@ -163,9 +165,9 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
 
     lib.linkLibC();
 
-    lib.defineCMacro("LUAJIT_UNWIND_EXTERNAL", null);
+    lib.root_module.addCMacro("LUAJIT_UNWIND_EXTERNAL", "");
+
     lib.linkSystemLibrary("unwind");
-    lib.root_module.unwind_tables = true;
 
     lib.addIncludePath(upstream.path("src"));
     lib.addIncludePath(luajit_h.dirname());

--- a/src/define.zig
+++ b/src/define.zig
@@ -102,7 +102,7 @@ pub fn addClass(
             try state.definitions.items[index].appendSlice("---@field ");
             try state.definitions.items[index].appendSlice(field.name);
 
-            if (field.default_value != null) {
+            if (field.defaultValue() != null) {
                 try state.definitions.items[index].appendSlice("?");
             }
             try state.definitions.items[index].appendSlice(" ");
@@ -123,13 +123,13 @@ fn luaTypeName(
             try addClass(state, T);
         },
         .pointer => |info| {
-            if (info.child == u8 and info.size == .Slice) {
+            if (info.child == u8 and info.size == .slice) {
                 try state.definitions.items[index].appendSlice("string");
             } else switch (info.size) {
-                .One => {
+                .one => {
                     try state.definitions.items[index].appendSlice("lightuserdata");
                 },
-                .C, .Many, .Slice => {
+                .c, .many, .slice => {
                     try luaTypeName(state, index, info.child);
                     try state.definitions.items[index].appendSlice("[]");
                 },

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2591,6 +2591,20 @@ test "pushAny struct" {
     try testing.expect(value.bar == (MyType{}).bar);
 }
 
+test "pushAny anon struct" {
+    var lua = try Lua.init(testing.allocator);
+    defer lua.deinit();
+
+    const MyType = struct {
+        x: i32,
+        enable: bool,
+    };
+    try lua.pushAny(.{ .x = @as(i32, 13), .enable = true });
+    const value = try lua.toAny(MyType, -1);
+    try testing.expect(value.x == 13);
+    try testing.expect(value.enable == true);
+}
+
 test "pushAny tagged union" {
     var lua = try Lua.init(testing.allocator);
     defer lua.deinit();


### PR DESCRIPTION
- There's no root_module.addCMacro anymore

- There's also no root_module.unwind_tables boolean anymore.  My fix only fixes the break but I don't know what's the right value to set here.  The choices are null, sync, and async.  I couldn't get the luajit variant to build on Windows.  Maybe merge this and ask the luajit contributor for a proper fix?

for #130