### PR TITLE
fix(build)!: lua_wrapper -> zlua

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *Build) void {
     }
 
     // Zig module
-    const lua_wrapper = b.addModule("lua_wrapper", .{
+    const zlua = b.addModule("zlua", .{
         .root_source_file = b.path("src/lib.zig"),
     });
 
@@ -32,11 +32,11 @@ pub fn build(b: *Build) void {
     const config = b.addOptions();
     config.addOption(Language, "lang", lang);
     config.addOption(bool, "luau_use_4_vector", luau_use_4_vector);
-    lua_wrapper.addOptions("config", config);
+    zlua.addOptions("config", config);
 
     if (lang == .luau) {
         const vector_size: usize = if (luau_use_4_vector) 4 else 3;
-        lua_wrapper.addCMacro("LUA_VECTOR_SIZE", b.fmt("{}", .{vector_size}));
+        zlua.addCMacro("LUA_VECTOR_SIZE", b.fmt("{}", .{vector_size}));
     }
 
     const upstream = b.dependency(@tagName(lang), .{});
@@ -53,15 +53,15 @@ pub fn build(b: *Build) void {
 
     switch (lang) {
         .luau => {
-            lua_wrapper.addIncludePath(upstream.path("Common/include"));
-            lua_wrapper.addIncludePath(upstream.path("Compiler/include"));
-            lua_wrapper.addIncludePath(upstream.path("Ast/include"));
-            lua_wrapper.addIncludePath(upstream.path("VM/include"));
+            zlua.addIncludePath(upstream.path("Common/include"));
+            zlua.addIncludePath(upstream.path("Compiler/include"));
+            zlua.addIncludePath(upstream.path("Ast/include"));
+            zlua.addIncludePath(upstream.path("VM/include"));
         },
-        else => lua_wrapper.addIncludePath(upstream.path("src")),
+        else => zlua.addIncludePath(upstream.path("src")),
     }
 
-    lua_wrapper.linkLibrary(lib);
+    zlua.linkLibrary(lib);
 
     // lib must expose all headers included by these root headers
     const c_header_path = switch (lang) {
@@ -84,7 +84,7 @@ pub fn build(b: *Build) void {
         .link_libc = c_headers.link_libc,
     });
 
-    lua_wrapper.addImport("c", ziglua_c);
+    zlua.addImport("c", ziglua_c);
 
     // Tests
     const tests = b.addTest(.{
@@ -92,7 +92,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    tests.root_module.addImport("lua_wrapper", lua_wrapper);
+    tests.root_module.addImport("zlua", zlua);
 
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run ziglua tests");
@@ -115,7 +115,7 @@ pub fn build(b: *Build) void {
             .target = target,
             .optimize = optimize,
         });
-        exe.root_module.addImport("lua_wrapper", lua_wrapper);
+        exe.root_module.addImport("zlua", zlua);
 
         const artifact = b.addInstallArtifact(exe, .{});
         const exe_step = b.step(b.fmt("install-example-{s}", .{example[0]}), b.fmt("Install {s} example", .{example[0]}));
@@ -151,7 +151,7 @@ pub fn build(b: *Build) void {
         .name = "define-zig-types",
         .target = target,
     });
-    def_exe.root_module.addImport("lua_wrapper", lua_wrapper);
+    def_exe.root_module.addImport("zlua", zlua);
     var run_def_exe = b.addRunArtifact(def_exe);
     run_def_exe.addFileArg(b.path("definitions.lua"));
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = .lua_wrapper,
-    .fingerprint = 0xb40fd4eedb02233b, // changing this has security and trust implications
+    .name = .zlua,
+    .fingerprint = 0xcf671dd0b696484, // changing this has security and trust implications
     .version = "0.1.0",
     .paths = .{ "build.zig", "build.zig.zon", "src", "license", "include", "build" },
 

--- a/examples/define-exe.zig
+++ b/examples/define-exe.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const lua_wrapper = @import("lua_wrapper");
+const zlua = @import("zlua");
 
 const T = struct { foo: i32 };
 const MyEnum = enum { asdf, fdsa, qwer, rewq };
@@ -10,5 +10,5 @@ const Foo = struct { far: MyEnum, near: SubType };
 
 pub fn main() !void {
     const output_file_path = std.mem.sliceTo(std.os.argv[1], 0);
-    try lua_wrapper.define(std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
+    try zlua.define(std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
 }

--- a/examples/interpreter.zig
+++ b/examples/interpreter.zig
@@ -3,8 +3,8 @@
 
 const std = @import("std");
 
-// The lua_wrapper module is made available in build.zig
-const lua_wrapper = @import("lua_wrapper");
+// The zlua module is made available in build.zig
+const zlua = @import("zlua");
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -14,7 +14,7 @@ pub fn main() anyerror!void {
     // Initialize The Lua vm and get a reference to the main thread
     //
     // Passing a Zig allocator to the Lua state requires a stable pointer
-    var lua = try lua_wrapper.Lua.init(allocator);
+    var lua = try zlua.Lua.init(allocator);
     defer lua.deinit();
 
     // Open all Lua standard libraries

--- a/examples/luau-bytecode.zig
+++ b/examples/luau-bytecode.zig
@@ -8,8 +8,8 @@
 
 const std = @import("std");
 
-// The lua_wrapper module is made available in build.zig
-const lua_wrapper = @import("lua_wrapper");
+// The zlua module is made available in build.zig
+const zlua = @import("zlua");
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -19,7 +19,7 @@ pub fn main() anyerror!void {
     // Initialize The Lua vm and get a reference to the main thread
     //
     // Passing a Zig allocator to the Lua state requires a stable pointer
-    var lua = try lua_wrapper.Lua.init(allocator);
+    var lua = try zlua.Lua.init(allocator);
     defer lua.deinit();
 
     // Open all Lua standard libraries
@@ -27,7 +27,7 @@ pub fn main() anyerror!void {
 
     // Load bytecode
     const src = @embedFile("./test.luau");
-    const bc = try lua_wrapper.compile(allocator, src, lua_wrapper.CompileOptions{});
+    const bc = try zlua.compile(allocator, src, zlua.CompileOptions{});
     defer allocator.free(bc);
 
     try lua.loadBytecode("...", bc);

--- a/examples/zig-fn.zig
+++ b/examples/zig-fn.zig
@@ -1,11 +1,11 @@
 //! Registering a Zig function to be called from Lua
 
 const std = @import("std");
-const lua_wrapper = @import("lua_wrapper");
+const zlua = @import("zlua");
 
 // It can be convenient to store a short reference to the Lua struct when
 // it is used multiple times throughout a file.
-const Lua = lua_wrapper.Lua;
+const Lua = zlua.Lua;
 
 // A Zig function called by Lua must accept a single *Lua parameter and must return an i32 (an error union is allowed)
 // This is the Zig equivalent of the lua_CFunction typedef int (*lua_CFunction) (lua_State *L) in the C API
@@ -26,10 +26,10 @@ pub fn main() anyerror!void {
     defer lua.deinit();
 
     // Push the adder function to the Lua stack.
-    // Here we use lua_wrapper.wrap() to convert from a Zig function to the lua_CFunction required by Lua.
+    // Here we use zlua.wrap() to convert from a Zig function to the lua_CFunction required by Lua.
     // This could be done automatically by pushFunction(), but that would require the parameter to be comptime-known.
-    // The call to lua_wrapper.wrap() is slightly more verbose, but has the benefit of being more flexible.
-    lua.pushFunction(lua_wrapper.wrap(adder));
+    // The call to zlua.wrap() is slightly more verbose, but has the benefit of being more flexible.
+    lua.pushFunction(zlua.wrap(adder));
 
     // Push the arguments onto the stack
     lua.pushInteger(10);
@@ -47,7 +47,7 @@ pub fn main() anyerror!void {
     std.debug.print("the result: {}\n", .{lua.toInteger(-1) catch unreachable});
 
     // We can also register the function to a global and run from a Lua "program"
-    lua.pushFunction(lua_wrapper.wrap(adder));
+    lua.pushFunction(zlua.wrap(adder));
     lua.setGlobal("add");
 
     // We need to open the base library so the global print() is available

--- a/readme.md
+++ b/readme.md
@@ -46,15 +46,15 @@ Then in your `build.zig` file you can use the dependency.
 pub fn build(b: *std.Build) void {
     // ... snip ...
 
-    const lua_dep = b.dependency("lua_wrapper", .{
+    const lua_dep = b.dependency("zlua", .{
         .target = target,
         .optimize = optimize,
     });
 
     // ... snip ...
 
-    // add the lua_wrapper module and lua artifact
-    exe.root_module.addImport("lua_wrapper", lua_dep.module("lua_wrapper"));
+    // add the zlua module and lua artifact
+    exe.root_module.addImport("zlua", lua_dep.module("zlua"));
 
 }
 ```
@@ -70,7 +70,7 @@ There are currently three additional options that can be passed to `b.dependency
 For example, here is a `b.dependency()` call that and links against a shared Lua 5.2 library:
 
 ```zig
-const lua_wrapper = b.dependency("lua_wrapper", .{
+const zlua = b.dependency("zlua", .{
     .target = target,
     .optimize = optimize,
     .lang = .lua52,
@@ -78,13 +78,13 @@ const lua_wrapper = b.dependency("lua_wrapper", .{
 });
 ``````
 
-The `lua_wrapper` module will now be available in your code. Here is a simple example that pushes and inspects an integer on the Lua stack:
+The `zlua` module will now be available in your code. Here is a simple example that pushes and inspects an integer on the Lua stack:
 
 ```zig
 const std = @import("std");
-const lua_wrapper = @import("lua_wrapper");
+const zlua = @import("zlua");
 
-const Lua = lua_wrapper.Lua;
+const Lua = zlua.Lua;
 
 pub fn main() anyerror!void {
     // Create an allocator

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,6 +1,6 @@
 //! Similar to the Lua C API documentation, each function has an indicator to describe how interacts with the stack and which errors it may return.
 //!
-//! Instead of using the form `[-o, +p, x]`, Lua_wrapper uses the words **Pops**, **Pushes**, and **Errors** for clarity.
+//! Instead of using the form `[-o, +p, x]`, Zlua uses the words **Pops**, **Pushes**, and **Errors** for clarity.
 //!
 //! * **Pops**: how many elements the function pops from the stack.
 //! * **Pushes**: how many elements the function pushes onto the stack.
@@ -302,7 +302,7 @@ pub const DebugInfo = switch (lang) {
     .luau => DebugInfoLuau,
 };
 
-/// The superset of all errors returned from lua_wrapper
+/// The superset of all errors returned from zlua
 pub const Error = error{
     /// A generic failure (used when a function can only fail in one way)
     LuaError,
@@ -750,7 +750,7 @@ pub const Lua = opaque {
     /// * Finally you call `Lua.call()`
     /// * `args.args` is the number of arguments that you pushed onto the stack. When the function returns, all arguments and
     /// the function value are popped and the call results are pushed onto the stack.
-    /// * The number of results is adjusted to `args.results`, unless `args.results` is `lua_wrapper.mult_return`. In this case, all results from the function are pushed
+    /// * The number of results is adjusted to `args.results`, unless `args.results` is `zlua.mult_return`. In this case, all results from the function are pushed
     /// * Lua takes care that the returned values fit into the stack space, but it does not ensure any extra space in the stack. The function results
     /// are pushed onto the stack in direct order (the first result is pushed first), so that after the call the last result is
     /// on the top of the stack.
@@ -4903,7 +4903,7 @@ pub const Buffer = struct {
     }
 };
 
-// Helper functions to make the lua_wrapper API easier to use
+// Helper functions to make the zlua API easier to use
 
 const Tuple = std.meta.Tuple;
 


### PR DESCRIPTION
"lua_wrapper", while descriptive, feels significantly worse than "ziglua". since the Zig project feels strongly that "zig" in the name is redundant, "zlua" feels like a nice middle ground.

BREAKING CHANGE: the package and exported module are now named "zlua"; the latter change will require alteration of build.zig files.