### PR TITLE
fix(docs): update docs.yml to use newer upload-artifact action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           version: 0.14.0-dev.3259+0779e847f
       - run: make docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'zig-out/docs'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
the docs CI runs are failing without running, because the stated usage of `upload-artifact@v1` is old enough that GitHub won't let you use it.