### PR TITLE
fix: update to latest Zig post Writergate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v5
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.15.0-dev.441+c1649d586
+          version: 0.15.0-dev.1034+bd97b6618
       - run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig: ["0.14.0", "0.15.0-dev.441+c1649d586"]
+        zig: ["0.14.0", "0.15.0-dev.1034+bd97b6618"]
 
     runs-on: ${{matrix.os}}
 
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig: ["0.14.0", "0.15.0-dev.441+c1649d586"]
+        zig: ["0.14.0", "0.15.0-dev.1034+bd97b6618"]
 
     runs-on: ${{matrix.os}}
 

--- a/build.zig
+++ b/build.zig
@@ -99,9 +99,11 @@ pub fn build(b: *Build) void {
 
     // Tests
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/tests.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tests.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     tests.root_module.addImport("zlua", zlua);
 
@@ -123,9 +125,11 @@ pub fn build(b: *Build) void {
     for (examples) |example| {
         const exe = b.addExecutable(.{
             .name = example[0],
-            .root_source_file = b.path(example[1]),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(example[1]),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         exe.root_module.addImport("zlua", zlua);
 
@@ -143,9 +147,11 @@ pub fn build(b: *Build) void {
 
     const docs = b.addObject(.{
         .name = "ziglua",
-        .root_source_file = b.path("src/lib.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const install_docs = b.addInstallDirectory(.{
@@ -159,9 +165,11 @@ pub fn build(b: *Build) void {
 
     // definitions example
     const def_exe = b.addExecutable(.{
-        .root_source_file = b.path("examples/define-exe.zig"),
         .name = "define-zig-types",
-        .target = target,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/define-exe.zig"),
+            .target = target,
+        }),
     });
     def_exe.root_module.addImport("zlua", zlua);
     var run_def_exe = b.addRunArtifact(def_exe);

--- a/build/luau.zig
+++ b/build/luau.zig
@@ -4,11 +4,15 @@ const Build = std.Build;
 const Step = std.Build.Step;
 
 pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, upstream: *Build.Dependency, luau_use_4_vector: bool) *Step.Compile {
-    const lib = b.addStaticLibrary(.{
-        .name = "luau",
+    const lib = b.createModule(.{
         .target = target,
         .optimize = optimize,
+    });
+    const library = b.addLibrary(.{
+        .name = "luau",
+        .linkage = .static,
         .version = std.SemanticVersion{ .major = 0, .minor = 653, .patch = 0 },
+        .root_module = lib,
     });
 
     lib.addIncludePath(upstream.path("Common/include"));
@@ -33,14 +37,14 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
         .flags = &flags,
     });
     lib.addCSourceFile(.{ .file = b.path("src/luau.cpp"), .flags = &flags });
-    lib.linkLibCpp();
+    library.linkLibCpp();
 
-    lib.installHeader(upstream.path("VM/include/lua.h"), "lua.h");
-    lib.installHeader(upstream.path("VM/include/lualib.h"), "lualib.h");
-    lib.installHeader(upstream.path("VM/include/luaconf.h"), "luaconf.h");
-    lib.installHeader(upstream.path("Compiler/include/luacode.h"), "luacode.h");
+    library.installHeader(upstream.path("VM/include/lua.h"), "lua.h");
+    library.installHeader(upstream.path("VM/include/lualib.h"), "lualib.h");
+    library.installHeader(upstream.path("VM/include/luaconf.h"), "luaconf.h");
+    library.installHeader(upstream.path("Compiler/include/luacode.h"), "luacode.h");
 
-    return lib;
+    return library;
 }
 
 const luau_source_files = [_][]const u8{

--- a/build/utils.zig
+++ b/build/utils.zig
@@ -17,8 +17,10 @@ pub fn applyPatchToFile(
 ) PatchFile {
     const patch = b.addExecutable(.{
         .name = "patch",
-        .root_source_file = b.path("build/patch.zig"),
-        .target = target,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("build/patch.zig"),
+            .target = target,
+        }),
     });
 
     const patch_run = b.addRunArtifact(patch);

--- a/examples/interpreter.zig
+++ b/examples/interpreter.zig
@@ -20,15 +20,19 @@ pub fn main() anyerror!void {
     // Open all Lua standard libraries
     lua.openLibs();
 
-    var stdin = std.io.getStdIn().reader();
-    var stdout = std.io.getStdOut().writer();
+    var in_buf: [4096]u8 = undefined;
+    var out_buf: [4096]u8 = undefined;
+    var stdin_file = std.fs.File.stdin().reader(&in_buf);
+    const stdin = &stdin_file.interface;
+    var stdout_file = std.fs.File.stdout().writer(&out_buf);
+    const stdout = &stdout_file.interface;
 
     var buffer: [256]u8 = undefined;
     while (true) {
-        _ = try stdout.write("> ");
+        _ = try stdout.writeAll("> ");
 
         // Read a line of input
-        const len = try stdin.read(&buffer);
+        const len = try stdin.readSliceShort(&buffer);
         if (len == 0) break; // EOF
         if (len >= buffer.len - 1) {
             try stdout.print("error: line too long!\n", .{});

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -76,7 +76,7 @@ pub const ArithOperator = switch (lang) {
 
 /// Type for C functions
 /// See https://www.lua.org/manual/5.4/manual.html#lua_CFunction for the protocol
-pub const CFn = *const fn (state: ?*LuaState) callconv(.C) c_int;
+pub const CFn = *const fn (state: ?*LuaState) callconv(.c) c_int;
 
 /// Operations supported by `Lua.compare()`
 pub const CompareOperator = enum(u2) {
@@ -86,13 +86,13 @@ pub const CompareOperator = enum(u2) {
 };
 
 /// Type for C userdata destructors
-pub const CUserdataDtorFn = *const fn (userdata: *anyopaque) callconv(.C) void;
+pub const CUserdataDtorFn = *const fn (userdata: *anyopaque) callconv(.c) void;
 
 /// Type for C interrupt callback
-pub const CInterruptCallbackFn = *const fn (state: ?*LuaState, gc: c_int) callconv(.C) void;
+pub const CInterruptCallbackFn = *const fn (state: ?*LuaState, gc: c_int) callconv(.c) void;
 
 /// Type for C useratom callback
-pub const CUserAtomCallbackFn = *const fn (str: [*c]const u8, len: usize) callconv(.C) i16;
+pub const CUserAtomCallbackFn = *const fn (str: [*c]const u8, len: usize) callconv(.c) i16;
 
 /// The internal Lua debug structure
 const Debug = c.lua_Debug;
@@ -357,7 +357,7 @@ pub const FnReg = struct {
 pub const globals_index = c.LUA_GLOBALSINDEX;
 
 /// Type for debugging hook functions
-pub const CHookFn = *const fn (state: ?*LuaState, ar: ?*Debug) callconv(.C) void;
+pub const CHookFn = *const fn (state: ?*LuaState, ar: ?*Debug) callconv(.c) void;
 
 /// Specifies on which events the hook will be called
 pub const HookMask = packed struct {
@@ -401,7 +401,7 @@ pub const Integer = c.lua_Integer;
 pub const Context = isize;
 
 /// Type for continuation functions
-pub const CContFn = *const fn (state: ?*LuaState, status: c_int, ctx: Context) callconv(.C) c_int;
+pub const CContFn = *const fn (state: ?*LuaState, status: c_int, ctx: Context) callconv(.c) c_int;
 
 pub const Libs51 = packed struct {
     base: bool = false,
@@ -499,7 +499,7 @@ pub const mult_return = c.LUA_MULTRET;
 pub const Number = c.lua_Number;
 
 /// The type of the reader function used by `Lua.load()`
-pub const CReaderFn = *const fn (state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.C) [*c]const u8;
+pub const CReaderFn = *const fn (state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.c) [*c]const u8;
 
 /// The possible status of a call to `Lua.resumeThread`
 pub const ResumeStatus = enum(u1) {
@@ -563,12 +563,12 @@ pub const Unsigned = c.lua_Unsigned;
 
 /// The type of warning functions used by Lua to emit warnings
 pub const CWarnFn = switch (lang) {
-    .lua54 => *const fn (data: ?*anyopaque, msg: [*c]const u8, to_cont: c_int) callconv(.C) void,
+    .lua54 => *const fn (data: ?*anyopaque, msg: [*c]const u8, to_cont: c_int) callconv(.c) void,
     else => @compileError("CWarnFn not defined"),
 };
 
 /// The type of the writer function used by `Lua.dump()`
-pub const CWriterFn = *const fn (state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int;
+pub const CWriterFn = *const fn (state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.c) c_int;
 
 /// For bundling a parsed value with an arena allocator
 /// Copied from std.json.Parsed
@@ -592,7 +592,7 @@ pub const Lua = opaque {
 
     /// Allows Lua to allocate memory using a Zig allocator passed in via data.
     /// See https://www.lua.org/manual/5.4/manual.html#lua_Alloc for more details
-    fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.C) ?*align(alignment) anyopaque {
+    fn alloc(data: ?*anyopaque, ptr: ?*anyopaque, osize: usize, nsize: usize) callconv(.c) ?*align(alignment) anyopaque {
         // just like malloc() returns a pointer "which is suitably aligned for any built-in type",
         // the memory allocated by this function should also be aligned for any type that Lua may
         // desire to allocate. use the largest alignment for the target
@@ -5163,7 +5163,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CFn
         Tuple(&.{*Lua}) => {
             return struct {
-                fn inner(state: ?*LuaState) callconv(.C) c_int {
+                fn inner(state: ?*LuaState) callconv(.c) c_int {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     if (has_error_union) {
@@ -5179,7 +5179,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CHookFn
         Tuple(&.{ *Lua, Event, *DebugInfo }) => {
             return struct {
-                fn inner(state: ?*LuaState, ar: ?*Debug) callconv(.C) void {
+                fn inner(state: ?*LuaState, ar: ?*Debug) callconv(.c) void {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     var debug_info: DebugInfo = .{
@@ -5202,7 +5202,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CContFn
         Tuple(&.{ *Lua, Status, Context }) => {
             return struct {
-                fn inner(state: ?*LuaState, status: c_int, ctx: Context) callconv(.C) c_int {
+                fn inner(state: ?*LuaState, status: c_int, ctx: Context) callconv(.c) c_int {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     if (has_error_union) {
@@ -5218,7 +5218,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CReaderFn
         Tuple(&.{ *Lua, *anyopaque }) => {
             return struct {
-                fn inner(state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.C) [*c]const u8 {
+                fn inner(state: ?*LuaState, data: ?*anyopaque, size: [*c]usize) callconv(.c) [*c]const u8 {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     if (has_error_union) {
@@ -5247,7 +5247,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CUserdataDtorFn
         Tuple(&.{*anyopaque}) => {
             return struct {
-                fn inner(userdata: *anyopaque) callconv(.C) void {
+                fn inner(userdata: *anyopaque) callconv(.c) void {
                     return @call(.always_inline, function, .{userdata});
                 }
             }.inner;
@@ -5255,7 +5255,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CInterruptCallbackFn
         Tuple(&.{ *Lua, i32 }) => {
             return struct {
-                fn inner(state: ?*LuaState, gc: c_int) callconv(.C) void {
+                fn inner(state: ?*LuaState, gc: c_int) callconv(.c) void {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     if (has_error_union) {
@@ -5271,7 +5271,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CUserAtomCallbackFn
         Tuple(&.{[]const u8}) => {
             return struct {
-                fn inner(str: [*c]const u8, len: usize) callconv(.C) i16 {
+                fn inner(str: [*c]const u8, len: usize) callconv(.c) i16 {
                     if (str) |s| {
                         const buf = s[0..len];
                         return @call(.always_inline, function, .{buf});
@@ -5283,7 +5283,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CWarnFn
         Tuple(&.{ ?*anyopaque, []const u8, bool }) => {
             return struct {
-                fn inner(data: ?*anyopaque, msg: [*c]const u8, to_cont: c_int) callconv(.C) void {
+                fn inner(data: ?*anyopaque, msg: [*c]const u8, to_cont: c_int) callconv(.c) void {
                     // warning messages emitted from Lua should be null-terminated for display
                     const message = std.mem.span(@as([*:0]const u8, @ptrCast(msg)));
                     @call(.always_inline, function, .{ data, message, to_cont != 0 });
@@ -5293,7 +5293,7 @@ pub fn wrap(comptime function: anytype) TypeOfWrap(function) {
         // CWriterFn
         Tuple(&.{ *Lua, []const u8, *anyopaque }) => {
             return struct {
-                fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.C) c_int {
+                fn inner(state: ?*LuaState, buf: ?*const anyopaque, size: usize, data: ?*anyopaque) callconv(.c) c_int {
                     // this is called by Lua, state should never be null
                     var lua: *Lua = @ptrCast(state.?);
                     const buffer = @as([*]const u8, @ptrCast(buf))[0..size];
@@ -5382,7 +5382,7 @@ pub fn exportFn(comptime name: []const u8, comptime func: anytype) CFn {
     if (lang == .luau) @compileError("Luau does not support compiling or loading shared modules");
 
     return struct {
-        fn luaopen(state: ?*LuaState) callconv(.C) c_int {
+        fn luaopen(state: ?*LuaState) callconv(.c) c_int {
             const declaration = comptime wrap(func);
 
             return @call(.always_inline, declaration, .{state});


### PR DESCRIPTION
mostly a whole slew of small changes—most in fact, from a build system change that merged `addStaticLibrary` and `addSharedLibrary` and evicted options like `target` from `Compile` steps.