### PR TITLE
Add build option to provide an additional header file to the Lua compilation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,9 +19,14 @@ pub fn build(b: *Build) void {
     const library_name = b.option([]const u8, "library_name", "Library name for lua linking, default is `lua`") orelse "lua";
     const shared = b.option(bool, "shared", "Build shared library instead of static") orelse false;
     const luau_use_4_vector = b.option(bool, "luau_use_4_vector", "Build Luau to use 4-vectors instead of the default 3-vector.") orelse false;
+    const lua_user_h = b.option(Build.LazyPath, "lua_user_h", "Lazy path to user supplied c header file") orelse null;
 
     if (lang == .luau and shared) {
         std.debug.panic("Luau does not support compiling or loading shared modules", .{});
+    }
+
+    if (lua_user_h != null and (lang == .luajit or lang == .luau)) {
+        std.debug.panic("Only basic lua supports a user provided header file", .{});
     }
 
     // Zig module
@@ -44,7 +49,7 @@ pub fn build(b: *Build) void {
         const lib = switch (lang) {
             .luajit => luajit_setup.configure(b, target, optimize, upstream, shared),
             .luau => luau_setup.configure(b, target, optimize, upstream, luau_use_4_vector),
-            else => lua_setup.configure(b, target, optimize, upstream, lang, shared, library_name),
+            else => lua_setup.configure(b, target, optimize, upstream, lang, shared, library_name, lua_user_h),
         };
 
         // Expose the Lua artifact, and get an install step that header translation can refer to

--- a/build.zig
+++ b/build.zig
@@ -108,6 +108,7 @@ pub fn build(b: *Build) void {
     var common_examples = [_]struct { []const u8, []const u8 }{
         .{ "interpreter", "examples/interpreter.zig" },
         .{ "zig-function", "examples/zig-fn.zig" },
+        .{ "multithreaded", "examples/multithreaded.zig" },
     };
     const luau_examples = [_]struct { []const u8, []const u8 }{
         .{ "luau-bytecode", "examples/luau-bytecode.zig" },

--- a/examples/multithreaded.zig
+++ b/examples/multithreaded.zig
@@ -1,0 +1,81 @@
+//! Multi threaded lua program
+//! The additional header must be passed to the build using `-Dlua_user_h=examples/user.h`
+//! Checkout http://lua-users.org/wiki/ThreadsTutorial for more info
+
+const std = @import("std");
+const zlua = @import("zlua");
+
+var mutex = std.Thread.Mutex{};
+
+export fn lua_zlock(L: *zlua.LuaState) callconv(.C) void {
+    _ = L;
+    mutex.lock();
+}
+
+export fn lua_zunlock(L: *zlua.LuaState) callconv(.C) void {
+    _ = L;
+    mutex.unlock();
+}
+
+fn add_to_x(lua: *zlua.Lua, num: usize) void {
+    for (0..num) |_| {
+        // omit error handling for brevity
+        lua.loadString("x = x + 1\n") catch return;
+        lua.protectedCall(.{}) catch return;
+    }
+
+    const size = 256;
+    var buf = [_:0]u8{0} ** size;
+    _ = std.fmt.bufPrint(&buf, "print(\"{}: \", x)", .{std.Thread.getCurrentId()}) catch return;
+
+    // The printing from different threads does not always work nicely
+    // There seems to be a separate sterr lock on each argument to print
+    lua.loadString(&buf) catch return;
+    lua.protectedCall(.{}) catch return;
+}
+
+pub fn main() anyerror!void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    defer _ = gpa.deinit();
+
+    // Initialize The Lua vm and get a reference to the main thread
+    var lua = try zlua.Lua.init(allocator);
+    defer lua.deinit();
+
+    lua.openLibs();
+
+    // create a global variable accessible by all threads
+    // omit error handling for brevity
+    try lua.loadString("_G.x = 0\n");
+    try lua.protectedCall(.{});
+
+    const num = 1_000;
+    const n_jobs = 5;
+    var subs: [n_jobs]*zlua.Lua = undefined;
+
+    // create a thread pool to run all the functions
+    var pool: std.Thread.Pool = undefined;
+    try pool.init(.{ .allocator = allocator, .n_jobs = n_jobs });
+    defer pool.deinit();
+
+    var wg: std.Thread.WaitGroup = .{};
+
+    for (0..n_jobs) |i| {
+        subs[i] = lua.newThread();
+        pool.spawnWg(&wg, add_to_x, .{ subs[i], num });
+    }
+
+    // also do the thing from the main thread
+    add_to_x(lua, num);
+
+    wg.wait();
+
+    for (subs) |sub| {
+        try lua.closeThread(sub);
+    }
+
+    // print the final value
+    try lua.loadString("print(x)\n");
+    try lua.protectedCall(.{});
+}

--- a/examples/user.h
+++ b/examples/user.h
@@ -1,0 +1,6 @@
+#define lua_lock(L) lua_zlock(L)
+#define lua_unlock(L) lua_zunlock(L)
+
+void lua_zlock(lua_State* L);
+void lua_zunlock(lua_State* L);
+

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ There are currently three additional options that can be passed to `b.dependency
 * `.lang`: Set the Lua language to build and embed. Defaults to `.lua54`. Possible values are `.lua51`, `.lua52`, `.lua53`, `.lua54`, and `luau`.
 * `.shared`: Defaults to `false` for embedding in a Zig program. Set to `true` to dynamically link the Lua source code (useful for creating shared modules).
 * `luau_use_4_vector`: defaults to false. Set to true to use 4-vectors instead of the default 3-vector in Luau.
+* `lua_user_h`: defaults to null. Provide a path to an additional header file for the Lua compilation. Must be set to to `examples/user.h` in order to run the multithreaded example.
 
 For example, here is a `b.dependency()` call that and links against a shared Lua 5.2 library:
 


### PR DESCRIPTION
resolves natecraddock/ziglua#143

Supplying the option as a `std.Builld.LazyPath` and expanding relative paths might not be the most elegant option, but it works for both the examples and when used as a module.

Alternatively to this solution, ziglua could provide its own header file and expose some functions a user would have to implement (like lua_zlock). But this would require additional flags or some structure containing all the options. Delegating the header to the user seems simpler and more flexible to me. (I am not sure how much this feature is going to be used anyways :D)