### PR TITLE
use builtin translate-c

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 
 const Build = std.Build;
 const Step = std.Build.Step;
-const Translator = @import("translate_c").Translator;
 
 const lua_setup = @import("build/lua.zig");
 const luau_setup = @import("build/luau.zig");
@@ -72,15 +71,13 @@ pub fn build(b: *Build) void {
     }
 
     // Translate the Lua C headers in to Zig code.
-    const translate_c = b.dependency("translate_c", .{});
-
     const c_header_path = switch (lang) {
         .luajit => b.path("build/include/luajit_all.h"),
         .luau => b.path("build/include/luau_all.h"),
         else => b.path("build/include/lua_all.h"),
     };
-    const t: Translator = .init(translate_c, .{
-        .c_source_file = c_header_path,
+    const t = b.addTranslateC(.{
+        .root_source_file = c_header_path,
         .target = target,
         .optimize = optimize,
     });
@@ -91,7 +88,7 @@ pub fn build(b: *Build) void {
         t.addSystemIncludePath(headers);
     }
 
-    zlua.addImport("c", t.mod);
+    zlua.addImport("c", t.createModule());
 
     if (system_lua) {
         const link_mode: std.builtin.LinkMode = if (shared) .dynamic else .static;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,10 +46,5 @@
             .hash = "N-V-__8AAHD3twASfaoQIBT7MgqysHE9qE1pnme3FsEVRc84",
             .lazy = true,
         },
-
-        .translate_c = .{
-            .url = "git+https://codeberg.org/ziglang/translate-c#46b5609b5ac4c0a896217d1d984f3ae50e4810b5",
-            .hash = "translate_c-0.0.0-Q_BUWpf0BgAwrh5AM-acJcslN_YPEhcoCVKbbNjwuUTJ",
-        },
     },
 }


### PR DESCRIPTION
since 0.16, translate-c is built into zig. this commit gets rid of the external dep and uses the builtin one

this also fixes issues with building on non fhs standard systems like nixos where it would fail with errors like

> fatal error: 'stdio.h' not found