### PR TITLE
Update to zig-0.14 changes to project name and fingerprint

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "ziglua",
+    .name = .ziglua,
+    .fingerprint = 0x98bbbb3e6b640f,
     .version = "0.1.0",
     .paths = .{ "build.zig", "build.zig.zon", "src", "license", "include", "build" },
 


### PR DESCRIPTION
Very minor change to fix local development (zig build, zig build test, etc.) for zig 0.14.

Maybe there's a lot less churn now as 0.14 seems like a pretty nice release.  At least I'm planning on sticking to that version for now.

I should mention that funnily enough, this PR is _not_ required for project depending on ziglua to work with zig-0.14.  I guess the name and fingerprint fields are not validated for deps. :)