### PR TITLE
fix(define): update "zig define" to zig 0.16.0-dev.2109+ac9179933

### DIFF
--- a/examples/define-exe.zig
+++ b/examples/define-exe.zig
@@ -8,7 +8,7 @@ const Bippity = struct { A: ?i32, B: *bool, C: []const u8, D: ?*SubType };
 const TestType = struct { a: i32, b: f32, c: bool, d: SubType, e: [10]Bippity };
 const Foo = struct { far: MyEnum, near: SubType };
 
-pub fn main() !void {
-    const output_file_path = std.mem.sliceTo(std.os.argv[1], 0);
-    try zlua.define(std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
+pub fn main(init: std.process.Init) !void {
+    const output_file_path = std.mem.sliceTo(init.minimal.args.vector[1], 0);
+    try zlua.define(init.io, std.heap.c_allocator, output_file_path, &.{ T, TestType, Foo });
 }


### PR DESCRIPTION
See https://codeberg.org/ziglang/zig/pulls/30644 and friends

Note: I don't really care about this executable per se, but I was looking for a simple way to repro an upstream linker failure and `zig build define`  would be a nice simple way to just build, link and run a liblua+zig executable.
