### PR TITLE
fix(build)!: update to zig 0.14.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v5
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0-dev.3259+0779e847f
+          version: 0.14.0
       - run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v1
       with:
-        version: 0.14.0-dev.3259+0779e847f
+        version: 0.14.0
 
     - name: Run tests
       run: make test

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = .lua_bindings,
-    .fingerprint = 0x7f4d6aaca0c057a7, // changing this has security and trust implications
+    .name = .lua_wrapper,
+    .fingerprint = 0xb40fd4eedb02233b, // changing this has security and trust implications
     .version = "0.1.0",
     .paths = .{ "build.zig", "build.zig.zon", "src", "license", "include", "build" },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "ziglua",
+    .name = .lua_bindings,
+    .fingerprint = 0x7f4d6aaca0c057a7, // changing this has security and trust implications
     .version = "0.1.0",
     .paths = .{ "build.zig", "build.zig.zon", "src", "license", "include", "build" },
 


### PR DESCRIPTION
BREAKING: this PR changes the package name from `ziglua` to `lua_bindings`. not using `zig` in the package name has been repeatedly communicated as best practices, analogous to `npm`'s naming guidelines. for this particular package, this is complicated by the fact that `ziglua` provides far more than just `lua` packaged for Zig's build system (which already exists in numerous places), but also aims to provide ergonomic and powerful Zig abstractions on top of the Lua C implementation. For this reason, I chose to add "bindings" to the name.

NB - the "fingerprint" field in build.zig.zon is new in Zig 0.14.0 and is computed in part based on the name. once we have settled on the name, if it is not "lua_bindings" it will be necessary to delete the fingerprint line and regenerated it.