### PR TITLE
feat: toNumeric and checkNumeric

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2601,7 +2601,7 @@ pub const Lua = opaque {
     /// * Pushes: `0`
     /// * Errors: `error.IntegerCastFailed` if `T` is an integer type and the value at index doesn't fit
     pub fn toNumeric(lua: *Lua, comptime T: type, index: i32) !T {
-        if (@typeInfo(T) == .int) return std.math.cast(try lua.toInteger(index)) orelse error.IntegerCastFailed;
+        if (@typeInfo(T) == .int) return std.math.cast(T, try lua.toInteger(index)) orelse error.IntegerCastFailed;
         return @floatCast(try lua.toNumber(index));
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2035,18 +2035,6 @@ pub const Lua = opaque {
         c.lua_pushnil(@ptrCast(lua));
     }
 
-    /// Pushes a numeric type with value `n` onto the stack
-    /// The conversion from the type of `n` to `Integer` or `Number`
-    /// is performed with `@_Cast` so will assert in modes with runtime safety enabled.
-    ///
-    /// * Pops:   `0`
-    /// * Pushes: `1`
-    /// * Errors: `never`
-    pub fn pushNumeric(lua: *Lua, n: anytype) void {
-        if (@typeInfo(@TypeOf(n)) == .int) return lua.pushInteger(@intCast(n));
-        lua.pushNumber(@floatCast(n));
-    }
-
     /// Pushes a float with value `n` onto the stack
     ///
     /// * Pops:   `0`

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2599,9 +2599,11 @@ pub const Lua = opaque {
     ///
     /// * Pops:   `0`
     /// * Pushes: `0`
-    /// * Errors: `error.IntegerCastFailed` if `T` is an integer type and the value at index doesn't fit
+    /// * Errors: `error.Overflow` if `T` is an integer type and the value at index doesn't fit
     pub fn toNumeric(lua: *Lua, comptime T: type, index: i32) !T {
-        if (@typeInfo(T) == .int) return std.math.cast(T, try lua.toInteger(index)) orelse error.IntegerCastFailed;
+        if (@typeInfo(T) == .int) {
+            return std.math.cast(T, try lua.toInteger(index)) orelse error.Overflow;
+        }
         return @floatCast(try lua.toNumber(index));
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2596,14 +2596,12 @@ pub const Lua = opaque {
 
     /// Converts the Lua value at the given `index` to a numeric type;
     /// if T is an integer type, the Lua value is converted to an integer.
-    /// The conversion from `Integer` or `Number` to T is performed with `@_Cast`,
-    /// which will assert in builds with runtime safety enabled
     ///
     /// * Pops:   `0`
     /// * Pushes: `0`
-    /// * Errors: `never`
+    /// * Errors: `error.IntegerCastFailed` if `T` is an integer type and the value at index doesn't fit
     pub fn toNumeric(lua: *Lua, comptime T: type, index: i32) !T {
-        if (@typeInfo(T) == .int) return @intCast(try lua.toInteger(index));
+        if (@typeInfo(T) == .int) return std.math.cast(try lua.toInteger(index)) orelse error.IntegerCastFailed;
         return @floatCast(try lua.toNumber(index));
     }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3061,7 +3061,7 @@ test "pushNumeric and toNumeric" {
     defer lua.deinit();
 
     const num: u32 = 100;
-    lua.pushNumeric(num);
+    lua.pushInteger(num);
     const pull = lua.toNumeric(u32, lua.getTop());
     try std.testing.expectEqual(num, pull);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3055,3 +3055,13 @@ test "error union for CFn" {
         try expectEqualStrings("MissingInteger", try lua.toString(-1));
     };
 }
+
+test "pushNumeric and toNumeric" {
+    const lua: *Lua = try .init(testing.allocator);
+    defer lua.deinit();
+
+    const num: u32 = 100;
+    lua.pushNumeric(num);
+    const pull = lua.toNumeric(u32, lua.getTop());
+    try std.testing.expectEqual(num, pull);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3087,7 +3087,7 @@ test "checkNumeric and toNumeric" {
     })) |_| {
         return error.ExpectedError;
     } else |_| {
-        const string = lua.toStringEx(lua.getTop());
+        const string = try lua.toString(lua.getTop());
         errdefer std.log.err("expected error message to contain: {s}", .{error_msg});
         errdefer std.log.err("error message: {s}", .{string});
         _ = std.mem.indexOf(u8, string, error_msg) orelse return error.BadErrorMessage;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3088,6 +3088,8 @@ test "checkNumeric and toNumeric" {
         return error.ExpectedError;
     } else |_| {
         const string = lua.toStringEx(lua.getTop());
-        try std.testing.expectEqualStrings(error_msg, string);
+        errdefer std.log.err("expected error message to contain: {s}", .{error_msg});
+        errdefer std.log.err("error message: {s}", .{string});
+        _ = std.mem.indexOf(u8, string, error_msg) orelse return error.BadErrorMessage;
     }
 }


### PR DESCRIPTION
These functions rely (lightly) on Zig's comptime to minimize some of the annoying overhead of writing `@intCast` and `@floatCast` all the time by making those builtins part of the function definition. However, since those builtins assert in builds with runtime safety enabled, these functions will crash the program if called with bad Lua input. More discussion is warranted about the tradeoffs of going this route before merging.

Resolves #172.