### PR TITLE
fix: pass missing gpa argument to addClass in define()

### DIFF
--- a/src/define.zig
+++ b/src/define.zig
@@ -33,7 +33,7 @@ pub fn define(
     defer state.deinit(gpa);
 
     inline for (to_define) |T| {
-        _ = try addClass(&state, T);
+        _ = try addClass(&state, gpa, T);
     }
 
     var file = try std.fs.createFileAbsolute(absolute_output_path, .{});


### PR DESCRIPTION
## Summary

- `define()` calls `addClass(&state, T)` but `addClass` requires 3 args: `(state, gpa, T)`. Added the missing `gpa` argument.

Fixes #197