### PR TITLE
fix(build): zig macos linker is not happy with luajit debug info

### DIFF
--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -123,6 +123,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     const buildvm_os_c_flags: []const []const u8 = if (target.result.os.tag == .windows)
         &.{"-DLUAJIT_OS=1"}
     else if (target.result.os.tag.isDarwin())
+        // FIXME: this can be removed once https://codeberg.org/ziglang/zig/issues/30669 is successfully resolved
         &.{"-DLJ_NO_UNWIND=1"}
     else
         &.{};


### PR DESCRIPTION
On master attempting to build -Dlang=luajit on macos (at least for arm64) hits an assert in Zig's MachO linker:

     thread 73187 panic: unexpected pointer encoding
       /home/bfredl/dev/zig/src/link/MachO/eh_frame.zig:33:21: 0x772f808 in parse (main.zig)
                           @panic("unexpected pointer encoding"); // TODO error
                           ^
       /home/bfredl/dev/zig/src/link/MachO/Object.zig:1125:22: 0x7732c1d in initEhFrameRecords (main.zig)
               try cie.parse(macho_file);
                            ^
       /home/bfredl/dev/zig/src/link/MachO/Object.zig:255:36: 0x7743887 in parse (main.zig)
               try self.initEhFrameRecords(gpa, index, handle, macho_file);
                                          ^
       /home/bfredl/dev/zig/src/link/MachO/file.zig:336:35: 0x7745bd3 in parse (main.zig)
                   .object => |x| x.parse(macho_file),
                                         ^
with some debugging this turns out to be the __eh_frame section which is generated in lj_vm.S. This debug info can be disabled at compile time using LJ_NO_UNWIND.

Ideally this should be handled better upstream by omitting debug frames it does not understand instead of crashing the compiler, but for now this allows luajit to be used on macos at all.