### PR TITLE
readme: change dependency name from ziglua to lua_wrapper

### DIFF
--- a/examples/define-exe.zig
+++ b/examples/define-exe.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const ziglua = @import("ziglua");
+const lua_wrapper = @import("lua_wrapper");
 
 const T = struct { foo: i32 };
 const MyEnum = enum { asdf, fdsa, qwer, rewq };
@@ -10,5 +10,5 @@ const Foo = struct { far: MyEnum, near: SubType };
 
 pub fn main() !void {
     const output_file_path = std.mem.sliceTo(std.os.argv[1], 0);
-    try ziglua.define(std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
+    try lua_wrapper.define(std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
 }

--- a/examples/interpreter.zig
+++ b/examples/interpreter.zig
@@ -3,8 +3,8 @@
 
 const std = @import("std");
 
-// The ziglua module is made available in build.zig
-const ziglua = @import("ziglua");
+// The lua_wrapper module is made available in build.zig
+const lua_wrapper = @import("lua_wrapper");
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -14,7 +14,7 @@ pub fn main() anyerror!void {
     // Initialize The Lua vm and get a reference to the main thread
     //
     // Passing a Zig allocator to the Lua state requires a stable pointer
-    var lua = try ziglua.Lua.init(allocator);
+    var lua = try lua_wrapper.Lua.init(allocator);
     defer lua.deinit();
 
     // Open all Lua standard libraries

--- a/examples/luau-bytecode.zig
+++ b/examples/luau-bytecode.zig
@@ -8,8 +8,8 @@
 
 const std = @import("std");
 
-// The ziglua module is made available in build.zig
-const ziglua = @import("ziglua");
+// The lua_wrapper module is made available in build.zig
+const lua_wrapper = @import("lua_wrapper");
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -19,7 +19,7 @@ pub fn main() anyerror!void {
     // Initialize The Lua vm and get a reference to the main thread
     //
     // Passing a Zig allocator to the Lua state requires a stable pointer
-    var lua = try ziglua.Lua.init(allocator);
+    var lua = try lua_wrapper.Lua.init(allocator);
     defer lua.deinit();
 
     // Open all Lua standard libraries
@@ -27,7 +27,7 @@ pub fn main() anyerror!void {
 
     // Load bytecode
     const src = @embedFile("./test.luau");
-    const bc = try ziglua.compile(allocator, src, ziglua.CompileOptions{});
+    const bc = try lua_wrapper.compile(allocator, src, lua_wrapper.CompileOptions{});
     defer allocator.free(bc);
 
     try lua.loadBytecode("...", bc);

--- a/examples/zig-fn.zig
+++ b/examples/zig-fn.zig
@@ -1,11 +1,11 @@
 //! Registering a Zig function to be called from Lua
 
 const std = @import("std");
-const ziglua = @import("ziglua");
+const lua_wrapper = @import("lua_wrapper");
 
 // It can be convenient to store a short reference to the Lua struct when
 // it is used multiple times throughout a file.
-const Lua = ziglua.Lua;
+const Lua = lua_wrapper.Lua;
 
 // A Zig function called by Lua must accept a single *Lua parameter and must return an i32 (an error union is allowed)
 // This is the Zig equivalent of the lua_CFunction typedef int (*lua_CFunction) (lua_State *L) in the C API
@@ -26,10 +26,10 @@ pub fn main() anyerror!void {
     defer lua.deinit();
 
     // Push the adder function to the Lua stack.
-    // Here we use ziglua.wrap() to convert from a Zig function to the lua_CFunction required by Lua.
+    // Here we use lua_wrapper.wrap() to convert from a Zig function to the lua_CFunction required by Lua.
     // This could be done automatically by pushFunction(), but that would require the parameter to be comptime-known.
-    // The call to ziglua.wrap() is slightly more verbose, but has the benefit of being more flexible.
-    lua.pushFunction(ziglua.wrap(adder));
+    // The call to lua_wrapper.wrap() is slightly more verbose, but has the benefit of being more flexible.
+    lua.pushFunction(lua_wrapper.wrap(adder));
 
     // Push the arguments onto the stack
     lua.pushInteger(10);
@@ -47,7 +47,7 @@ pub fn main() anyerror!void {
     std.debug.print("the result: {}\n", .{lua.toInteger(-1) catch unreachable});
 
     // We can also register the function to a global and run from a Lua "program"
-    lua.pushFunction(ziglua.wrap(adder));
+    lua.pushFunction(lua_wrapper.wrap(adder));
     lua.setGlobal("add");
 
     // We need to open the base library so the global print() is available

--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,8 @@ pub fn build(b: *std.Build) void {
 
     // ... snip ...
 
-    // add the ziglua module and lua artifact
-    exe.root_module.addImport("ziglua", lua_dep.module("ziglua"));
+    // add the lua_wrapper module and lua artifact
+    exe.root_module.addImport("lua_wrapper", lua_dep.module("lua_wrapper"));
 
 }
 ```
@@ -70,7 +70,7 @@ There are currently three additional options that can be passed to `b.dependency
 For example, here is a `b.dependency()` call that and links against a shared Lua 5.2 library:
 
 ```zig
-const ziglua = b.dependency("lua_wrapper", .{
+const lua_wrapper = b.dependency("lua_wrapper", .{
     .target = target,
     .optimize = optimize,
     .lang = .lua52,
@@ -78,13 +78,13 @@ const ziglua = b.dependency("lua_wrapper", .{
 });
 ``````
 
-The `ziglua` module will now be available in your code. Here is a simple example that pushes and inspects an integer on the Lua stack:
+The `lua_wrapper` module will now be available in your code. Here is a simple example that pushes and inspects an integer on the Lua stack:
 
 ```zig
 const std = @import("std");
-const ziglua = @import("ziglua");
+const lua_wrapper = @import("lua_wrapper");
 
-const Lua = ziglua.Lua;
+const Lua = lua_wrapper.Lua;
 
 pub fn main() anyerror!void {
     // Create an allocator

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Then in your `build.zig` file you can use the dependency.
 pub fn build(b: *std.Build) void {
     // ... snip ...
 
-    const ziglua = b.dependency("ziglua", .{
+    const lua_dep = b.dependency("lua_wrapper", .{
         .target = target,
         .optimize = optimize,
     });
@@ -54,7 +54,7 @@ pub fn build(b: *std.Build) void {
     // ... snip ...
 
     // add the ziglua module and lua artifact
-    exe.root_module.addImport("ziglua", ziglua.module("ziglua"));
+    exe.root_module.addImport("ziglua", lua_dep.module("ziglua"));
 
 }
 ```
@@ -70,7 +70,7 @@ There are currently three additional options that can be passed to `b.dependency
 For example, here is a `b.dependency()` call that and links against a shared Lua 5.2 library:
 
 ```zig
-const ziglua = b.dependency("ziglua", .{
+const ziglua = b.dependency("lua_wrapper", .{
     .target = target,
     .optimize = optimize,
     .lang = .lua52,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,6 +1,6 @@
 //! Similar to the Lua C API documentation, each function has an indicator to describe how interacts with the stack and which errors it may return.
 //!
-//! Instead of using the form `[-o, +p, x]`, Ziglua uses the words **Pops**, **Pushes**, and **Errors** for clarity.
+//! Instead of using the form `[-o, +p, x]`, Lua_wrapper uses the words **Pops**, **Pushes**, and **Errors** for clarity.
 //!
 //! * **Pops**: how many elements the function pops from the stack.
 //! * **Pushes**: how many elements the function pushes onto the stack.
@@ -302,7 +302,7 @@ pub const DebugInfo = switch (lang) {
     .luau => DebugInfoLuau,
 };
 
-/// The superset of all errors returned from ziglua
+/// The superset of all errors returned from lua_wrapper
 pub const Error = error{
     /// A generic failure (used when a function can only fail in one way)
     LuaError,
@@ -750,7 +750,7 @@ pub const Lua = opaque {
     /// * Finally you call `Lua.call()`
     /// * `args.args` is the number of arguments that you pushed onto the stack. When the function returns, all arguments and
     /// the function value are popped and the call results are pushed onto the stack.
-    /// * The number of results is adjusted to `args.results`, unless `args.results` is `ziglua.mult_return`. In this case, all results from the function are pushed
+    /// * The number of results is adjusted to `args.results`, unless `args.results` is `lua_wrapper.mult_return`. In this case, all results from the function are pushed
     /// * Lua takes care that the returned values fit into the stack space, but it does not ensure any extra space in the stack. The function results
     /// are pushed onto the stack in direct order (the first result is pushed first), so that after the call the last result is
     /// on the top of the stack.
@@ -4903,7 +4903,7 @@ pub const Buffer = struct {
     }
 };
 
-// Helper functions to make the ziglua API easier to use
+// Helper functions to make the lua_wrapper API easier to use
 
 const Tuple = std.meta.Tuple;
 


### PR DESCRIPTION
the purpose of this PR is to close #139.

still left to consider:

- [x] the module name as defined in `build.zig` is currently "ziglua", and the README adopts this module name in the examples. do we want to change it, or leave it as-is?