### PR TITLE
Use zig assert for apicheck

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,7 +106,7 @@ pub fn build(b: *Build) void {
         }
     } else if (b.lazyDependency(@tagName(lang), .{})) |upstream| {
         const lib = switch (lang) {
-            .luajit => luajit_setup.configure(b, target, optimize, upstream, shared),
+            .luajit => luajit_setup.configure(b, target, optimize, upstream, shared, api_check),
             .luau => luau_setup.configure(b, target, optimize, upstream, luau_use_4_vector),
             else => lua_setup.configure(b, target, optimize, upstream, .{
                 .lang = lang,

--- a/build/header_gen.zig
+++ b/build/header_gen.zig
@@ -1,0 +1,48 @@
+//! Concatenates two files together.
+
+pub fn main(init: std.process.Init) !void {
+    const arena = init.arena.allocator();
+
+    var iter = try init.minimal.args.iterateAllocator(arena);
+
+    // Skip executable name
+    _ = iter.next();
+
+    const file1 = iter.next() orelse @panic("Missing file1 argument");
+    const file2 = iter.next() orelse @panic("Missing file2 argument");
+    const output_path = iter.next() orelse @panic("Missing output_path argument");
+    if (iter.next() != null) @panic("Too many arguments");
+
+    const output_file = try Io.Dir.cwd().openFile(init.io, output_file, .{});
+    defer output_file.close(init.io);
+    var out_buf: [4096]u8 = undefined;
+    var writer = output_file.writer(init.io, &out_buf);
+    defer (&writer.interface).flush() catch {};
+
+    {
+        const file = try Io.Dir.cwd().openFile(init.io, file1, .{ .mode = .read_only });
+        defer file.deinit(init.io);
+
+        var buf: [4096]u8 = undefined;
+        var reader = file.reader(init.io, &buf);
+
+        try (&reader.interface).stream(&writer.interface, .unlimited);
+    }
+
+    try (&writer.interface).writeByte('\n');
+
+    {
+        const file = try Io.Dir.cwd().openFile(init.io, file2, .{ .mode = .read_only });
+        defer file.deinit(init.io);
+
+        var buf: [4096]u8 = undefined;
+        var reader = file.reader(init.io, &buf);
+
+        try (&reader.interface).stream(&writer.interface, .unlimited);
+    }
+}
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const File = Io.File;

--- a/build/lua.zig
+++ b/build/lua.zig
@@ -3,7 +3,9 @@ const std = @import("std");
 const Build = std.Build;
 const Step = std.Build.Step;
 
-const applyPatchToFile = @import("utils.zig").applyPatchToFile;
+const utils = @import("utils.zig");
+const applyPatchToFile = utils.applyPatchToFile;
+const concatenateFiles = utils.concatenateFiles;
 
 const build = @import("../build.zig");
 
@@ -56,6 +58,8 @@ pub fn configure(
 
     const user_header = "user.h";
 
+    const enable_apicheck = opts.api_check == .on or (opts.api_check == .debug and optimize == .Debug);
+
     const flags = [_][]const u8{
         // Standard version used in Lua Makefile
         "-std=gnu99",
@@ -69,12 +73,12 @@ pub fn configure(
         },
 
         // Enable api check
-        if (opts.api_check == .on or (opts.api_check == .debug and optimize == .Debug)) "-DLUA_USE_APICHECK" else "",
+        if (lang == .lua55 and enable_apicheck) "-DLUA_USE_APICHECK" else "",
 
         // Build as DLL for windows if shared
         if (target.result.os.tag == .windows and shared) "-DLUA_BUILD_AS_DLL" else "",
 
-        if (lua_user_h) |_| b.fmt("-DLUA_USER_H=\"{s}\"", .{user_header}) else "",
+        if (enable_apicheck or lua_user_h != null) b.fmt("-DLUA_USER_H=\"{s}\"", .{user_header}) else "",
     };
 
     const lua_source_files = switch (lang) {
@@ -110,8 +114,19 @@ pub fn configure(
     library.installHeader(upstream.path("src/luaconf.h"), "luaconf.h");
 
     if (lua_user_h) |user_h| {
-        library.root_module.addIncludePath(user_h.dirname());
-        library.installHeader(user_h, user_header);
+        if (enable_apicheck) {
+            const concat = concatenateFiles(b, b.graph.host, user_h, b.path("src/user.h"), user_header);
+            library.step.dependOn(&concat.run.step);
+
+            library.root_module.addIncludePath(concat.output.dirname());
+            library.installHeader(concat.output, user_header);
+        } else {
+            library.root_module.addIncludePath(user_h.dirname());
+            library.installHeader(user_h, user_header);
+        }
+    } else if (enable_apicheck) {
+        library.root_module.addIncludePath(b.path("src"));
+        library.installHeader(b.path("src/user.h"), user_header);
     }
 
     return library;

--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -3,9 +3,18 @@ const std = @import("std");
 const Build = std.Build;
 const Step = std.Build.Step;
 
+const ApiCheck = @import("../build.zig").ApiCheck;
+
 const applyPatchToFile = @import("utils.zig").applyPatchToFile;
 
-pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, upstream: *Build.Dependency, shared: bool) *Step.Compile {
+pub fn configure(
+    b: *Build,
+    target: Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    upstream: *Build.Dependency,
+    shared: bool,
+    api_check: ApiCheck,
+) *Step.Compile {
     // TODO: extract this to the main build function because it is shared between all specialized build functions
 
     const lib = b.createModule(.{
@@ -216,12 +225,18 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     library.root_module.addIncludePath(recdef_header.dirname());
     library.root_module.addIncludePath(folddef_header.dirname());
 
+    const flags = [_][]const u8{
+        // Enable api check
+        if (api_check == .on or (api_check == .debug and optimize == .Debug)) "-DLUA_USE_APICHECK" else "",
+    };
+
     lib.addCSourceFiles(.{
         .root = .{ .dependency = .{
             .dependency = upstream,
             .sub_path = "",
         } },
         .files = &luajit_vm,
+        .flags = &flags,
     });
 
     lib.sanitize_c = .off;

--- a/build/utils.zig
+++ b/build/utils.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Build = std.Build;
 const Step = std.Build.Step;
 
-const PatchFile = struct {
+const RunOutput = struct {
     run: *Step.Run,
     output: Build.LazyPath,
 };
@@ -14,7 +14,7 @@ pub fn applyPatchToFile(
     file: Build.LazyPath,
     patch_file: Build.LazyPath,
     output_file: []const u8,
-) PatchFile {
+) RunOutput {
     const patch = b.addExecutable(.{
         .name = "patch",
         .root_module = b.createModule(.{
@@ -31,6 +31,33 @@ pub fn applyPatchToFile(
 
     return .{
         .run = patch_run,
+        .output = out,
+    };
+}
+
+pub fn concatenateFiles(
+    b: *Build,
+    target: Build.ResolvedTarget,
+    file1: Build.LazyPath,
+    file2: Build.LazyPath,
+    output_file: []const u8,
+) RunOutput {
+    const concatenate = b.addExecutable(.{
+        .name = "concat",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("build/header_gen.zig"),
+            .target = target,
+        }),
+    });
+
+    const concatenate_run = b.addRunArtifact(concatenate);
+    concatenate_run.addFileArg(file1);
+    concatenate_run.addFileArg(file2);
+
+    const out = concatenate_run.addOutputFileArg(output_file);
+
+    return .{
+        .run = concatenate_run,
         .output = out,
     };
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -735,12 +735,8 @@ pub const Lua = opaque {
         } else if (nsize == 0) {
             return null;
         } else {
-            const builtin = @import("builtin"); // FIXME: remove when zig-0.15 is released and 0.14 can be dropped
             // ptr is null, allocate a new block of memory
-            const new_ptr = (if (builtin.zig_version.major == 0 and builtin.zig_version.minor < 15)
-                allocator_ptr.alignedAlloc(u8, alignment, nsize)
-            else
-                allocator_ptr.alignedAlloc(u8, .fromByteUnits(alignment), nsize)) catch return null;
+            const new_ptr = allocator_ptr.alignedAlloc(u8, .fromByteUnits(alignment), nsize) catch return null;
             return new_ptr.ptr;
         }
     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -111,6 +111,10 @@ extern "c" fn zig_registerAssertionHandler() void;
 /// This function is defined in luau.cpp and ensures Zig uses the correct free when compiling luau code
 extern "c" fn zig_luau_free(ptr: *anyopaque) void;
 
+export fn zlua_assert(ok: bool) void {
+    std.debug.assert(ok);
+}
+
 const Allocator = std.mem.Allocator;
 
 // Types

--- a/src/user.h
+++ b/src/user.h
@@ -1,0 +1,4 @@
+extern void zlua_assert(int e);
+
+#define luai_apicheck(l,e) zlua_assert(e)
+


### PR DESCRIPTION
Using a zig assert for apicheck enables stack traces for panics.

TODO:

* Lua 5.5 changed how LUA_USE_APICHECK works and I cannot find a way to define `lua_assert` correctly
* Not working for luajit yet. Haven't looked closely