### PR TITLE
Fix changes for zig version v0.16.0-dev.3153+d6f43caad

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -112,7 +112,7 @@ pub fn build(b: *Build) void {
         c_headers.step.dependOn(&install_lib.step);
 
         const ziglua_c = c_headers.createModule();
-        b.modules.put("ziglua-c", ziglua_c) catch @panic("OOM");
+        b.modules.put(b.graph.arena, "ziglua-c", ziglua_c) catch @panic("OOM");
 
         zlua.addImport("c", ziglua_c);
     }

--- a/examples/interpreter.zig
+++ b/examples/interpreter.zig
@@ -29,7 +29,7 @@ fn flushedStdoutPrint(io: std.Io, comptime fmt: []const u8, args: anytype) !void
 }
 
 pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
 

--- a/examples/luau-bytecode.zig
+++ b/examples/luau-bytecode.zig
@@ -11,15 +11,13 @@ const std = @import("std");
 // The zlua module is made available in build.zig
 const zlua = @import("zlua");
 
-pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) anyerror!void {
+    const gpa = init.gpa;
 
     // Initialize The Lua vm and get a reference to the main thread
     //
     // Passing a Zig allocator to the Lua state requires a stable pointer
-    var lua = try zlua.Lua.init(allocator);
+    var lua = try zlua.Lua.init(gpa);
     defer lua.deinit();
 
     // Open all Lua standard libraries
@@ -27,8 +25,8 @@ pub fn main() anyerror!void {
 
     // Load bytecode
     const src = @embedFile("./test.luau");
-    const bc = try zlua.compile(allocator, src, zlua.CompileOptions{});
-    defer allocator.free(bc);
+    const bc = try zlua.compile(gpa, src, zlua.CompileOptions{});
+    defer gpa.free(bc);
 
     try lua.loadBytecode("...", bc);
     try lua.protectedCall(.{});

--- a/examples/multithreaded.zig
+++ b/examples/multithreaded.zig
@@ -34,13 +34,11 @@ fn add_to_x(lua: *zlua.Lua, num: usize) void {
     lua.protectedCall(.{}) catch return;
 }
 
-pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) anyerror!void {
+    const gpa = init.gpa;
 
     // Initialize The Lua vm and get a reference to the main thread
-    var lua = try zlua.Lua.init(allocator);
+    var lua = try zlua.Lua.init(gpa);
     defer lua.deinit();
 
     lua.openLibs();
@@ -56,7 +54,7 @@ pub fn main() anyerror!void {
 
     // create a thread pool to run all the functions
     var pool: std.Thread.Pool = undefined;
-    try pool.init(.{ .allocator = allocator, .n_jobs = n_jobs });
+    try pool.init(.{ .allocator = gpa, .n_jobs = n_jobs });
     defer pool.deinit();
 
     var wg: std.Thread.WaitGroup = .{};

--- a/examples/zig-fn.zig
+++ b/examples/zig-fn.zig
@@ -16,13 +16,11 @@ fn adder(lua: *Lua) i32 {
     return 1;
 }
 
-pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) anyerror!void {
+    const gpa = init.gpa;
 
     // Initialize The Lua vm and get a reference to the main thread
-    var lua = try Lua.init(allocator);
+    var lua = try Lua.init(gpa);
     defer lua.deinit();
 
     // Push the adder function to the Lua stack.

--- a/readme.md
+++ b/readme.md
@@ -87,14 +87,12 @@ const zlua = @import("zlua");
 
 const Lua = zlua.Lua;
 
-pub fn main() anyerror!void {
-    // Create an allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) anyerror!void {
+    // Get an allocator from juicy main
+    const gpa = init.gpa;
 
     // Initialize the Lua vm
-    var lua = try Lua.init(allocator);
+    var lua = try Lua.init(gpa);
     defer lua.deinit();
 
     // Add an integer to the Lua stack and retrieve it


### PR DESCRIPTION
On `build.zig`, `b.modules.put` now requires an allocator. For the allocator, I use `b.graph.arena` because [`std.Build.addModule`](https://ziglang.org/documentation/master/std/#std.Build.addModule) uses that one.

Here, zig version v0.16.0-dev.3153+d6f43caad is used.