### PR TITLE
bump luajit version to LuaJIT 2.1.1771261233 (1c3b5a4d7)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -40,8 +40,8 @@
         },
 
         .luajit = .{
-            .url = "https://github.com/LuaJIT/LuaJIT/archive/c525bcb9024510cad9e170e12b6209aedb330f83.tar.gz",
-            .hash = "N-V-__8AACcgQgCuLYTPzCp6pnBmFJHyG77RAtM13hjOfTaG",
+            .url = "https://github.com/LuaJIT/LuaJIT/archive/1c3b5a4d722598ecbb9219480142eda682e87bb1.tar.gz",
+            .hash = "N-V-__8AADvoQgDNXzLQ8axn5XarZnk9amsbNxFk1GRxj5mH",
             .lazy = true,
         },
 


### PR DESCRIPTION
The luajit version is a bit old, we in neovim want to use a quite recent one. This is the latest of the v2.1 branch (which is the closest thing to "versions" which luajit does right now).

There will be another PR for the v0.15.2 branch.