### PR TITLE
fix(build): use cross-platform init.args.iterateAllocator()

### DIFF
--- a/build/patch.zig
+++ b/build/patch.zig
@@ -10,7 +10,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer threaded.deinit();
     const io = threaded.io();
 
-    var iter = init.args.iterate();
+    var iter = try init.args.iterateAllocator(allocator);
 
     // Skip executable name
     _ = iter.next();


### PR DESCRIPTION
When running on windows an allocator is required:

           +- run exe minilua (buildvm_arch.h)
              +- run cmd
                 +- run exe patch (dynasm-patched.lua)
                    +- compile exe patch Debug native 1 errors
    ...\zig-x86_64-windows-0.16.0\lib\std\process\Args.zig:39:36: error: In Windows, use initAllocator instead.
    if (native_os == .windows) @compileError("In Windows, use initAllocator instead.");

As this one-shot script uses an arena, there is no deinit() call