### PR TITLE
Support both zig-0.14 and zig-0.15-dev in main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        zig: ["0.14.0", "0.15.0-dev.375+8f8f37fb0"]
+
     runs-on: ${{matrix.os}}
 
     steps:
@@ -20,7 +22,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v1
       with:
-        version: 0.15.0-dev.375+8f8f37fb0
+        version: ${{ matrix.zig }}
 
     - name: Run tests
       run: make test

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -613,8 +613,12 @@ pub const Lua = opaque {
         } else if (nsize == 0) {
             return null;
         } else {
+            const builtin = @import("builtin"); // FIXME: remove when zig-0.15 is released and 0.14 can be dropped
             // ptr is null, allocate a new block of memory
-            const new_ptr = allocator_ptr.alignedAlloc(u8, .fromByteUnits(alignment), nsize) catch return null;
+            const new_ptr = (if (builtin.zig_version.major == 0 and builtin.zig_version.minor < 15)
+                allocator_ptr.alignedAlloc(u8, alignment, nsize)
+            else
+                allocator_ptr.alignedAlloc(u8, .fromByteUnits(alignment), nsize)) catch return null;
             return new_ptr.ptr;
         }
     }


### PR DESCRIPTION
Conditionalize on zig version to make ziglua build with both zig-0.14 and later 0.15-dev versions.  This way those who like to keep using zig-0.14 can still pick up new updates to ziglua.

This also adds a CI configuration to add protection for both versions.

for #153