### PR TITLE
Support zig 0.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
+  #------ zig-dev builds ------
+  test_zig_nightly:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
@@ -24,8 +25,29 @@ jobs:
         version: master
 
     - name: Run tests
-      run: make test
+      run: make test_zig_nightly
 
+  #------ zig-0.14 ------
+  test_zig_014:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - name: Clone Ziglua
+      uses: actions/checkout@v3
+
+    - name: Setup Zig
+      uses: mlugg/setup-zig@v2
+      with:
+        version: "0.14.1"
+
+    - name: Run tests
+      run: make test_zig_014
+
+  #------ cross compilation ------
   test_cross:
     strategy:
       matrix:

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 .PHONY: test docs
 
-test:
+test_zig_nightly:
 	zig build test --summary failures -Dlang=lua51
 	zig build test --summary failures -Dlang=lua52
 	zig build test --summary failures -Dlang=lua53
@@ -12,6 +12,17 @@ test:
 	zig build -Dlang=luau install-example-luau-bytecode
 
 	zig build -Dlang=luajit
+
+# A subset of tests that are expected to work also on zig-0.14
+test_zig_014:
+	zig build test --summary failures -Dlang=lua52
+	zig build test --summary failures -Dlang=lua53
+	zig build test --summary failures -Dlang=lua54
+	zig build test --summary failures -Dlang=luau
+
+	zig build install-example-interpreter
+	zig build install-example-zig-function
+	zig build -Dlang=luau install-example-luau-bytecode
 
 test_cross:
 	zig build -Dlang=lua51 -Dtarget=aarch64-linux


### PR DESCRIPTION
- Fix the interpreter sample to work on both zig-0.14 and zig-nightly.  Also fixes bug #167 
- Update CI scripts to resume testing zig-0.14 but with a smaller test plan.  See git commit messages for more details.