### PR TITLE
fix(build): make patch utility work with zig 0.15.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: "0.15.1"
+        version: "0.15.2"
 
     - name: Run tests
       run: make test_zig_stable

--- a/build/patch.zig
+++ b/build/patch.zig
@@ -55,11 +55,11 @@ pub fn main() !void {
                 const chunk = chunk_details.lines[line_number - chunk_details.src];
                 switch (chunk.action) {
                     .remove => {
-                        const line = try reader.interface.takeDelimiterExclusive('\n');
+                        const line = (try reader.interface.takeDelimiter('\n')).?;
                         if (!std.mem.eql(u8, chunk.buf, line)) @panic("Failed to apply patch");
                     },
                     .keep => {
-                        const line = try reader.interface.takeDelimiterExclusive('\n');
+                        const line = (try reader.interface.takeDelimiter('\n')).?;
                         if (!std.mem.eql(u8, chunk.buf, line)) @panic("Failed to apply patch");
                         try writer.interface.writeAll(line);
                         try writer.interface.writeByte('\n');


### PR DESCRIPTION
takeDelimiterExclusive doesn't advance the seek position after the newline anymore, leading to failures. This is noticed when building with -Dlang=lua51