### PR TITLE
build: add -flto for wasm32 to fix setjmp/longjmp with Emscripten

### DIFF
--- a/build/lua.zig
+++ b/build/lua.zig
@@ -75,6 +75,7 @@ pub fn configure(
         if (target.result.os.tag == .windows and shared) "-DLUA_BUILD_AS_DLL" else "",
 
         if (lua_user_h) |_| b.fmt("-DLUA_USER_H=\"{s}\"", .{user_header}) else "",
+        if (target.result.cpu.arch == .wasm32) "-flto" else "",
     };
 
     const lua_source_files = switch (lang) {


### PR DESCRIPTION
When building Lua for wasm32 with Emscripten, WebAssembly does not natively support traditional `setjmp/longjmp` semantics. Emscripten implements support by applying compiler and linker transformations that rewrite and instrument `setjmp/longjmp` usage. But when Lua is compiled by Zig as a separate static library outside Emscripten's normal compilation pipeline. Without `-flto`, Zig compiles Lua's source files into object code that Emscripten cannot fully analyze or rewrite during the final link step which prevents the required `setjmp/longjmp` transformations from being applied correctly.

Adding `-flto` for the wasm32 build causes Zig to preserve LLVM IR in the generated artifacts. When emcc performs the final link, it can see inside the Lua code and apply its `setjmp/longjmp` instrumentation passes across the entire program.

Note: This issue was discovered while building Neovim for WebAssembly as part of the active Neovim wasm project: https://github.com/neovim/neovim/issues/39987