### PR TITLE
toStruct: set a field to null if the field is nullable and isn't getting set

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -4990,6 +4990,8 @@ pub const Lua = opaque {
                     @field(result, field.name) = default;
                 } else if (field_type_info != .optional) {
                     return error.LuaTableMissingValue;
+                } else if (field_type_info == .optional) {
+                    @field(result, field.name) = null;
                 }
             } else {
                 const stack_size_before_call = lua.getTop();

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -4990,7 +4990,7 @@ pub const Lua = opaque {
                     @field(result, field.name) = default;
                 } else if (field_type_info != .optional) {
                     return error.LuaTableMissingValue;
-                } else if (field_type_info == .optional) {
+                } else {
                     @field(result, field.name) = null;
                 }
             } else {


### PR DESCRIPTION
Since the struct in `toStruct` is created from undefined memory it does need to be set to something to not have undefined behavior. Maybe it'd be a good idea to make nothing getting set unreachable or perhaps panic?