### PR TITLE
fix: update unwind_tables for latest Zig

### DIFF
--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -161,7 +161,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
 
     lib.defineCMacro("LUAJIT_UNWIND_EXTERNAL", null);
     lib.linkSystemLibrary("unwind");
-    lib.root_module.unwind_tables = true;
+    lib.root_module.unwind_tables = .sync;
 
     lib.addIncludePath(upstream.path("src"));
     lib.addIncludePath(luajit_h.dirname());


### PR DESCRIPTION
just to close the loop on zig-0.13.0 with a good commit